### PR TITLE
Collection of fixes / improvements to CnCNet / IRC functionality

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
@@ -477,9 +477,11 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             }
 
             IRCUser ircUser = currentChatChannel.Users[lbPlayerList.SelectedIndex].IRCUser;
+            bool isAdmin = currentChatChannel.Users[lbPlayerList.SelectedIndex].IsAdmin;
 
             playerContextMenu.Items[1].Text = cncnetUserData.IsFriend(ircUser.Name) ? "Remove Friend" : "Add Friend";
-            playerContextMenu.Items[2].Text = cncnetUserData.IsIgnored(ircUser.Ident) ? "Unblock" : "Block";
+            playerContextMenu.Items[2].Text = cncnetUserData.IsIgnored(ircUser.Ident) && !isAdmin ? "Unblock" : "Block";
+            playerContextMenu.Items[2].Selectable = !isAdmin;
 
             playerContextMenu.Open(GetCursorPoint());
         }
@@ -1030,7 +1032,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
         private void AddMessageToChat(ChatMessage message)
         {
-            if (!string.IsNullOrEmpty(message.SenderIdent) && cncnetUserData.IsIgnored(message.SenderIdent))
+            if (!string.IsNullOrEmpty(message.SenderIdent) && cncnetUserData.IsIgnored(message.SenderIdent) && !message.SenderIsAdmin)
             {
                 lbChatMessages.AddMessage(new ChatMessage(Color.Silver, "Message blocked from - " + message.SenderName));
             }

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
@@ -165,9 +165,9 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             playerContextMenu.AddItem("Private Message", () => 
                 PerformUserListContextMenuAction(iu => pmWindow.InitPM(iu.Name)));
             playerContextMenu.AddItem("Add Friend", () => 
-                PerformUserListContextMenuAction(iu => cncnetUserData.ToggleFriend(iu.Name)));
+                PerformUserListContextMenuAction(iu => ToggleFriend(iu.Name)));
             playerContextMenu.AddItem("Ignore User", () => 
-                PerformUserListContextMenuAction(iu => cncnetUserData.ToggleIgnoreUser(iu.Ident)));
+                PerformUserListContextMenuAction(iu => ToggleIgnoreUser(iu.Ident)));
 
             lbChatMessages = new ChatListBox(WindowManager);
             lbChatMessages.Name = "lbChatMessages";
@@ -512,6 +512,32 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             var channelUser = (ChannelUser)lbPlayerList.SelectedItem.Tag;
 
             pmWindow.InitPM(channelUser.IRCUser.Name);
+        }
+
+        /// <summary>
+        /// Adds or removes a specified user to from the chat ignore list depending on whether
+        /// they already are on the ignore list.
+        /// </summary>
+        /// <param name="ident">The ident of the IRCUser.</param>
+        private void ToggleIgnoreUser(string ident)
+        {
+            cncnetUserData.ToggleIgnoreUser(ident);
+            ChannelUser user = currentChatChannel.Users.Find(x => x.IRCUser.Ident == ident);
+            if (user != null)
+                RefreshPlayerListUser(user);
+        }
+
+        /// <summary>
+        /// Adds or removes an user from the friend list depending on whether
+        /// they already are on the friend list.
+        /// </summary>
+        /// <param name="name">The name of the user.</param>
+        private void ToggleFriend(string name)
+        {
+            cncnetUserData.ToggleFriend(name);
+            ChannelUser user = currentChatChannel.Users.Find(x => x.IRCUser.Name == name);
+            if (user != null)
+                RefreshPlayerListUser(user);
         }
 
         /// <summary>
@@ -1017,6 +1043,17 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 lbPlayerList.SelectedIndex = lbPlayerList.Items.FindIndex(
                     i => i.Text == selectedUserName);
             }
+        }
+
+        /// <summary>
+        /// Refreshes a single user's info on the player list.
+        /// </summary>
+        /// <param name="user">User on the current chat channel.</param>
+        private void RefreshPlayerListUser(ChannelUser user)
+        {
+            user.IRCUser.IsFriend = cncnetUserData.IsFriend(user.IRCUser.Name);
+            user.IRCUser.IsIgnored = cncnetUserData.IsIgnored(user.IRCUser.Ident);
+            lbPlayerList.UpdateUserInfo(user);
         }
 
         private void CurrentChatChannel_UserGameIndexUpdated(object sender, ChannelUserEventArgs e)

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/PrivateMessagingWindow.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/PrivateMessagingWindow.cs
@@ -385,7 +385,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             }
 
             // Messages from users we've blocked are not wanted
