### PR TITLE
Allow pre-declaring game modes in MPMaps.ini.

### DIFF
--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -48,6 +48,21 @@ namespace DTAClient.Domain.Multiplayer
 
             IniFile mpMapsIni = new IniFile(ProgramConstants.GamePath + ClientConfiguration.Instance.MPMapsIniPath);
 
+            var gameModes = mpMapsIni.GetSectionKeys("GameModes");
+
+            if (gameModes != null)
+            {
+                foreach (string key in gameModes)
+                {
+                    string gameModeName = mpMapsIni.GetStringValue("GameModes", key, string.Empty);
+                    if (!string.IsNullOrEmpty(gameModeName))
+                    {
+                        GameMode gm = new GameMode(gameModeName);
+                        GameModes.Add(gm);
+                    }
+                }
+            }
+
             var gmAliases = mpMapsIni.GetSectionKeys("GameModeAliases");
 
             if (gmAliases != null)
@@ -144,6 +159,8 @@ namespace DTAClient.Domain.Multiplayer
                     gm.Maps.Add(map);
                 }
             }
+
+            GameModes.RemoveAll(g => g.Maps.Count < 1);
 
             MapLoadingComplete?.Invoke(this, EventArgs.Empty);
         }


### PR DESCRIPTION
Allows modders to pre-declare game modes in MPMaps.ini using GameModes list. Primary use-case of this would be to pre-determine the order of the game modes list displayed in the game lobby dropdown. Normally this would be achievable by simply adjusting the map list order, but there are specific conditions (most of which are admittedly rarely encountered) under which this is not possible. One example would be game modes that use subsets of maps from other game modes, which could result in an undesirable game modes list order if determined solely by map order. 

Some notes:
- I determined pre-declaring would be much less convoluted than trying to alter list order, especially the dropdown one directly after the fact, hence the chosen approach here.
- The pre-declared game modes list does not (at least currently) interact with GameModeAliases - any aliases included must be explicitly declared. This would thus also allow separating alias modes from each other in the list ordering, however illogical that might be.
- Duplicate pre-declared game mode entries and game modes that do not have any maps assigned to them are removed after loading maps. 
- Game modes that do not already exist in the list are still added during map loading like previously.