### PR TITLE
Fixes to various UI-related problems

### DIFF
--- a/ClientGUI/ToolTip.cs
+++ b/ClientGUI/ToolTip.cs
@@ -27,12 +27,17 @@ namespace ClientGUI
             masterControl.MouseMove += MasterControl_MouseMove;
             masterControl.EnabledChanged += MasterControl_EnabledChanged;
             InputEnabled = false;
-            DrawOrder = int.MinValue;
-            // TODO: adding tool tips as root-level controls might be CPU-intensive.
-            // instead we could find out the root-level parent and only have the tooltip
-            // in the window manager's list when the root-level parent is visible.
-            WindowManager.AddControl(this);
+            DrawOrder = int.MaxValue;
+            GetParentWindow(masterControl.Parent).AddChild(this);
             Visible = false;
+        }
+
+        private XNAWindow GetParentWindow(XNAControl parent)
+        {
+            if (parent is XNAWindow)
+                return parent as XNAWindow;
+            else
+                return GetParentWindow(parent.Parent);
         }
 
         private void MasterControl_EnabledChanged(object sender, EventArgs e)

--- a/ClientGUI/XNALinkButton.cs
+++ b/ClientGUI/XNALinkButton.cs
@@ -17,13 +17,13 @@ namespace ClientGUI
 
         public string URL { get; set; }
 
-        public ToolTip ToolTip;
+        private ToolTip toolTip;
 
         public override void Initialize()
         {
             base.Initialize();
 
-            ToolTip = new ToolTip(WindowManager, this);
+            toolTip = new ToolTip(WindowManager, this);
         }
 
         public override void ParseAttributeFromINI(IniFile iniFile, string key, string value)
@@ -35,7 +35,7 @@ namespace ClientGUI
             }
             else if (key == "ToolTip")
             {
-                ToolTip.Text = value;
+                toolTip.Text = value.Replace("@", Environment.NewLine);
                 return;
             }
 

--- a/DTAConfig/OptionPanels/ComponentsPanel.cs
+++ b/DTAConfig/OptionPanels/ComponentsPanel.cs
@@ -235,10 +235,10 @@ namespace DTAConfig.OptionPanels
                         cc.GUIName));
                 }
 
-                btn.Text = "Install";
+                btn.Text = "Install (" + GetSizeString(cc.RemoteSize) + ")";
 
                 if (File.Exists(ProgramConstants.GamePath + cc.LocalPath))
-                    btn.Text = "Update";
+                    btn.Text = "Update (" + GetSizeString(cc.RemoteSize) + ")";
             }
             else
             {

--- a/DTAConfig/OptionPanels/UpdaterOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/UpdaterOptionsPanel.cs
@@ -164,5 +164,10 @@ namespace DTAConfig.OptionPanels
 
             return false;
         }
+
+        public override void ToggleMainMenuOnlyOptions(bool enable)
+        {
+            btnForceUpdate.AllowClick = enable;
+        }
     }
 }

--- a/DTAConfig/OptionPanels/XNAOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/XNAOptionsPanel.cs
@@ -83,5 +83,14 @@ namespace DTAConfig.OptionPanels
             foreach (var checkBox in fileSettingCheckBoxes)
                 checkBox.Load();
         }
+
+        /// <summary>
+        /// Enables or disables any options that should only be available when
+        /// options window was opened in main menu.
+        /// </summary>
+        /// <param name="enable">If true enables options, disables if false.</param>
+        public virtual void ToggleMainMenuOnlyOptions(bool enable)
+        {
+        }
     }
 }

--- a/DTAConfig/OptionsWindow.cs
+++ b/DTAConfig/OptionsWindow.cs
@@ -143,12 +143,14 @@ namespace DTAConfig
                 return;
             }
 
+            WindowManager.SoundPlayer.SetVolume(Convert.ToSingle(UserINISettings.Instance.ClientVolume));
             Disable();
         }
 
         private void ExitDownloadCancelConfirmation_YesClicked(XNAMessageBox messageBox)
         {
             componentsPanel.CancelAllDownloads();
+            WindowManager.SoundPlayer.SetVolume(Convert.ToSingle(UserINISettings.Instance.ClientVolume));
             Disable();
         }
 