-            if (iu.IsIgnored)
+            if (cncnetUserData.IsIgnored(iu.Ident))
             {
                 return;
             }

--- a/DXMainClient/DXGUI/Multiplayer/PlayerListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/PlayerListBox.cs
@@ -89,7 +89,7 @@ namespace DTAClient.DXGUI.Multiplayer
                         GetColorWithAlpha(FocusColor));
                 }
 
-                DrawTexture(lbItem.Texture, new Rectangle(x, height,
+                DrawTexture(user.IsAdmin ? adminGameIcon : lbItem.Texture, new Rectangle(x, height,
                         adminGameIcon.Width, adminGameIcon.Height), Color.White);
 
                 x += adminGameIcon.Width + MARGIN;
@@ -128,7 +128,7 @@ namespace DTAClient.DXGUI.Multiplayer
 
                 DrawStringWithShadow(name, FontIndex,
                     new Vector2(x, height),
-                    lbItem.TextColor);
+                    user.IsAdmin ? Color.Red : lbItem.TextColor);
 
                 height += LineHeight;
             }

--- a/DXMainClient/DXGUI/Multiplayer/PlayerListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/PlayerListBox.cs
@@ -44,15 +44,15 @@ namespace DTAClient.DXGUI.Multiplayer
 
         public void AddUser(ChannelUser user)
         {
-            AddUserToList(user);
+            XNAListBoxItem item = new XNAListBoxItem();
+            UpdateItemInfo(user, item);
+            AddItem(item);
         }
 
-        /// <summary>
-        /// Refreshes game information in the game list box.
-        /// </summary>
-        public void Refresh()
+        public void UpdateUserInfo(ChannelUser user)
         {
-            Items.Clear();
+            XNAListBoxItem item = Items.Find(x => x.Tag == user);
+            UpdateItemInfo(user, item);
         }
 
         public override void Draw(GameTime gameTime)
@@ -139,10 +139,8 @@ namespace DTAClient.DXGUI.Multiplayer
             DrawChildren(gameTime);
         }
 
-        private void AddUserToList(ChannelUser user)
+        private void UpdateItemInfo(ChannelUser user, XNAListBoxItem item)
         {
-            XNAListBoxItem item = new XNAListBoxItem();
-
             item.Tag = user;
 
             if (user.IsAdmin)
@@ -160,8 +158,6 @@ namespace DTAClient.DXGUI.Multiplayer
                 else
                     item.Texture = gameCollection.GameList[user.IRCUser.GameID].Texture;
             }
-
-            AddItem(item);
         }
     }
 }

--- a/DXMainClient/DXGUI/Multiplayer/PlayerListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/PlayerListBox.cs
@@ -104,7 +104,7 @@ namespace DTAClient.DXGUI.Multiplayer
                     x += friendIcon.Width + MARGIN;
                 }
                 // Ignore Icon
-                else if (user.IRCUser.IsIgnored)
+                else if (user.IRCUser.IsIgnored && !user.IsAdmin)
                 {
                     DrawTexture(ignoreIcon,
                         new Rectangle(x, height,

--- a/DXMainClient/Online/ChatMessage.cs
+++ b/DXMainClient/Online/ChatMessage.cs
@@ -33,12 +33,14 @@ namespace DTAClient.Online
         /// </summary>
         /// <param name="senderName">The sender of the message. Use null for none (system messages).</param>
         /// <param name="ident">The IRC identifier of the sender.</param>
+        /// <param name="senderIsAdmin">The sender of the message is a channel admin.</param>
         /// <param name="color">The color of the message.</param>
         /// <param name="dateTime">The date and time of the message.</param>
         /// <param name="message">The message.</param>
-        public ChatMessage(string senderName, string ident, Color color, DateTime dateTime, string message) : this(senderName, color, dateTime, message)
+        public ChatMessage(string senderName, string ident, bool senderIsAdmin, Color color, DateTime dateTime, string message) : this(senderName, color, dateTime, message)
         {
             SenderIdent = ident;
+            SenderIsAdmin = senderIsAdmin;
         }
 
         /// <summary>
@@ -61,5 +63,6 @@ namespace DTAClient.Online
         public Color Color { get; private set; }
         public DateTime DateTime { get; private set; }
         public string Message { get; private set; }
+        public bool SenderIsAdmin { get; private set; }
     }
 }

--- a/DXMainClient/Online/CnCNetManager.cs
+++ b/DXMainClient/Online/CnCNetManager.cs
@@ -358,7 +358,7 @@ namespace DTAClient.Online
                 message = message.Remove(message.Length - 1);
 
             ChannelUser user = channel.Users.Find(x => x.IRCUser.Ident == ident);
-            bool senderIsAdmin = user != null && user.IsAdmin ? true : false;
+            bool senderIsAdmin = user != null && user.IsAdmin;
 
             channel.AddMessage(new ChatMessage(senderName, ident, senderIsAdmin, foreColor, DateTime.Now, message.Replace('\r', ' ')));
         }

