### PR TITLE
Fix "The game host has..." spam on map change

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -360,6 +360,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             if (disableGameOptionUpdateBroadcast)
                 return;
 
+            var checkBox = (GameLobbyCheckBox)sender;
+            checkBox.UserDefinedValue = checkBox.Checked;
             OnGameOptionChanged();
         }
 

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -351,7 +351,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 return;
 
             var dd = (GameLobbyDropDown)sender;
-            dd.LastHostSelectedIndex = dd.SelectedIndex;
+            dd.HostSelectedIndex = dd.SelectedIndex;
             OnGameOptionChanged();
         }
 
@@ -361,7 +361,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 return;
 
             var checkBox = (GameLobbyCheckBox)sender;
-            checkBox.LastHostChecked = checkBox.Checked;
+            checkBox.HostChecked = checkBox.Checked;
             OnGameOptionChanged();
         }
 
@@ -1723,10 +1723,10 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             ApplyForcedDropDownOptions(dropDownListClone, map.ForcedDropDownValues);
 
             foreach (var chkBox in checkBoxListClone)
-                chkBox.Checked = chkBox.LastHostChecked;
+                chkBox.Checked = chkBox.HostChecked;
 
             foreach (var dd in dropDownListClone)
-                dd.SelectedIndex = dd.LastHostSelectedIndex;
+                dd.SelectedIndex = dd.HostSelectedIndex;
 
             // Enable all sides by default
             foreach (var ddSide in ddPlayerSides)

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -351,7 +351,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 return;
 
             var dd = (GameLobbyDropDown)sender;
-            dd.UserDefinedIndex = dd.SelectedIndex;
+            dd.LastHostSelectedIndex = dd.SelectedIndex;
             OnGameOptionChanged();
         }
 
@@ -361,7 +361,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 return;
 
             var checkBox = (GameLobbyCheckBox)sender;
-            checkBox.UserDefinedValue = checkBox.Checked;
+            checkBox.LastHostChecked = checkBox.Checked;
             OnGameOptionChanged();
         }
 
@@ -1723,10 +1723,10 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             ApplyForcedDropDownOptions(dropDownListClone, map.ForcedDropDownValues);
 
             foreach (var chkBox in checkBoxListClone)
-                chkBox.Checked = chkBox.UserDefinedValue;
+                chkBox.Checked = chkBox.LastHostChecked;
 
             foreach (var dd in dropDownListClone)
-                dd.SelectedIndex = dd.UserDefinedIndex;
+                dd.SelectedIndex = dd.LastHostSelectedIndex;
 
             // Enable all sides by default
             foreach (var ddSide in ddPlayerSides)

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyCheckBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyCheckBox.cs
@@ -40,14 +40,14 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         /// Defaults to the default value of Checked after the check-box
         /// has been initialized, but its value is only changed by user interaction.
         /// </summary>
-        public bool LastHostChecked { get; set; }
+        public bool HostChecked { get; set; }
 
         /// <summary>
         /// The last this user checked value for this check box.
         /// Defaults to the default value of Checked after the check-box
         /// has been initialized, but its value is only changed by user interaction.
         /// </summary>
-        public bool LastUserChecked { get; set; }
+        public bool UserChecked { get; set; }
 
         /// <summary>
         /// The side index that this check box disallows when checked.
@@ -99,8 +99,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                     bool checkedValue = Conversions.BooleanFromString(value, false);
                     Checked = checkedValue;
                     defaultValue = checkedValue;
-                    LastHostChecked = checkedValue;
-                    LastUserChecked = checkedValue;
+                    HostChecked = checkedValue;
+                    UserChecked = checkedValue;
                     return;
                 case "DisallowedSideIndex":
                     DisallowedSideIndex = Conversions.IntFromString(value, DisallowedSideIndex);
@@ -174,7 +174,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 return;
 
             base.OnLeftClick();
-            LastUserChecked = Checked;
+            UserChecked = Checked;
         }
     }
 }

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyCheckBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyCheckBox.cs
@@ -36,11 +36,18 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         public bool IsMultiplayer { get; set; }
 
         /// <summary>