--- a/DTAConfig/OptionsWindow.cs
+++ b/DTAConfig/OptionsWindow.cs
@@ -235,6 +235,14 @@ namespace DTAConfig
             Enable();
         }
 
+        public void ToggleMainMenuOnlyOptions(bool enable)
+        {
+            foreach (var panel in optionsPanels)
+            {
+                panel.ToggleMainMenuOnlyOptions(enable);
+            }
+        }
+
         public void SwitchToCustomComponentsPanel()
         {
             foreach (var panel in optionsPanels)

--- a/DXMainClient/DXGUI/Generic/MainMenu.cs
+++ b/DXMainClient/DXGUI/Generic/MainMenu.cs
@@ -100,16 +100,16 @@ namespace DTAClient.DXGUI.Generic
         private CancellationTokenSource cncnetPlayerCountCancellationSource;
 
         // Main Menu Buttons
-        XNAClientButton btnNewCampaign;
-        XNAClientButton btnLoadGame;
-        XNAClientButton btnSkirmish;
-        XNAClientButton btnCnCNet;
-        XNAClientButton btnLan;
-        XNAClientButton btnOptions;
-        XNAClientButton btnMapEditor;
-        XNAClientButton btnStatistics;
-        XNAClientButton btnCredits;
-        XNAClientButton btnExtras;
+        private XNAClientButton btnNewCampaign;
+        private XNAClientButton btnLoadGame;
+        private XNAClientButton btnSkirmish;
+        private XNAClientButton btnCnCNet;
+        private XNAClientButton btnLan;
+        private XNAClientButton btnOptions;
+        private XNAClientButton btnMapEditor;
+        private XNAClientButton btnStatistics;
+        private XNAClientButton btnCredits;
+        private XNAClientButton btnExtras;
 
         /// <summary>
         /// Initializes the main menu's controls.

--- a/DXMainClient/DXGUI/Generic/MainMenu.cs
+++ b/DXMainClient/DXGUI/Generic/MainMenu.cs
@@ -245,14 +245,14 @@ namespace DTAClient.DXGUI.Generic
                 CUpdater.OnCustomComponentsOutdated += CUpdater_OnCustomComponentsOutdated;
             }
 
+            base.Initialize(); // Read control attributes from INI
+
             innerPanel = new MainMenuDarkeningPanel(WindowManager, discordHandler);
             innerPanel.ClientRectangle = new Rectangle(0, 0,
                 Width,
                 Height);
             AddChild(innerPanel);
             innerPanel.Hide();
-
-            base.Initialize(); // Read control attributes from INI
 
             lblVersion.Text = CUpdater.GameVersion;
 

--- a/DXMainClient/DXGUI/Generic/MainMenu.cs
+++ b/DXMainClient/DXGUI/Generic/MainMenu.cs
@@ -70,7 +70,19 @@ namespace DTAClient.DXGUI.Generic
 
         private XNAMessageBox firstRunMessageBox;
 
-        private bool updateInProgress = false;
+        private bool _updateInProgress;
+        private bool UpdateInProgress
+        {
+            get { return _updateInProgress; }
+            set 
+            {
+                _updateInProgress = value;
+                topBar.SetSwitchButtonsClickable(!_updateInProgress);
+                topBar.SetOptionsButtonClickable(!_updateInProgress);
+                SetButtonHotkeys(!_updateInProgress);
+            }
+        }
+
         private bool customComponentDialogQueued = false;
 
         private DateTime lastUpdateCheckTime;
@@ -87,6 +99,18 @@ namespace DTAClient.DXGUI.Generic
 
         private CancellationTokenSource cncnetPlayerCountCancellationSource;
 
+        // Main Menu Buttons
+        XNAClientButton btnNewCampaign;
+        XNAClientButton btnLoadGame;
+        XNAClientButton btnSkirmish;
+        XNAClientButton btnCnCNet;
+        XNAClientButton btnLan;
+        XNAClientButton btnOptions;
+        XNAClientButton btnMapEditor;
+        XNAClientButton btnStatistics;
+        XNAClientButton btnCredits;
+        XNAClientButton btnExtras;
+
         /// <summary>
         /// Initializes the main menu's controls.
         /// </summary>
