### PR TITLE
Fix High DPI issue

### DIFF
--- a/DXMainClient/Properties/app.manifest
+++ b/DXMainClient/Properties/app.manifest
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<asmv1:assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv1="urn:schemas-microsoft-com:asm.v1" xmlns:asmv2="urn:schemas-microsoft-com:asm.v2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<asmv1:assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv1="urn:schemas-microsoft-com:asm.v1" xmlns:asmv2="urn:schemas-microsoft-com:asm.v2" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <assemblyIdentity version="1.0.0.0" name="MyApplication.app" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
@@ -31,8 +31,16 @@
       <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
     </application>
   </compatibility>
+
+   <!-- Enable High DPI awareness to avoid being resized. -->
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+
   <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
-  <!-- <dependency>
+  <dependency>
     <dependentAssembly>
       <assemblyIdentity
           type="win32"
@@ -43,5 +51,5 @@
           language="*"
         />
     </dependentAssembly>
-  </dependency>-->
+  </dependency>
 </asmv1:assembly>


### PR DESCRIPTION
When High DPI is set, e.g. 125%
both DTA client and the game will be resized to a bad size, which sometimes causes the game failed to be started.

Example:
1920x1080 monitor with 125% DPI settings, which is the default setting on a 15.6 inch laptop.
The game will be resized to 1536x768 and then failed to start because the graphic card doesn't support this strange resolution.

By changing the manifest file this issue can be solved.

Note: although user can change the compatibility settings on Windows, but that is not a nice way. The issue should be solved directly, i.e this pull request.
