### PR TITLE
Add Windows Firewall settings + Restart UAC

### DIFF
--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -175,6 +175,8 @@ namespace ClientCore
 
         public string FinalSunIniPath => clientDefinitionsIni.GetStringValue(SETTINGS, "FSIniPath", "FinalSun\\FinalSun.ini");
 
+        public bool BypassWindowsFirewall => clientDefinitionsIni.GetBooleanValue(SETTINGS, "BypassWindowsFirewall", true);
+
         public int MaxNameLength => clientDefinitionsIni.GetIntValue(SETTINGS, "MaxNameLength", 16);
 
         public int MapCellSizeX => clientDefinitionsIni.GetIntValue(SETTINGS, "MapCellSizeX", 48); 

--- a/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
@@ -380,7 +380,7 @@ namespace DTAConfig.OptionPanels
                 var messageBox = XNAMessageBox.ShowYesNoDialog(WindowManager, "New Compatibility Fix",
                     "A performance-enhancing compatibility fix for modern Windows versions" + Environment.NewLine +
                     "has been included in this version of " + defaultGame + ". Enabling it requires" + Environment.NewLine +
-                    "administrative priveleges. Would you like to install the compatibility fix?" + Environment.NewLine + Environment.NewLine + 
+                    "administrative privileges. Would you like to install the compatibility fix?" + Environment.NewLine + Environment.NewLine + 
                     "You'll always be able to install or uninstall the compatibility fix later from the options menu.");
                 messageBox.YesClickedAction = MessageBox_YesClicked;
                 messageBox.NoClickedAction = MessageBox_NoClicked;

--- a/DXMainClient/DXGUI/Generic/MainMenu.cs
+++ b/DXMainClient/DXGUI/Generic/MainMenu.cs
@@ -440,7 +440,8 @@ namespace DTAClient.DXGUI.Generic
 
             PlayMusic();
 