@@ -100,85 +124,75 @@ namespace DTAClient.DXGUI.Generic
 
             WindowManager.CenterControlOnScreen(this);
 
-            var btnNewCampaign = new XNAClientButton(WindowManager);
+            btnNewCampaign = new XNAClientButton(WindowManager);
             btnNewCampaign.Name = "btnNewCampaign";
             btnNewCampaign.IdleTexture = AssetLoader.LoadTexture("MainMenu\\campaign.png");
             btnNewCampaign.HoverTexture = AssetLoader.LoadTexture("MainMenu\\campaign_c.png");
             btnNewCampaign.HoverSoundEffect = new EnhancedSoundEffect("MainMenu\\button.wav");
             btnNewCampaign.LeftClick += BtnNewCampaign_LeftClick;
-            btnNewCampaign.HotKey = Keys.C;
 
-            var btnLoadGame = new XNAClientButton(WindowManager);
+            btnLoadGame = new XNAClientButton(WindowManager);
             btnLoadGame.Name = "btnLoadGame";
             btnLoadGame.IdleTexture = AssetLoader.LoadTexture("MainMenu\\loadmission.png");
             btnLoadGame.HoverTexture = AssetLoader.LoadTexture("MainMenu\\loadmission_c.png");
             btnLoadGame.HoverSoundEffect = new EnhancedSoundEffect("MainMenu\\button.wav");
             btnLoadGame.LeftClick += BtnLoadGame_LeftClick;
-            btnLoadGame.HotKey = Keys.L;
 
-            var btnSkirmish = new XNAClientButton(WindowManager);
+            btnSkirmish = new XNAClientButton(WindowManager);
             btnSkirmish.Name = "btnSkirmish";
             btnSkirmish.IdleTexture = AssetLoader.LoadTexture("MainMenu\\skirmish.png");
             btnSkirmish.HoverTexture = AssetLoader.LoadTexture("MainMenu\\skirmish_c.png");
             btnSkirmish.HoverSoundEffect = new EnhancedSoundEffect("MainMenu\\button.wav");
             btnSkirmish.LeftClick += BtnSkirmish_LeftClick;
-            btnSkirmish.HotKey = Keys.S;
 
-            var btnCnCNet = new XNAClientButton(WindowManager);
+            btnCnCNet = new XNAClientButton(WindowManager);
             btnCnCNet.Name = "btnCnCNet";
             btnCnCNet.IdleTexture = AssetLoader.LoadTexture("MainMenu\\cncnet.png");
             btnCnCNet.HoverTexture = AssetLoader.LoadTexture("MainMenu\\cncnet_c.png");
             btnCnCNet.HoverSoundEffect = new EnhancedSoundEffect("MainMenu\\button.wav");
             btnCnCNet.LeftClick += BtnCnCNet_LeftClick;
-            btnCnCNet.HotKey = Keys.M;
 
-            var btnLan = new XNAClientButton(WindowManager);
+            btnLan = new XNAClientButton(WindowManager);
             btnLan.Name = "btnLan";
             btnLan.IdleTexture = AssetLoader.LoadTexture("MainMenu\\lan.png");
             btnLan.HoverTexture = AssetLoader.LoadTexture("MainMenu\\lan_c.png");
             btnLan.HoverSoundEffect = new EnhancedSoundEffect("MainMenu\\button.wav");
             btnLan.LeftClick += BtnLan_LeftClick;
-            btnLan.HotKey = Keys.N;
 
-            var btnOptions = new XNAClientButton(WindowManager);
+            btnOptions = new XNAClientButton(WindowManager);
             btnOptions.Name = "btnOptions";
             btnOptions.IdleTexture = AssetLoader.LoadTexture("MainMenu\\options.png");
             btnOptions.HoverTexture = AssetLoader.LoadTexture("MainMenu\\options_c.png");
             btnOptions.HoverSoundEffect = new EnhancedSoundEffect("MainMenu\\button.wav");
             btnOptions.LeftClick += BtnOptions_LeftClick;
-            btnOptions.HotKey = Keys.O;
 
