### PR TITLE
Fix truncated ident

### DIFF
--- a/DXMainClient/Online/Connection.cs
+++ b/DXMainClient/Online/Connection.cs
@@ -110,7 +110,9 @@ namespace DTAClient.Online
         {
             lock (idLocker)
             {
-                systemId = Utilities.CalculateSHA1ForString(id).Substring(0, ID_LENGTH);
+                // E.g "DTA". or "YR."
+                int maxLength = (ID_LENGTH - ClientConfiguration.Instance.LocalGame.Length + 1);
+                systemId = Utilities.CalculateSHA1ForString(id).Substring(0, maxLength);
                 idSet = true;
             }
         }


### PR DESCRIPTION
Fixes scenario where ident was truncated due to not taking into account the prepended game and full stop.