-            BypassWindowsFirewall();
+            if (ClientConfiguration.Instance.BypassWindowsFirewall)
+                BypassWindowsFirewall();
 
             if (!ClientConfiguration.Instance.ModMode)
             {

--- a/DXMainClient/DXMainClient.csproj
+++ b/DXMainClient/DXMainClient.csproj
@@ -377,6 +377,8 @@
     <Compile Include="DXGUI\Generic\UpdateQueryWindow.cs" />
     <Compile Include="DXGUI\Generic\UpdateWindow.cs" />
     <Compile Include="Domain\FinalSunSettings.cs" />
+    <Compile Include="Domain\WindowsFirewallSettings.cs" />
+    <Compile Include="Domain\UACHelper.cs" />
     <Compile Include="Online\Channel.cs" />
     <Compile Include="Online\CnCNetManager.cs" />
     <Compile Include="Online\Connection.cs" />

--- a/DXMainClient/Domain/UACHelper.cs
+++ b/DXMainClient/Domain/UACHelper.cs
@@ -1,0 +1,59 @@
+﻿using Rampastring.Tools;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Security.Principal;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace DTAClient.Domain
+{
+
+    public static class UACHelper
+    {
+        /// <summary>
+        /// Detect whether the current process runs as Administrator.
+        /// </summary>
+        /// <returns>Whether the current process runs as Administrator.</returns>
+        public static bool IsElevated()
+        {
+            //https://stackoverflow.com/questions/1220213/detect-if-running-as-administrator-with-or-without-elevated-privileges
+            return WindowsIdentity.GetCurrent().Owner.IsWellKnown(WellKnownSidType.BuiltinAdministratorsSid);
+        } 
+
+        public static void RequireElevated(string reasonText, bool canSkip = true)
+        {
+            if (!IsElevated())
+            {
+                if (MessageBox.Show(
+                    reasonText + Environment.NewLine + Environment.NewLine +
+                     "Would you like to restart the client with elevated privileges?" + Environment.NewLine + Environment.NewLine +
+                     (canSkip ? "Click \"No\" to skip this step." : "Click \"No\" to exit the client.")
+                , "Elevated privileges required", MessageBoxButtons.YesNo, MessageBoxIcon.Information) == DialogResult.No)
+                {
+                    if (!canSkip)
+                    {
+                        Environment.Exit(0);
+                    }
+                    return;
+                }
+                RestartAsElevated();
+            }
+        }
+
+        /// <summary>
+        /// Restart the client with elevated privileges.
+        /// </summary>
+        public static void RestartAsElevated()
+        {
+
+            ProcessStartInfo psInfo = new ProcessStartInfo();
+            psInfo.FileName = Process.GetCurrentProcess().MainModule.FileName;
+            psInfo.Verb = "runas";
+            Process.Start(psInfo);
+            Environment.Exit(0);
+        }
+    }
+}

--- a/DXMainClient/Domain/WindowsFirewallSettings.cs
+++ b/DXMainClient/Domain/WindowsFirewallSettings.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Diagnostics;
+using System.Windows.Forms;
+using ClientCore;
+using Rampastring.Tools;
+
+namespace DTAClient.Domain
+{
+    /// <summary>
+    /// A util on setting Windows Firewall exception to avoid the anoying firewall pop-up at the first time.
+    /// Only for Windows Vista or later.
+    /// </summary>
+    public static class WindowsFirewallSettings
+    {
+
+        /// <summary>
+        /// Add Windows Firewall exception for the specified program.
+        /// Administrator privilege is required.
+        /// </summary>
+        /// <param name="programPath">The path of the program</param>
+        public static void AddItem(string programPath)
+        {
+            // As what Microsoft said, one should use `netsh.exe` to set up the Windows firewall,
+            // and editing the corresponding registry is not recommended.
+            // See: https://social.technet.microsoft.com/Forums/windows/en-US/7df33d04-8b35-4527-8579-b68feed60a75/adding-windows-firewall-setting-to-the-registry-why-does-it-not-appear
+
+            // try to remove existing item
+            RemoveItem(programPath);
+
+            var programPathHash32 = GetShortHash(programPath);
+            Process process = new Process()
+            {
+                StartInfo = new ProcessStartInfo()
+                {
+                    FileName = "netsh.exe",
+                    Arguments = "advfirewall firewall add rule name=\"DTA-Client-Exception-" + programPathHash32 + "\" dir=in action=allow program=\"" + programPath + "\"",
+                    RedirectStandardInput = false,
+                    RedirectStandardOutput = false,
+                    RedirectStandardError = false,
+                    UseShellExecute = true,
+                    CreateNoWindow = false,
+                    WindowStyle = ProcessWindowStyle.Hidden
+                }
+            };
+            process.Start();
+            process.WaitForExit();
+        }
+
+        /// <summary>
+        /// Detect whether Windows Firewall exception for the specified program exists added by AddItem() method.
+        /// Administrator privilege is NOT required.
+        /// </summary>
+        /// <param name="programPath">The path of the program</param>
+        public static bool ItemExists(string programPath)
+        {
+            var programPathHash32 = GetShortHash(programPath);
+
+            Process process = new Process()
+            {
+                StartInfo = new ProcessStartInfo()
+                {
+                    FileName = "netsh.exe",
+                    Arguments = "advfirewall firewall show rule name=\"DTA-Client-Exception-" + programPathHash32 + "\" dir=in",
+                    RedirectStandardInput = false,
+                    RedirectStandardOutput = false,
+                    RedirectStandardError = false,
+                    UseShellExecute = true,
+                    CreateNoWindow = false,
+                    WindowStyle = ProcessWindowStyle.Hidden
+                }
+            };
+            process.Start();
+            process.WaitForExit(500);
+
+            // Exit Code 0 means at least one item exists.
+            return process.ExitCode == 0;
+        }
+
+        /// <summary> 
+        /// Remove Windows Firewall exception for the specified program added by AddItem() method.
+        /// Administrator privilege is required.
+        /// </summary>
+        /// <param name="programPath">The path of the program</param>
+        public static void RemoveItem(string programPath)
+        {
+            var programPathHash32 = GetShortHash(programPath);
+
+            Process process = new Process()
+            {
+                StartInfo = new ProcessStartInfo()
+                {
+                    FileName = "netsh.exe",
+                    Arguments = "advfirewall firewall delete rule name=\"DTA-Client-Exception-" + programPathHash32 + "\" dir=in",
+                    RedirectStandardInput = false,
+                    RedirectStandardOutput = false,
+                    RedirectStandardError = false,
+                    UseShellExecute = true,
+                    CreateNoWindow = false,
+                    WindowStyle = ProcessWindowStyle.Hidden
+                }
+            };
+            process.Start();
+            process.WaitForExit(500);
+        }
+
+        private static string GetShortHash(string programPath)
+        {
+            StringBuilder programPathHash32 = new StringBuilder();
+            {
+                byte[] bytes = Encoding.UTF8.GetBytes(programPath);
+                byte[] hash = System.Security.Cryptography.SHA256.Create().ComputeHash(bytes);
+
+                for (int i = 0; i < Math.Min(hash.Length, 8); i++)
+                {
+                    programPathHash32.Append(hash[i].ToString("X2"));
+                }
+            }
+            return programPathHash32.ToString();
+        }
+
+
+    }
+}

--- a/DXMainClient/PreStartup.cs
+++ b/DXMainClient/PreStartup.cs
@@ -141,10 +141,10 @@ namespace DTAClient
                 return;
 
             DialogResult dr = MessageBox.Show(string.Format("You seem to be running {0} from a write-protected directory." + Environment.NewLine + Environment.NewLine +
-                "For {1} to function properly when run from a write-protected directory, it needs administrative priveleges." + Environment.NewLine + Environment.NewLine +
+                "For {1} to function properly when run from a write-protected directory, it needs administrative privileges." + Environment.NewLine + Environment.NewLine +
                 "Would you like to restart the client with administrative rights?" + Environment.NewLine + Environment.NewLine +
                 "Please also make sure that your security software isn't blocking {1}.", MainClientConstants.GAME_NAME_LONG, MainClientConstants.GAME_NAME_SHORT),
-                "Administrative priveleges required", MessageBoxButtons.YesNo);
+                "Administrative privileges required", MessageBoxButtons.YesNo);
 
             if (dr == DialogResult.No)
                 Environment.Exit(0);

--- a/DXMainClient/Startup.cs
+++ b/DXMainClient/Startup.cs
@@ -101,6 +101,8 @@ namespace DTAClient
 
             WriteInstallPathToRegistry();
 
+            //WindowsFirewallSettings.BypassFirewallForGame();
+
             ClientConfiguration.Instance.RefreshSettings();
 
             GameClass gameClass = new GameClass();


### PR DESCRIPTION
No one likes the Windows Firewall pop-up window.
This pull request implement a new feature to check and set up firewall settings to avoid the firewall pop-up window.
If the firewall settings are there, nothing happens.
Otherwise, the client will ask for user would he/she want to restart the client and gain administrator privileges. Once user clicked 'yes', the client will restart and set up firewall settings.
XNAMessagebox is used to ask user.

A new key in `ClientDefination.ini` is set as `BypassWindowsFirewall` with default value `true`.

Tested on DTA and MO.