-            var btnMapEditor = new XNAClientButton(WindowManager);
+            btnMapEditor = new XNAClientButton(WindowManager);
             btnMapEditor.Name = "btnMapEditor";
             btnMapEditor.IdleTexture = AssetLoader.LoadTexture("MainMenu\\mapeditor.png");
             btnMapEditor.HoverTexture = AssetLoader.LoadTexture("MainMenu\\mapeditor_c.png");
             btnMapEditor.HoverSoundEffect = new EnhancedSoundEffect("MainMenu\\button.wav");
             btnMapEditor.LeftClick += BtnMapEditor_LeftClick;
-            btnMapEditor.HotKey = Keys.E;
 
-            var btnStatistics = new XNAClientButton(WindowManager);
+            btnStatistics = new XNAClientButton(WindowManager);
             btnStatistics.Name = "btnStatistics";
             btnStatistics.IdleTexture = AssetLoader.LoadTexture("MainMenu\\statistics.png");
             btnStatistics.HoverTexture = AssetLoader.LoadTexture("MainMenu\\statistics_c.png");
             btnStatistics.HoverSoundEffect = new EnhancedSoundEffect("MainMenu\\button.wav");
             btnStatistics.LeftClick += BtnStatistics_LeftClick;
-            btnStatistics.HotKey = Keys.T;
 
-            var btnCredits = new XNAClientButton(WindowManager);
+            btnCredits = new XNAClientButton(WindowManager);
             btnCredits.Name = "btnCredits";
             btnCredits.IdleTexture = AssetLoader.LoadTexture("MainMenu\\credits.png");
             btnCredits.HoverTexture = AssetLoader.LoadTexture("MainMenu\\credits_c.png");
             btnCredits.HoverSoundEffect = new EnhancedSoundEffect("MainMenu\\button.wav");
             btnCredits.LeftClick += BtnCredits_LeftClick;
-            btnCredits.HotKey = Keys.R;
 
-            var btnExtras = new XNAClientButton(WindowManager);
+            btnExtras = new XNAClientButton(WindowManager);
             btnExtras.Name = "btnExtras";
             btnExtras.IdleTexture = AssetLoader.LoadTexture("MainMenu\\extras.png");
             btnExtras.HoverTexture = AssetLoader.LoadTexture("MainMenu\\extras_c.png");
             btnExtras.HoverSoundEffect = new EnhancedSoundEffect("MainMenu\\button.wav");
             btnExtras.LeftClick += BtnExtras_LeftClick;
-            btnExtras.HotKey = Keys.E;
 
             var btnExit = new XNAClientButton(WindowManager);
             btnExit.Name = "btnExit";
@@ -272,6 +286,41 @@ namespace DTAClient.DXGUI.Generic
             UserINISettings.Instance.SettingsSaved += SettingsSaved;
 
             CUpdater.Restart += CUpdater_Restart;
+
+            SetButtonHotkeys(true);
+        }
+
+        private void SetButtonHotkeys(bool enableHotkeys)
+        {
+            if (!Initialized)
+                return;
+
+            if (enableHotkeys)
+            {
+                btnNewCampaign.HotKey = Keys.C;
+                btnLoadGame.HotKey = Keys.L;
+                btnSkirmish.HotKey = Keys.S;
+                btnCnCNet.HotKey = Keys.M;
+                btnLan.HotKey = Keys.N;
+                btnOptions.HotKey = Keys.O;
+                btnMapEditor.HotKey = Keys.E;
+                btnStatistics.HotKey = Keys.T;
+                btnCredits.HotKey = Keys.R;
+                btnExtras.HotKey = Keys.X;
+            }
+            else
+            {
+                btnNewCampaign.HotKey = Keys.None;
+                btnLoadGame.HotKey = Keys.None;
+                btnSkirmish.HotKey = Keys.None;
+                btnCnCNet.HotKey = Keys.None;
+                btnLan.HotKey = Keys.None;
+                btnOptions.HotKey = Keys.None;
+                btnMapEditor.HotKey = Keys.None;
+                btnStatistics.HotKey = Keys.None;
+                btnCredits.HotKey = Keys.None;
+                btnExtras.HotKey = Keys.None;
+            }
         }
 
         private void OptionsWindow_EnabledChanged(object sender, EventArgs e)
