### PR TITLE
A fix to custom map game mode name capitalization

### DIFF
--- a/DXMainClient/Domain/Multiplayer/Map.cs
+++ b/DXMainClient/Domain/Multiplayer/Map.cs
@@ -341,6 +341,14 @@ namespace DTAClient.Domain.Multiplayer
                     Logger.Log("Custom map " + path + " has no game modes!");
                     return false;
                 }
+                else
+                {
+                    for (int i = 0; i < GameModes.Length; i++)
+                    {
+                        string gameMode = GameModes[i].Trim();
+                        GameModes[i] = gameMode.Substring(0, 1).ToUpperInvariant() + gameMode.Substring(1);
+                    }
+                }
 
                 MinPlayers = 0;
                 if (basicSection.KeyExists("ClientMaxPlayer"))

--- a/DXMainClient/Domain/Multiplayer/Map.cs
+++ b/DXMainClient/Domain/Multiplayer/Map.cs
@@ -341,13 +341,11 @@ namespace DTAClient.Domain.Multiplayer
                     Logger.Log("Custom map " + path + " has no game modes!");
                     return false;
                 }
-                else
+                
+                for (int i = 0; i < GameModes.Length; i++)
                 {
-                    for (int i = 0; i < GameModes.Length; i++)
-                    {
-                        string gameMode = GameModes[i].Trim();
-                        GameModes[i] = gameMode.Substring(0, 1).ToUpperInvariant() + gameMode.Substring(1);
-                    }
+                    string gameMode = GameModes[i].Trim();
+                    GameModes[i] = gameMode.Substring(0, 1).ToUpperInvariant() + gameMode.Substring(1);
                 }
 
                 MinPlayers = 0;


### PR DESCRIPTION
Restores the previous behaviour where first letter of game modes listed in custom maps was automatically capitalized and whitespace around it was ignored.