### PR TITLE
A number of proposed improvements & fixes to FileHashCalculator

### DIFF
--- a/DXMainClient/Online/FileHashCalculator.cs
+++ b/DXMainClient/Online/FileHashCalculator.cs
@@ -11,8 +11,8 @@ namespace DTAClient.Online
 {
     public class FileHashCalculator
     {
-        FileHashes fh;
-        const string CONFIGNAME = "FHCConfig.ini";
+        private FileHashes fh;
+        private const string CONFIGNAME = "FHCConfig.ini";
 
         string[] fileNamesToCheck = new string[]
         {
@@ -61,13 +61,12 @@ namespace DTAClient.Online
             "INI\\AIE.ini",
             "INI\\AIFS.ini",
 #endif
-            ProgramConstants.BASE_RESOURCE_PATH + CONFIGNAME,
         };
 
 
         public FileHashCalculator()
         {
-            GetFileListFromConfig();
+            ParseConfigFile();
         }
 
         public void CalculateHashes(List<GameMode> gameModes)
@@ -81,6 +80,7 @@ namespace DTAClient.Online
                 MainExeHash = Utilities.CalculateSHA1ForFile(ProgramConstants.GamePath + ClientConfiguration.Instance.GetGameExecutableName()),
                 LauncherExeHash = Utilities.CalculateSHA1ForFile(ProgramConstants.GamePath + ClientConfiguration.Instance.GameLauncherExecutableName),
                 MPMapsHash = Utilities.CalculateSHA1ForFile(ProgramConstants.GamePath + ClientConfiguration.Instance.MPMapsIniPath),
+                FHCConfigHash = Utilities.CalculateSHA1ForFile(ProgramConstants.BASE_RESOURCE_PATH + CONFIGNAME),
                 INIHashes = string.Empty
             };
 
@@ -110,10 +110,9 @@ namespace DTAClient.Online
 
                     foreach (string fileName in files)
                     {
-                        fh.INIHashes = fh.INIHashes + Utilities.CalculateSHA1ForFile(fileName);
+                        fh.INIHashes += Utilities.CalculateSHA1ForFile(fileName);
                         Logger.Log("Hash for " + fileName.Replace(ProgramConstants.GamePath, "") + 
                             ": " + Utilities.CalculateSHA1ForFile(fileName));
-
                     }
                 }
             }
@@ -134,28 +133,35 @@ namespace DTAClient.Online
         public string GetCompleteHash()
         {
             string str = fh.GameOptionsHash;
-            str = str + fh.ClientDXHash;
-            str = str + fh.ClientXNAHash;
-            str = str + fh.ClientOGLHash;
-            str = str + fh.MainExeHash;
-            str = str + fh.LauncherExeHash;
-            str = str + fh.INIHashes;
-            str = str + fh.MPMapsHash;
+            str += fh.ClientDXHash;
+            str += fh.ClientXNAHash;
+            str += fh.ClientOGLHash;
+            str += fh.MainExeHash;
+            str += fh.LauncherExeHash;
+            str += fh.INIHashes;
+            str += fh.MPMapsHash;
+            str += fh.FHCConfigHash;
 
             Logger.Log("Complete hash: " + Utilities.CalculateSHA1ForString(str));
 
             return Utilities.CalculateSHA1ForString(str);
         }
 
-        private void GetFileListFromConfig()
+        private void ParseConfigFile()
         {
-            IniFile filenamesconfig = new IniFile(ProgramConstants.GetBaseResourcePath() + CONFIGNAME);
-            List<string> filenames = filenamesconfig.GetSectionKeys("FilenameList");
-            if (filenames == null || filenames.Count < 1) return;
-#if YR
-            filenames.Add("INI\\Map Code\\GlobalCode.ini");
-#endif
-            filenames.Add(ProgramConstants.BASE_RESOURCE_PATH + CONFIGNAME);
+            IniFile config = new IniFile(ProgramConstants.GetBaseResourcePath() + CONFIGNAME);
+
+            List<string> keys = config.GetSectionKeys("FilenameList");
+            if (keys == null || keys.Count < 1)
+                return;
+
+            List<string> filenames = new List<string>();
+            foreach (string key in keys)
+            {
+                string value = config.GetStringValue("FilenameList", key, string.Empty);
+                filenames.Add(value == string.Empty ? key : value);
+            }
+
             fileNamesToCheck = filenames.ToArray();
         }
     }
