### PR TITLE
Auto-ready checkbox for multiplayer game lobbies.

### DIFF
--- a/ClientCore/ProgramConstants.cs
+++ b/ClientCore/ProgramConstants.cs
@@ -20,8 +20,8 @@ namespace ClientCore
 
         public const string QRES_EXECUTABLE = "qres.dat";
 
-        public const string CNCNET_PROTOCOL_REVISION = "R6";
-        public const string LAN_PROTOCOL_REVISION = "RL4";
+        public const string CNCNET_PROTOCOL_REVISION = "R7";
+        public const string LAN_PROTOCOL_REVISION = "RL5";
         public const int LAN_PORT = 1234;
         public const int LAN_INGAME_PORT = 1234;
         public const int LAN_LOBBY_PORT = 1232;

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -559,7 +559,10 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 return;
             }
 
-            channel.SendCTCPMessage("R 1", QueuedMessageType.GAME_PLAYERS_READY_STATUS_MESSAGE, 5);
+            if (chkAutoReady.Checked)
+                channel.SendCTCPMessage("R 2", QueuedMessageType.GAME_PLAYERS_READY_STATUS_MESSAGE, 5);
+            else
+                channel.SendCTCPMessage("R 1", QueuedMessageType.GAME_PLAYERS_READY_STATUS_MESSAGE, 5);
         }
 
         protected override void AddNotice(string message, Color color)
@@ -646,6 +649,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 return;
 
             pInfo.Ready = readyStatus > 0;
+            pInfo.AutoReady = readyStatus > 1;
 
             CopyPlayerDataToUI();
             BroadcastPlayerOptions();
@@ -682,7 +686,10 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 sb.Append(";");
                 if (!pInfo.IsAI)
                 {
-                    sb.Append(Convert.ToInt32(pInfo.Ready));
+                    if (pInfo.AutoReady)
+                        sb.Append(2);
+                    else
+                        sb.Append(Convert.ToInt32(pInfo.Ready));
                     sb.Append(';');
                 }
             }
@@ -780,6 +787,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                         return;
 
                     pInfo.Ready = readyStatus > 0;
+                    pInfo.AutoReady = readyStatus > 1;
 
                     Players.Add(pInfo);
                     i += HUMAN_PLAYER_OPTIONS_LENGTH;

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -232,6 +232,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             TopBar.AddPrimarySwitchable(this);
             TopBar.SwitchToPrimary();
             WindowManager.SelectedControl = tbChatInput;
+            ResetAutoReadyCheckbox();
         }
 
         private void PrintTunnelServerInformation(string s)

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -1491,7 +1491,10 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         protected void ClearReadyStatuses()
         {
             for (int i = 1; i < Players.Count; i++)
-                Players[i].Ready = false;
+            {
+                if (!Players[i].AutoReady)
+                    Players[i].Ready = false;
+            }
         }
 
         /// <summary>

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
@@ -159,6 +159,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             var fhc = new FileHashCalculator();
             fhc.CalculateHashes(GameModes);
             SendMessageToHost(FILE_HASH_COMMAND + " " + fhc.GetCompleteHash());
+            ResetAutoReadyCheckbox();
         }
 
         #region Server code

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
@@ -50,7 +50,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 new NoParamCommandHandler(RETURN_COMMAND, GameHost_HandleReturnCommand),
                 new StringCommandHandler(PLAYER_OPTIONS_REQUEST_COMMAND, HandlePlayerOptionsRequest),
                 new NoParamCommandHandler(PLAYER_QUIT_COMMAND, HandlePlayerQuit),
-                new NoParamCommandHandler(PLAYER_READY_REQUEST, GameHost_HandleReadyRequest),
+                new StringCommandHandler(PLAYER_READY_REQUEST, GameHost_HandleReadyRequest),
                 new StringCommandHandler(FILE_HASH_COMMAND, HandleFileHashCommand),
                 new StringCommandHandler(DICE_ROLL_COMMAND, Host_HandleDiceRoll),
             };