--- a/DXMainClient/Online/CnCNetManager.cs
+++ b/DXMainClient/Online/CnCNetManager.cs
@@ -807,15 +807,16 @@ namespace DTAClient.Online
 
             string[] eInfoParts = extraInfo.Split(' ');
 
-            if (eInfoParts.Length < 3)
-                return;
+            int gameIndex = -1;
+            if (eInfoParts.Length > 2)
+            {
+                string gameName = eInfoParts[2];
 
-            string gameName = eInfoParts[2];
+                gameIndex = gameCollection.GetGameIndexFromInternalName(gameName);
 
-            int gameIndex = gameCollection.GetGameIndexFromInternalName(gameName);
-
-            if (gameIndex == -1)
-                return;
+                if (gameIndex == -1)
+                    return;
+            }
 
             var user = UserList.Find(u => u.Name == userName);
             if (user != null)
@@ -824,9 +825,11 @@ namespace DTAClient.Online
                 user.Ident = ident;
                 user.Hostname = hostName;
 
-                channels.ForEach(ch => ch.UpdateGameIndexForUser(userName));
-
-                UserGameIndexUpdated?.Invoke(this, new UserEventArgs(user));
+                if (gameIndex != -1)
+                {
+                    channels.ForEach(ch => ch.UpdateGameIndexForUser(userName));
+                    UserGameIndexUpdated?.Invoke(this, new UserEventArgs(user));
+                }
             }
         }
 

--- a/DXMainClient/Online/CnCNetManager.cs
+++ b/DXMainClient/Online/CnCNetManager.cs
@@ -357,7 +357,10 @@ namespace DTAClient.Online
             if (message.Length > 1 && message[message.Length - 1] == '\u001f')
                 message = message.Remove(message.Length - 1);
 
-            channel.AddMessage(new ChatMessage(senderName, ident, foreColor, DateTime.Now, message.Replace('\r', ' ')));
+            ChannelUser user = channel.Users.Find(x => x.IRCUser.Ident == ident);
+            bool senderIsAdmin = user != null && user.IsAdmin ? true : false;
+
+            channel.AddMessage(new ChatMessage(senderName, ident, senderIsAdmin, foreColor, DateTime.Now, message.Replace('\r', ' ')));
         }
 
         public void OnCTCPParsed(string channelName, string userName, string message)

--- a/DXMainClient/Online/Connection.cs
+++ b/DXMainClient/Online/Connection.cs
@@ -555,7 +555,9 @@ namespace DTAClient.Online
                         string modeUserName = prefix.Substring(0, prefix.IndexOf('!'));
                         string modeChannelName = parameters[0];
                         string modeString = parameters[1];
-                        connectionManager.OnChannelModesChanged(modeUserName, modeChannelName, modeString);
+                        List<string> modeParameters = 
+                            parameters.Count > 2 ? parameters.GetRange(2, parameters.Count - 2) : new List<string>();
+                        connectionManager.OnChannelModesChanged(modeUserName, modeChannelName, modeString, modeParameters);
                         break;
                     case "KICK":
                         string kickChannelName = parameters[0];

--- a/DXMainClient/Online/IConnectionManager.cs
+++ b/DXMainClient/Online/IConnectionManager.cs
@@ -1,4 +1,6 @@
-﻿namespace DTAClient.Online
+﻿using System.Collections.Generic;
+
+namespace DTAClient.Online
 {
     /// <summary>
     /// An interface for handling IRC messages.
@@ -41,7 +43,7 @@
 
         void OnPrivateMessageReceived(string sender, string message);
 
-        void OnChannelModesChanged(string userName, string channelName, string modeString);
+        void OnChannelModesChanged(string userName, string channelName, string modeString, List<string> modeParameters);
 
         void OnUserKicked(string channelName, string userName);
 


### PR DESCRIPTION
These changes address issues #82, #85 and #86. 

The fix for #82 comes with a small caveat in that it will only bypass the ignore list (and likewise disables the block functionality in context menu) for admins on the channels themselves where the said users are admins - it won't extend to other channels and private messaging. It could probably in theory be extended to apply to admins from all connected channels and even in private messaging, but that would probably require considerable amount of extra work, especially for private messages which do not really know anything about channels or admins.

The other changes are more complementary, allowing the client to more reliably adjust user information and reflect the changes in the player list box.