@@ -420,7 +469,7 @@ namespace DTAClient.DXGUI.Generic
 
             if (cncnetPlayerCountCancellationSource != null) cncnetPlayerCountCancellationSource.Cancel();
             topBar.Clean();
-            if (updateInProgress)
+            if (UpdateInProgress)
                 CUpdater.TerminateUpdate = true;
 
             if (connectionManager.IsConnected)
@@ -461,7 +510,7 @@ namespace DTAClient.DXGUI.Generic
             lblUpdateStatus.Text = "Updating failed! Click to retry.";
             lblUpdateStatus.DrawUnderline = true;
             lblUpdateStatus.Enabled = true;
-            updateInProgress = false;
+            UpdateInProgress = false;
 
             innerPanel.Show(null); // Darkening
             XNAMessageBox msgBox = new XNAMessageBox(WindowManager, "Update failed",
@@ -486,7 +535,7 @@ namespace DTAClient.DXGUI.Generic
             lblUpdateStatus.Text = "The update was cancelled. Click to retry.";
             lblUpdateStatus.DrawUnderline = true;
             lblUpdateStatus.Enabled = true;
-            updateInProgress = false;
+            UpdateInProgress = false;
         }
 
         private void UpdateWindow_UpdateCompleted(object sender, EventArgs e)
@@ -494,7 +543,7 @@ namespace DTAClient.DXGUI.Generic
             innerPanel.Hide();
             lblUpdateStatus.Text = MainClientConstants.GAME_NAME_SHORT + " was succesfully updated to v." + CUpdater.GameVersion;
             lblVersion.Text = CUpdater.GameVersion;
-            updateInProgress = false;
+            UpdateInProgress = false;
             lblUpdateStatus.Enabled = true;
             lblUpdateStatus.DrawUnderline = false;
         }
@@ -519,7 +568,7 @@ namespace DTAClient.DXGUI.Generic
 
         private void ForceUpdate()
         {
-            updateInProgress = true;
+            UpdateInProgress = true;
             innerPanel.Hide();
             innerPanel.UpdateWindow.ForceUpdate();
             innerPanel.Show(innerPanel.UpdateWindow);
@@ -552,7 +601,7 @@ namespace DTAClient.DXGUI.Generic
         /// </summary>
         private void HandleFileIdentifierUpdate()
         {
-            if (updateInProgress)
+            if (UpdateInProgress)
             {
                 return;
             }
@@ -587,7 +636,7 @@ namespace DTAClient.DXGUI.Generic
             if (innerPanel.UpdateQueryWindow.Visible)
                 return;
 
-            if (updateInProgress)
+            if (UpdateInProgress)
                 return;
 
             if ((firstRunMessageBox != null && firstRunMessageBox.Visible) || optionsWindow.Enabled)
@@ -634,7 +683,7 @@ namespace DTAClient.DXGUI.Generic
             innerPanel.UpdateWindow.SetData(CUpdater.ServerGameVersion);
             innerPanel.Show(innerPanel.UpdateWindow);
             lblUpdateStatus.Text = "Updating...";
-            updateInProgress = true;
+            UpdateInProgress = true;
             CUpdater.StartAsyncUpdate();
         }
 

--- a/DXMainClient/DXGUI/Generic/TopBar.cs
+++ b/DXMainClient/DXGUI/Generic/TopBar.cs
@@ -227,10 +227,16 @@ namespace DTAClient.DXGUI.Generic
         }
 
         private void ConnectionManager_ConnectionLost(object sender, Online.EventArguments.ConnectionLostEventArgs e)
-            => ConnectionEvent("OFFLINE");
+        {
+            if (!lanMode)
+                ConnectionEvent("OFFLINE");
+        }
 
         private void ConnectionManager_ConnectAttemptFailed(object sender, EventArgs e)
