### PR TITLE
A small random side selectors fix & couple of other changes.

### DIFF
--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -573,6 +573,14 @@ namespace ClientCore
             get { return clientDefinitionsIni.GetBooleanValue(SETTINGS, "DisplayPlayerCountInTopBar", false); }
         }
 
+        public string ClientDefaultResolutionText
+        {
+            get
+            {
+                return clientDefinitionsIni.GetStringValue(SETTINGS, "ClientDefaultResolutionText", "(recommended)");
+            }
+        }
+
         /// <summary>
         /// Returns the name of the game executable file that is used on
         /// Linux and macOS.

--- a/DTAConfig/DirectDrawWrapper.cs
+++ b/DTAConfig/DirectDrawWrapper.cs
@@ -124,7 +124,7 @@ namespace DTAConfig
         public void Clean()
         {
             if (!string.IsNullOrEmpty(configFileName))
-                File.Delete(ProgramConstants.GamePath + configFileName);
+                File.Delete(ProgramConstants.GamePath + Path.GetFileName(configFileName));
 
             foreach (var file in filesToCopy)
                 File.Delete(ProgramConstants.GamePath + Path.GetFileName(file));

--- a/DTAConfig/DisplayOptionsPanel.cs
+++ b/DTAConfig/DisplayOptionsPanel.cs
@@ -220,7 +220,7 @@ namespace DTAConfig
             if (optimalWindowedResIndex > -1)
             {
                 var item = ddClientResolution.Items[optimalWindowedResIndex];
-                item.Text = item.Text + " (recommended)";
+                item.Text = item.Text + " " + ClientConfiguration.Instance.ClientDefaultResolutionText;
             }
 
             chkBorderlessClient = new XNAClientCheckBox(WindowManager);

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -710,6 +710,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 }
             }
 
+            var concatPlayerList = Players.Concat(AIPlayers);
+
             // Disable custom random groups if all or all except one of included sides are unavailable.
             int c = 0;
             foreach (int[] randomsides in RandomSelectors)
@@ -725,10 +727,13 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 {
                     dd.Items[1 + c].Selectable = !disabled;
                 }
+                foreach (PlayerInfo pInfo in concatPlayerList)
+                {
+                    if (pInfo.SideId == 1 + c && disabled)
+                        pInfo.SideId = defaultSide;
+                }
                 c++;
             }
-
-            var concatPlayerList = Players.Concat(AIPlayers);
 
             // Go over the side array and either disable or enable the side
             // dropdown options depending on whether the side is available


### PR DESCRIPTION
- Due to an oversight, random side selectors were not properly unselected if changing to a map where they were unavailable. Now the interactions with disallowed side logic should work properly under all circumstances.
- Allow changing the text displayed on the item in client resolution dropdown that is designated as recommended resolution. By default this displays '(recommended)', which is way too big to fit in the dropdown with the larger font used in most YR mods - changing it to '(default)' leaves enough space. Issues like this can potentially crop up elsewhere in the client as well, and treating them all as special cases like this might not be the best course of action. Would probably warrant further discussion on how to approach the said problems, or if even should at all.
- A simple fix to cleaning up renderer config files that would have previously raised an error if directory names were included in config file name paths in renderer configuration.