### PR TITLE
Set admin status on existing users upon receiving channel user list

### DIFF
--- a/DXMainClient/Online/Channel.cs
+++ b/DXMainClient/Online/Channel.cs
@@ -119,8 +119,11 @@ namespace DTAClient.Online
         {
             foreach (var user in userList)
             {
-                if (users.Find(u => u.IRCUser.Name == user.IRCUser.Name) == null)
+                var existingUser = users.Find(u => u.IRCUser.Name == user.IRCUser.Name);
+                if (existingUser == null)
                     users.Add(user);
+                else
+                    existingUser.IsAdmin = user.IsAdmin;
             }
 
             users = users.OrderBy(u => u.IRCUser.Name).OrderBy(u => !u.IsAdmin).ToList();


### PR DESCRIPTION
Addresses a minor issue where current client user's admin status in client was not updated properly if it was changed after joining the channel but before receiving channel user info (f.ex when being the first user to join an unregistered IRC channel).