-        /// The last user-defined value for this check box.
+        /// The last host checked value for this check box.
         /// Defaults to the default value of Checked after the check-box
         /// has been initialized, but its value is only changed by user interaction.
         /// </summary>
-        public bool UserDefinedValue { get; set; }
+        public bool LastHostChecked { get; set; }
+
+        /// <summary>
+        /// The last this user checked value for this check box.
+        /// Defaults to the default value of Checked after the check-box
+        /// has been initialized, but its value is only changed by user interaction.
+        /// </summary>
+        public bool LastUserChecked { get; set; }
 
         /// <summary>
         /// The side index that this check box disallows when checked.
@@ -92,7 +99,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                     bool checkedValue = Conversions.BooleanFromString(value, false);
                     Checked = checkedValue;
                     defaultValue = checkedValue;
-                    UserDefinedValue = checkedValue;
+                    LastHostChecked = checkedValue;
+                    LastUserChecked = checkedValue;
                     return;
                 case "DisallowedSideIndex":
                     DisallowedSideIndex = Conversions.IntFromString(value, DisallowedSideIndex);
@@ -166,6 +174,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 return;
 
             base.OnLeftClick();
+            LastUserChecked = Checked;
         }
     }
 }

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyCheckBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyCheckBox.cs
@@ -166,7 +166,6 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 return;
 
             base.OnLeftClick();
-            UserDefinedValue = Checked;
         }
     }
 }

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyCheckBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyCheckBox.cs
@@ -36,14 +36,14 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         public bool IsMultiplayer { get; set; }
 
         /// <summary>
-        /// The last host checked value for this check box.
+        /// The last host-defined value for this check box.
         /// Defaults to the default value of Checked after the check-box
         /// has been initialized, but its value is only changed by user interaction.
         /// </summary>
         public bool HostChecked { get; set; }
 
         /// <summary>
-        /// The last this user checked value for this check box.
+        /// The last value that the local player gave for this check box.
         /// Defaults to the default value of Checked after the check-box
         /// has been initialized, but its value is only changed by user interaction.
         /// </summary>

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyDropDown.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyDropDown.cs
@@ -17,7 +17,9 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
         public string OptionName { get; private set; }
 
-        public int UserDefinedIndex { get; set; }
+        public int LastHostSelectedIndex { get; set; }
+
+        public int LastUserSelectedIndex { get; set; }
 
         private DropDownDataWriteMode dataWriteMode = DropDownDataWriteMode.BOOLEAN;
 
@@ -60,7 +62,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 case "DefaultIndex":
                     SelectedIndex = int.Parse(value);
                     defaultIndex = SelectedIndex;
-                    UserDefinedIndex = SelectedIndex;
+                    LastHostSelectedIndex = SelectedIndex;
+                    LastUserSelectedIndex = SelectedIndex;
                     return;
                 case "OptionName":
                     OptionName = value;
@@ -122,6 +125,15 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             else customIniPath = Items[SelectedIndex].Text;
 
             MapCodeHelper.ApplyMapCode(mapIni, customIniPath, gameMode);
+        }
+
+        public override void OnLeftClick()
+        {
+            if (!AllowDropDown)
+                return;
+
+            base.OnLeftClick();
+            LastUserSelectedIndex = SelectedIndex;
         }
     }
 }

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyDropDown.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyDropDown.cs
@@ -17,9 +17,9 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
         public string OptionName { get; private set; }
 
-        public int LastHostSelectedIndex { get; set; }
+        public int HostSelectedIndex { get; set; }
 
-        public int LastUserSelectedIndex { get; set; }
+        public int UserSelectedIndex { get; set; }
 
         private DropDownDataWriteMode dataWriteMode = DropDownDataWriteMode.BOOLEAN;
 
@@ -62,8 +62,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 case "DefaultIndex":
                     SelectedIndex = int.Parse(value);
                     defaultIndex = SelectedIndex;
-                    LastHostSelectedIndex = SelectedIndex;
-                    LastUserSelectedIndex = SelectedIndex;
+                    HostSelectedIndex = SelectedIndex;
+                    UserSelectedIndex = SelectedIndex;
                     return;
                 case "OptionName":
                     OptionName = value;
@@ -133,7 +133,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 return;
 
             base.OnLeftClick();