@@ -170,6 +176,7 @@ namespace DTAClient.Online
         public string MPMapsHash { get; set; }
         public string MainExeHash { get; set; }
         public string LauncherExeHash { get; set; }
+        public string FHCConfigHash { get; set; }
 
         public override string ToString()
         {
@@ -180,7 +187,8 @@ namespace DTAClient.Online
                 "INI Hashes: " + INIHashes + Environment.NewLine +
                 "MPMaps Hash: " + MPMapsHash + Environment.NewLine +
                 "MainExe Hash: " + MainExeHash + Environment.NewLine +
-                "LauncherExe Hash: " + LauncherExeHash;
+                "LauncherExe Hash: " + LauncherExeHash + Environment.NewLine +
+                "FHCConfig Hash: " + FHCConfigHash;
         }
     }
 }

--- a/DXMainClient/Online/FileHashCalculator.cs
+++ b/DXMainClient/Online/FileHashCalculator.cs
@@ -86,6 +86,17 @@ namespace DTAClient.Online
                 INIHashes = string.Empty
             };
 
+            Logger.Log("Hash for " + ProgramConstants.BASE_RESOURCE_PATH + CONFIGNAME + ": " + fh.FHCConfigHash);
+            Logger.Log("Hash for " + ProgramConstants.BASE_RESOURCE_PATH + "GameOptions.ini: " + fh.GameOptionsHash);
+            Logger.Log("Hash for " + ProgramConstants.BASE_RESOURCE_PATH + "clientdx.exe: " + fh.ClientDXHash);
+            Logger.Log("Hash for " + ProgramConstants.BASE_RESOURCE_PATH + "clientxna.exe: " + fh.ClientXNAHash);
+            Logger.Log("Hash for " + ProgramConstants.BASE_RESOURCE_PATH + "clientogl.exe: " + fh.ClientOGLHash);
+            Logger.Log("Hash for " + ClientConfiguration.Instance.MPMapsIniPath + ": " + fh.MPMapsHash);
+            if (calculateGameExeHash)
+                Logger.Log("Hash for " + ClientConfiguration.Instance.GetGameExecutableName() + ": " + fh.GameExeHash);
+            if (!string.IsNullOrEmpty(ClientConfiguration.Instance.GameLauncherExecutableName))
+                Logger.Log("Hash for " + ClientConfiguration.Instance.GameLauncherExecutableName + ": " + fh.LauncherExeHash);
+
             foreach (string filePath in fileNamesToCheck)
             {
                 fh.INIHashes = AddToStringIfFileExists(fh.INIHashes, filePath);

--- a/DXMainClient/Online/FileHashCalculator.cs
+++ b/DXMainClient/Online/FileHashCalculator.cs
@@ -13,6 +13,7 @@ namespace DTAClient.Online
     {
         private FileHashes fh;
         private const string CONFIGNAME = "FHCConfig.ini";
+        private bool calculateGameExeHash = true;
 
         string[] fileNamesToCheck = new string[]
         {
@@ -77,7 +78,8 @@ namespace DTAClient.Online
                 ClientDXHash = Utilities.CalculateSHA1ForFile(ProgramConstants.GetBaseResourcePath() + "clientdx.exe"),
                 ClientXNAHash = Utilities.CalculateSHA1ForFile(ProgramConstants.GetBaseResourcePath() + "clientxna.exe"),
                 ClientOGLHash = Utilities.CalculateSHA1ForFile(ProgramConstants.GetBaseResourcePath() + "clientogl.exe"),
-                MainExeHash = Utilities.CalculateSHA1ForFile(ProgramConstants.GamePath + ClientConfiguration.Instance.GetGameExecutableName()),
+                GameExeHash = calculateGameExeHash ?
+                Utilities.CalculateSHA1ForFile(ProgramConstants.GamePath + ClientConfiguration.Instance.GetGameExecutableName()) : string.Empty,
                 LauncherExeHash = Utilities.CalculateSHA1ForFile(ProgramConstants.GamePath + ClientConfiguration.Instance.GameLauncherExecutableName),
                 MPMapsHash = Utilities.CalculateSHA1ForFile(ProgramConstants.GamePath + ClientConfiguration.Instance.MPMapsIniPath),
                 FHCConfigHash = Utilities.CalculateSHA1ForFile(ProgramConstants.BASE_RESOURCE_PATH + CONFIGNAME),
@@ -111,7 +113,7 @@ namespace DTAClient.Online
                     foreach (string fileName in files)
                     {
                         fh.INIHashes += Utilities.CalculateSHA1ForFile(fileName);
-                        Logger.Log("Hash for " + fileName.Replace(ProgramConstants.GamePath, "") + 
+                        Logger.Log("Hash for " + fileName.Replace(ProgramConstants.GamePath, "") +
                             ": " + Utilities.CalculateSHA1ForFile(fileName));
                     }
                 }
@@ -136,7 +138,7 @@ namespace DTAClient.Online
             str += fh.ClientDXHash;
             str += fh.ClientXNAHash;
             str += fh.ClientOGLHash;
-            str += fh.MainExeHash;
+            str += fh.GameExeHash;
             str += fh.LauncherExeHash;
             str += fh.INIHashes;
             str += fh.MPMapsHash;
@@ -150,6 +152,7 @@ namespace DTAClient.Online
         private void ParseConfigFile()
         {
             IniFile config = new IniFile(ProgramConstants.GetBaseResourcePath() + CONFIGNAME);
+            calculateGameExeHash = config.GetBooleanValue("Settings", "CalculateGameExeHash", true);
 
             List<string> keys = config.GetSectionKeys("FilenameList");
             if (keys == null || keys.Count < 1)
@@ -174,7 +177,7 @@ namespace DTAClient.Online
         public string ClientOGLHash { get; set; }
         public string INIHashes { get; set; }
         public string MPMapsHash { get; set; }
-        public string MainExeHash { get; set; }
+        public string GameExeHash { get; set; }
         public string LauncherExeHash { get; set; }
         public string FHCConfigHash { get; set; }
 
@@ -186,7 +189,7 @@ namespace DTAClient.Online
                 "ClientOGLHash: " + ClientOGLHash + Environment.NewLine +
                 "INI Hashes: " + INIHashes + Environment.NewLine +
                 "MPMaps Hash: " + MPMapsHash + Environment.NewLine +
-                "MainExe Hash: " + MainExeHash + Environment.NewLine +
+                "MainExe Hash: " + GameExeHash + Environment.NewLine +
                 "LauncherExe Hash: " + LauncherExeHash + Environment.NewLine +
                 "FHCConfig Hash: " + FHCConfigHash;
         }


### PR DESCRIPTION
- Can now set `CalculateGameExeHash` under `[Settings]` in `FHCConfig.ini` to false to disable calculating hash for game executable file.
- Changes to `FHCConfig.ini` parsing:
  - Now supports proper INI format (key=value) when parsing `[FilenameList]`. Old format (key only) is still supported for backwards compatibility.
  - `INI\Map Code\GlobalCode.ini` is no longer added to the list of filenames parsed from the config on YRRelease build as an arbitrary exception.
- The 'hardcoded' list of files (client & game executables etc) now have their hashes logged as well.