-            => ConnectionEvent("OFFLINE");
+        {
+            if (!lanMode)
+                ConnectionEvent("OFFLINE");
+        }
 
         private void ConnectionManager_AttemptedServerChanged(object sender, Online.EventArguments.AttemptedServerEventArgs e)
         {
@@ -244,7 +250,8 @@ namespace DTAClient.DXGUI.Generic
         private void ConnectionManager_Disconnected(object sender, EventArgs e)
         {
             btnLogout.AllowClick = false;
-            ConnectionEvent("OFFLINE");
+            if (!lanMode)
+                ConnectionEvent("OFFLINE");
         }
 
         private void ConnectionEvent(string text)

--- a/DXMainClient/DXGUI/Generic/TopBar.cs
+++ b/DXMainClient/DXGUI/Generic/TopBar.cs
@@ -100,8 +100,7 @@ namespace DTAClient.DXGUI.Generic
             if (!lanMode) 
                 SetSwitchButtonsClickable(!optionsWindow.Enabled);
 
-            if (btnOptions != null)
-                btnOptions.AllowClick = !optionsWindow.Enabled;
+            SetOptionsButtonClickable(!optionsWindow.Enabled);
         }
 
         public void Clean()
@@ -355,6 +354,12 @@ namespace DTAClient.DXGUI.Generic
                 btnCnCNetLobby.AllowClick = allowClick;
             if (btnPrivateMessages != null)
                 btnPrivateMessages.AllowClick = allowClick;
+        }
+
+        public void SetOptionsButtonClickable(bool allowClick)
+        {
+            if (btnOptions != null)
+                btnOptions.AllowClick = allowClick;
         }
 
         public void SetLanMode(bool lanMode)

--- a/DXMainClient/DXGUI/Generic/TopBar.cs
+++ b/DXMainClient/DXGUI/Generic/TopBar.cs
@@ -101,6 +101,9 @@ namespace DTAClient.DXGUI.Generic
                 SetSwitchButtonsClickable(!optionsWindow.Enabled);
 
             SetOptionsButtonClickable(!optionsWindow.Enabled);
+
+            if (optionsWindow != null)
+                optionsWindow.ToggleMainMenuOnlyOptions(primarySwitches.Count == 1 && !lanMode);
         }
 
         public void Clean()

--- a/DXMainClient/DXGUI/Generic/TopBar.cs
+++ b/DXMainClient/DXGUI/Generic/TopBar.cs
@@ -97,12 +97,17 @@ namespace DTAClient.DXGUI.Generic
 
         private void OptionsWindow_EnabledChanged(object sender, EventArgs e)
         {
-            if (!lanMode) SetSwitchButtonsClickable(!optionsWindow.Enabled);
+            if (!lanMode) 
+                SetSwitchButtonsClickable(!optionsWindow.Enabled);
+
+            if (btnOptions != null)
+                btnOptions.AllowClick = !optionsWindow.Enabled;
         }
 
         public void Clean()
         {
-            if (cncnetPlayerCountCancellationSource != null) cncnetPlayerCountCancellationSource.Cancel();
+            if (cncnetPlayerCountCancellationSource != null) 
+                cncnetPlayerCountCancellationSource.Cancel();
         }
 
         public override void Initialize()


### PR DESCRIPTION
- Custom component button text now retains file size information even if download is canceled or unsuccessful.
- Options button in top bar will now be disabled if options window is open. This comes with minor graphical issues due to pressing the Options button altering its own AllowClick property. https://github.com/Rampastring/Rampastring.XNAUI/pull/5 contains a proposed fix to these graphical issues.
- Top bar buttons and main menu hotkeys are now disabled while updater window is open. Disabling hotkeys is not currently possible without just outright unsetting them, so there is potentially some room for improvement here. Also renders #134 incompatible and obsolete.
- Top bar status text won't be changed on disconnect from CnCNet if you have LAN (game) lobby currently open.
- Tooltips are now added as child controls of the most immediate XNAWindow-derived parent of their master control, instead of as a root-level controls. This fixes issues with tooltip display in certain places of the client such as the main menu. Also made XNALinkButton support multi-line tooltip text like checkboxes do.
- Saved client sound volume setting is now immediately restored upon exiting options without saving, instead of leaving the current sound volume active until the settings are refreshed by starting game or opening options window again.
- Main menu is initialized and extra controls are parsed and added before the MainMenuDarkeningPanel to ensure that none of the main menu elements can be interacted with through the darkening panel.