-            LastUserSelectedIndex = SelectedIndex;
+            UserSelectedIndex = SelectedIndex;
         }
     }
 }

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
@@ -604,13 +604,13 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 foreach (GameLobbyDropDown dd in DropDowns)
                 {
                     dd.InputEnabled = true;
-                    dd.SelectedIndex = dd.LastUserSelectedIndex;
+                    dd.SelectedIndex = dd.UserSelectedIndex;
                 }
 
                 foreach (GameLobbyCheckBox checkBox in CheckBoxes)
                 {
                     checkBox.AllowChanges = true;
-                    checkBox.Checked = checkBox.LastUserChecked;
+                    checkBox.Checked = checkBox.UserChecked;
                 }
 
                 GenerateGameID();

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
@@ -604,13 +604,13 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 foreach (GameLobbyDropDown dd in DropDowns)
                 {
                     dd.InputEnabled = true;
-                    dd.SelectedIndex = dd.UserDefinedIndex;
+                    dd.SelectedIndex = dd.LastUserSelectedIndex;
                 }
 
                 foreach (GameLobbyCheckBox checkBox in CheckBoxes)
                 {
                     checkBox.AllowChanges = true;
-                    checkBox.Checked = checkBox.UserDefinedValue;
+                    checkBox.Checked = checkBox.LastUserChecked;
                 }
 
                 GenerateGameID();

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/SkirmishLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/SkirmishLobby.cs
@@ -215,7 +215,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 {
                     foreach (GameLobbyDropDown dd in DropDowns)
                     {
-                        skirmishSettingsIni.SetStringValue("GameOptions", dd.Name, dd.LastUserSelectedIndex + "");
+                        skirmishSettingsIni.SetStringValue("GameOptions", dd.Name, dd.UserSelectedIndex + "");
                     }
 
                     foreach (GameLobbyCheckBox cb in CheckBoxes)
@@ -340,10 +340,10 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                         }
                     }
 
-                    dd.LastUserSelectedIndex = skirmishSettingsIni.GetIntValue("GameOptions", dd.Name, dd.LastUserSelectedIndex);
+                    dd.UserSelectedIndex = skirmishSettingsIni.GetIntValue("GameOptions", dd.Name, dd.UserSelectedIndex);
 
-                    if (dd.LastUserSelectedIndex > -1 && dd.LastUserSelectedIndex < dd.Items.Count)
-                        dd.SelectedIndex = dd.LastUserSelectedIndex;
+                    if (dd.UserSelectedIndex > -1 && dd.UserSelectedIndex < dd.Items.Count)
+                        dd.SelectedIndex = dd.UserSelectedIndex;
                 }
 
                 foreach (GameLobbyCheckBox cb in CheckBoxes)

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/SkirmishLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/SkirmishLobby.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Rampastring.XNAUI;
@@ -215,7 +215,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 {
                     foreach (GameLobbyDropDown dd in DropDowns)
                     {
-                        skirmishSettingsIni.SetStringValue("GameOptions", dd.Name, dd.UserDefinedIndex + "");
+                        skirmishSettingsIni.SetStringValue("GameOptions", dd.Name, dd.LastUserSelectedIndex + "");
                     }
 
                     foreach (GameLobbyCheckBox cb in CheckBoxes)
@@ -340,10 +340,10 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                         }
                     }
 
-                    dd.UserDefinedIndex = skirmishSettingsIni.GetIntValue("GameOptions", dd.Name, dd.UserDefinedIndex);
+                    dd.LastUserSelectedIndex = skirmishSettingsIni.GetIntValue("GameOptions", dd.Name, dd.LastUserSelectedIndex);
 
-                    if (dd.UserDefinedIndex > -1 && dd.UserDefinedIndex < dd.Items.Count)
-                        dd.SelectedIndex = dd.UserDefinedIndex;
+                    if (dd.LastUserSelectedIndex > -1 && dd.LastUserSelectedIndex < dd.Items.Count)
+                        dd.SelectedIndex = dd.LastUserSelectedIndex;
                 }
 
                 foreach (GameLobbyCheckBox cb in CheckBoxes)


### PR DESCRIPTION
The spam was caused by an improper fix to another issue of game settings being carried over from the game in which you wasn't the host.