@@ -455,7 +455,10 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 sb.Append(pInfo.ColorId);
                 sb.Append(pInfo.StartingLocation);
                 sb.Append(pInfo.TeamId);
-                sb.Append(Convert.ToInt32(pInfo.IsAI || pInfo.Ready));
+                if (pInfo.AutoReady)
+                    sb.Append(2);
+                else
+                    sb.Append(Convert.ToInt32(pInfo.IsAI || pInfo.Ready));
                 sb.Append(pInfo.IPAddress);
                 if (pInfo.IsAI)
                     sb.Append(pInfo.AILevel);
@@ -490,7 +493,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
         protected override void RequestReadyStatus()
         {
-            SendMessageToHost("READY");
+            SendMessageToHost(PLAYER_READY_REQUEST + " " + Convert.ToInt32(chkAutoReady.Checked));
         }
 
         protected override void SendChatMessage(string message)
@@ -865,6 +868,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 pInfo.StartingLocation = start;
                 pInfo.TeamId = team;
                 pInfo.Ready = readyStatus > 0;
+                pInfo.AutoReady = readyStatus > 1;
                 pInfo.IPAddress = ipAddress;
             }
 
@@ -982,7 +986,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             }
         }
 
-        private void GameHost_HandleReadyRequest(string sender)
+        private void GameHost_HandleReadyRequest(string sender, string autoReady)
         {
             PlayerInfo pInfo = Players.Find(p => p.Name == sender);
 
@@ -990,6 +994,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 return;
 
             pInfo.Ready = true;
+            pInfo.AutoReady = Convert.ToBoolean(Conversions.IntFromString(autoReady, 0));
             CopyPlayerDataToUI();
             BroadcastPlayerOptions();
         }

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
@@ -54,12 +54,14 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         protected ChatListBox lbChatMessages;
         protected XNAChatTextBox tbChatInput;
         protected XNAClientButton btnLockGame;
+        protected XNAClientCheckBox chkAutoReady;
 
         protected bool IsHost = false;
 
         protected bool Locked = false;
 
         protected bool DisplayRandomMapButton = false;
+        protected bool DisplayAutoReadyCheckbox = false;
 
         protected EnhancedSoundEffect sndJoinSound;
         protected EnhancedSoundEffect sndLeaveSound;
@@ -170,9 +172,18 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             btnLockGame.Text = "Lock Game";
             btnLockGame.LeftClick += BtnLockGame_LeftClick;
 
+            chkAutoReady = new XNAClientCheckBox(WindowManager);
+            chkAutoReady.Name = "chkAutoReady";
+            chkAutoReady.ClientRectangle = new Rectangle(btnLaunchGame.Right + 12,
+                btnLaunchGame.Y + 2, 133, 23);
+            chkAutoReady.Text = "Auto-Ready";
+            chkAutoReady.CheckedChanged += ChkAutoReady_CheckedChanged;
+            chkAutoReady.Visible = false;
+
             AddChild(lbChatMessages);
             AddChild(tbChatInput);
             AddChild(btnLockGame);
+            AddChild(chkAutoReady);
 
             MapPreviewBox.LocalStartingLocationSelected += MapPreviewBox_LocalStartingLocationSelected;
             MapPreviewBox.StartingLocationApplied += MapPreviewBox_StartingLocationApplied;
@@ -180,6 +191,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             InitializeWindow();
 
             DisplayRandomMapButton = btnPickRandomMap.Enabled && btnPickRandomMap.Visible;
+            DisplayAutoReadyCheckbox = chkAutoReady.Visible;
 
             sndJoinSound = new EnhancedSoundEffect("joingame.wav");
             sndLeaveSound = new EnhancedSoundEffect("leavegame.wav");
@@ -343,6 +355,12 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             SendChatMessage(tbChatInput.Text);
             tbChatInput.Text = string.Empty;
+        }
+
+        private void ChkAutoReady_CheckedChanged(object sender, EventArgs e)
+        {
+            btnLaunchGame.Enabled = !chkAutoReady.Checked;
+            RequestReadyStatus();
         }
 
         private void SetFrameSendRate(string value)
