### PR TITLE
Bugfix for a client freeze introduced by the recent changes to map listing in game lobby.

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -403,13 +403,17 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             lbMapList.SelectedIndex = -1;
 
             int mapIndex = -1;
+            int skippedMapsCount = 0;
 
             for (int i = 0; i < GameMode.Maps.Count; i++)
             {
                 if (tbMapSearch.Text != tbMapSearch.Suggestion)
                 {
                     if (!GameMode.Maps[i].Name.ToUpper().Contains(tbMapSearch.Text.ToUpper()))
+                    {
+                        skippedMapsCount++;
                         continue;
+                    }
                 }
 
                 XNAListBoxItem rankItem = new XNAListBoxItem();
@@ -440,7 +444,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 lbMapList.AddItem(mapInfoArray);
 
                 if (GameMode.Maps[i] == Map)
-                    mapIndex = i;
+                    mapIndex = i - skippedMapsCount;
             }
 
             if (mapIndex > -1)


### PR DESCRIPTION
Fixes a problem introduced in commit aa6faa8002575d7b0ee4132ca7ee0bdc937ea704 included in PR #87 that would sometimes cause the client to freeze when searching for maps.

Long story short, when doing code refactoring to get rid of the 'unnecessary' counter variable, I somehow completely failed to register that just flat-out changing it to use the loop counter completely changes how the whole thing works when searching maps, as it skips pretty much the entire loop if map's name doesn't contain the search string and previously the counter would only get incremented if it didn't skip. Trying to get rid of the counter variable turned out to be a mostly moot point too, since it ended up needing an extra one regardless.

I did keep the for-loop implementation rather than revert back, however, since as far as I know that's bit more efficient on lists and arrays. I don't know if there are concerns for code style / consistency that'd take priority over that, though.