### PR TITLE
Fix game channel naming; support VS2019

### DIFF
--- a/BuildScripts/Build.bat
+++ b/BuildScripts/Build.bat
@@ -12,7 +12,7 @@ call FindMSBuild
 if exist "%msbuild%" goto msbuildok
 ECHO.
 ECHO.
-echo Visual Studio 2017 required.
+echo Visual Studio 2017, Visual Studio 2019 or MSBuild required.
 ECHO.
 ECHO.
 goto error

--- a/BuildScripts/FindMSBuild.bat
+++ b/BuildScripts/FindMSBuild.bat
@@ -10,6 +10,10 @@ if exist "%InstallDir%\MSBuild\15.0\Bin\MSBuild.exe" (
   SET "msbuild=%InstallDir%\MSBuild\15.0\Bin\MSBuild.exe"
 )
 
+if exist "%InstallDir%\MSBuild\Current\Bin\MSBuild.exe" (
+  SET "msbuild=%InstallDir%\MSBuild\Current\Bin\MSBuild.exe"
+)
+
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe" (
   SET "msbuild=%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe"
 )
@@ -20,6 +24,18 @@ if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\MSBuild\15.
 
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin\MSBuild.exe" (
   SET "msbuild=%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin\MSBuild.exe"
+)
+
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe" (
+  SET "msbuild=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe"
+)
+
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe" (
+  SET "msbuild=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe"
+)
+
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\MSBuild.exe" (
+  SET "msbuild=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\MSBuild.exe"
 )
 
 ENDLOCAL&set msbuild=%msbuild%

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
@@ -843,7 +843,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
         {
             while (true)
             {
-                string channelName = "#cncnet-" + localGameID.ToLower() + "-game" + new Random().Next(1000000, 9999999);
+                string channelName = gameCollection.GetGameChatChannelNameFromIdentifier(localGameID) + "-game" + new Random().Next(1000000, 9999999);
                 int index = lbGameList.HostedGames.FindIndex(c => ((HostedCnCNetGame)c).ChannelName == channelName);
                 if (index == -1)
                     return channelName;


### PR DESCRIPTION
Game room channels will now utilize postfixed main game lobby name instead of one generated from short game name and cncnet prefix. This change is meant to make game room channels inline with those mods that don't use #cncnet-[short game name] naming template.

Edit: now that VS2019 is out I edited buildscripts to be able to use it's MSBuild. Resulting binaries are proven to be working on XP.