@@ -562,6 +580,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 btnLockGame.Text = "Lock Game";
                 btnLockGame.Enabled = true;
                 btnLockGame.Visible = true;
+                chkAutoReady.Visible = false;
 
                 foreach (GameLobbyDropDown dd in DropDowns)
                 {
@@ -583,6 +602,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
                 btnLockGame.Enabled = false;
                 btnLockGame.Visible = false;
+                if (DisplayAutoReadyCheckbox)
+                    chkAutoReady.Visible = true;
 
                 foreach (GameLobbyDropDown dd in DropDowns)
                     dd.InputEnabled = false;

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
@@ -61,7 +61,6 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         protected bool Locked = false;
 
         protected bool DisplayRandomMapButton = false;
-        protected bool DisplayAutoReadyCheckbox = false;
 
         protected EnhancedSoundEffect sndJoinSound;
         protected EnhancedSoundEffect sndLeaveSound;
@@ -178,7 +177,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 btnLaunchGame.Y + 2, 133, 23);
             chkAutoReady.Text = "Auto-Ready";
             chkAutoReady.CheckedChanged += ChkAutoReady_CheckedChanged;
-            chkAutoReady.Visible = false;
+            chkAutoReady.Disable();
 
             AddChild(lbChatMessages);
             AddChild(tbChatInput);
@@ -191,7 +190,6 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             InitializeWindow();
 
             DisplayRandomMapButton = btnPickRandomMap.Enabled && btnPickRandomMap.Visible;
-            DisplayAutoReadyCheckbox = chkAutoReady.Visible;
 
             sndJoinSound = new EnhancedSoundEffect("joingame.wav");
             sndLeaveSound = new EnhancedSoundEffect("leavegame.wav");
@@ -588,7 +586,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 btnLockGame.Text = "Lock Game";
                 btnLockGame.Enabled = true;
                 btnLockGame.Visible = true;
-                chkAutoReady.Visible = false;
+                chkAutoReady.Disable();
 
                 foreach (GameLobbyDropDown dd in DropDowns)
                 {
@@ -610,8 +608,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
                 btnLockGame.Enabled = false;
                 btnLockGame.Visible = false;
-                if (DisplayAutoReadyCheckbox)
-                    chkAutoReady.Visible = true;
+                chkAutoReady.GetAttributes(ThemeIni);
 
                 foreach (GameLobbyDropDown dd in DropDowns)
                     dd.InputEnabled = false;

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
@@ -363,6 +363,14 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             RequestReadyStatus();
         }
 
+        protected void ResetAutoReadyCheckbox()
+        {
+            chkAutoReady.CheckedChanged -= ChkAutoReady_CheckedChanged;
+            chkAutoReady.Checked = false;
+            chkAutoReady.CheckedChanged += ChkAutoReady_CheckedChanged;
+            btnLaunchGame.Enabled = true;
+        }
+
         private void SetFrameSendRate(string value)
         {
             bool success = int.TryParse(value, out int intValue);

--- a/DXMainClient/Domain/Multiplayer/PlayerInfo.cs
+++ b/DXMainClient/Domain/Multiplayer/PlayerInfo.cs
@@ -30,6 +30,7 @@ namespace DTAClient.Domain.Multiplayer
         public int ColorId { get; set; }
         public int TeamId { get; set; }
         public bool Ready { get; set; }
+        public bool AutoReady { get; set; }
         public bool IsAI { get; set; }
 
         public bool IsInGame { get; set; }


### PR DESCRIPTION
This feature is based on a suggestion from players. Essentially an invisible-by-default (must be made visible through the UI INI system) checkbox that if toggled on, marks the player as with 'auto-ready' status which means that their actual ready status is not revoked under any circumstances until after the checkbox is unticked (unticking itself won't remove it, though). This piggybacks on existing messaging between players and game host, but since LAN game variant breaks compatibility and CnCNet one would otherwise be susceptible to sync problems, the protocol versions have been incremented as well. Default position of the checkbox is equivalent to where the 'Lock Game' button appears for game hosts.

Isn't marked as draft, but still open for discussion / scrutiny.