### PR TITLE
Added DNS resolution and latency test for the Lobby servers.

### DIFF
--- a/DXMainClient/Online/Connection.cs
+++ b/DXMainClient/Online/Connection.cs
@@ -380,8 +380,8 @@ namespace DTAClient.Online
                                     Logger.Log($"The latency in milliseconds to the server {serverName} ({serverIPAddress}): {pingInMs}.");
                                     availableServerAndLatencyDict.Add(new Server(serverIPAddress.ToString(), serverName, serverPorts), pingInMs);
                                 }
-                                else if (pingReply.Status == IPStatus.TimedOut)
-                                    Logger.Log($"Pinging the server {serverName} ({serverIPAddress}) timed out!");
+                                else
+                                    Logger.Log($"Failed to ping the server {serverName} ({serverIPAddress}): {Enum.GetName(typeof(IPStatus), pingReply.Status)}.");
                             });
 
                             pingTask.Start();

--- a/DXMainClient/Online/Connection.cs
+++ b/DXMainClient/Online/Connection.cs
@@ -358,32 +358,30 @@ namespace DTAClient.Online
 
                         foreach (IPAddress serverIPAddress in serverIPAddresses)
                         {
-                            IPAddress theIPAddress = serverIPAddress;
-
-                            if (availableServerAndLatencyDict.Any(item => item.Key.Host == theIPAddress.ToString()))
+                            if (availableServerAndLatencyDict.Any(item => item.Key.Host == serverIPAddress.ToString()))
                             {
-                                Logger.Log($"Skipped a duplicate IP from {serverName} ({theIPAddress}).");
+                                Logger.Log($"Skipped a duplicate IP from {serverName} ({serverIPAddress}).");
                                 continue;
                             }
 
-                            if (failedServerIPs.Contains(theIPAddress.ToString()))
+                            if (failedServerIPs.Contains(serverIPAddress.ToString()))
                             {
-                                Logger.Log($"Skipped a failed server {serverName} ({theIPAddress}).");
+                                Logger.Log($"Skipped a failed server {serverName} ({serverIPAddress}).");
                                 continue;
                             }
 
                             Task pingTask = new Task(() =>
                             {
-                                Logger.Log($"Attempting to ping {serverName} ({theIPAddress}).");
-                                PingReply pingReply = new Ping().Send(theIPAddress, MAXIMUM_LATENCY);
+                                Logger.Log($"Attempting to ping {serverName} ({serverIPAddress}).");
+                                PingReply pingReply = new Ping().Send(serverIPAddress, MAXIMUM_LATENCY);
                                 if (pingReply.Status == IPStatus.Success)
                                 {
                                     long pingInMs = pingReply.RoundtripTime;
-                                    Logger.Log($"The latency in milliseconds to the server {serverName} ({theIPAddress}): {pingInMs}.");
-                                    availableServerAndLatencyDict.Add(new Server(theIPAddress.ToString(), serverName, serverPorts), pingInMs);
+                                    Logger.Log($"The latency in milliseconds to the server {serverName} ({serverIPAddress}): {pingInMs}.");
+                                    availableServerAndLatencyDict.Add(new Server(serverIPAddress.ToString(), serverName, serverPorts), pingInMs);
                                 }
                                 else if (pingReply.Status == IPStatus.TimedOut)
-                                    Logger.Log($"Pinging the server {serverName} ({theIPAddress}) timed out!");
+                                    Logger.Log($"Pinging the server {serverName} ({serverIPAddress}) timed out!");
                             });
 
                             pingTask.Start();

--- a/DXMainClient/Online/Connection.cs
+++ b/DXMainClient/Online/Connection.cs
@@ -333,6 +333,7 @@ namespace DTAClient.Online
         /// <returns>A list of available Lobby servers sorted by latency.</returns>
         private IEnumerable<Server> GetAvailableServerList()
         {
+            List<string> triedIPAddressList = new List<string>();
             Dictionary<Server, long> availableServerAndLatencyDict = new Dictionary<Server, long>();
 
             try
@@ -358,11 +359,12 @@ namespace DTAClient.Online
 
                         foreach (IPAddress serverIPAddress in serverIPAddresses)
                         {
-                            if (availableServerAndLatencyDict.Any(item => item.Key.Host == serverIPAddress.ToString()))
+                            if (triedIPAddressList.Contains(serverIPAddress.ToString()))
                             {
                                 Logger.Log($"Skipped a duplicate IP from {serverName} ({serverIPAddress}).");
                                 continue;
                             }
+                            triedIPAddressList.Add(serverIPAddress.ToString());
 
                             if (failedServerIPs.Contains(serverIPAddress.ToString()))
                             {

--- a/DXMainClient/Online/Connection.cs
+++ b/DXMainClient/Online/Connection.cs
@@ -363,38 +363,27 @@ namespace DTAClient.Online
                             if (availableServerAndLatencyDict.Any(item => item.Key.Host == theIPAddress.ToString()))
                             {
                                 Logger.Log($"Skipped a duplicate IP from {serverName} ({theIPAddress}).");
-
                                 continue;
                             }
 
                             if (failedServerIPs.Contains(theIPAddress.ToString()))
                             {
                                 Logger.Log($"Skipped a failed server {serverName} ({theIPAddress}).");
-
                                 continue;
                             }
 
                             Task pingTask = new Task(() =>
                             {
                                 Logger.Log($"Attempting to ping {serverName} ({theIPAddress}).");
-
                                 PingReply pingReply = new Ping().Send(theIPAddress, MAXIMUM_LATENCY);
-
                                 if (pingReply.Status == IPStatus.Success)
                                 {
                                     long pingInMs = pingReply.RoundtripTime;
-
                                     Logger.Log($"The latency in milliseconds to the server {serverName} ({theIPAddress}): {pingInMs}.");
-
                                     availableServerAndLatencyDict.Add(new Server(theIPAddress.ToString(), serverName, serverPorts), pingInMs);
                                 }
-                                else
-                                {
-                                    if (pingReply.Status == IPStatus.TimedOut)
-                                    {
-                                        Logger.Log($"Pinging the server {serverName} ({theIPAddress}) timed out!");
-                                    }
-                                }
+                                else if (pingReply.Status == IPStatus.TimedOut)
+                                    Logger.Log($"Pinging the server {serverName} ({theIPAddress}) timed out!");
                             });
 
                             pingTask.Start();
@@ -413,20 +402,13 @@ namespace DTAClient.Online
             catch (Exception ex)
             {
                 if (ex is AggregateException)
-                {
                     foreach (Exception innerEx in ((AggregateException)ex).Flatten().InnerExceptions)
-                    {
                         Logger.Log("Unable to contact with the server. " + innerEx.Message);
-                    }
-                }
                 else
-                {
                     Logger.Log("Unable to contact with the server. " + ex.Message);
-                }
             }
 
             Logger.Log($"The number of available Lobby servers is {availableServerAndLatencyDict.Count}.");
-
             return availableServerAndLatencyDict.OrderBy(item => item.Value).Select(item => item.Key);
         }
 


### PR DESCRIPTION
Thanks for your great work. I've made some modification about the process of connection to the Lobby servers. Please review and test it. Thank you.

### Commit message

1. Get all IP addresses of servers by resolving the hostname.
2. Test the latency to the servers and store them in a list.
3. If the latency is greater than 400 ms, ignore the server.
4. Sort the list and connect to the servers one by one.

### It can...

1. Find the closest and reachable server in few seconds.
2. Connect to all servers bound to one domain name.

### It also can...

1. Resolve #141 .

### Test

At 10:16 PM 4/17/2020, there are 843 players on the server.

<details>
  <summary>client.log</summary>
  <pre>
...
17.04. 22:16:59.701    Writing settings INI.
17.04. 22:16:59.739    Attempting to DNS resolve GameSurge (irc.gamesurge.net).
17.04. 22:16:59.760    Attempting to DNS resolve GameSurge London, UK (Burstfire.UK.EU.GameSurge.net).
17.04. 22:16:59.769    Attempting to DNS resolve GameSurge Chicago, IL (ColoCrossing.IL.US.GameSurge.net).
17.04. 22:16:59.780    DNS resolved GameSurge (irc.gamesurge.net): 108.174.48.100, 91.217.189.76, 192.223.27.109, 162.248.94.123, 195.68.206.250, 195.8.250.180
17.04. 22:16:59.789    DNS resolved GameSurge London, UK (Burstfire.UK.EU.GameSurge.net): 195.68.206.250
17.04. 22:16:59.804    Attempting to ping GameSurge (195.8.250.180).
17.04. 22:16:59.812    DNS resolved GameSurge Chicago, IL (ColoCrossing.IL.US.GameSurge.net): 108.174.48.100
17.04. 22:16:59.829    Attempting to ping GameSurge London, UK (195.68.206.250).
17.04. 22:16:59.840    Attempting to ping GameSurge Chicago, IL (108.174.48.100).
17.04. 22:17:00.064    The latency in milliseconds to the server GameSurge (195.8.250.180): 249.
17.04. 22:17:00.076    Attempting to ping GameSurge (195.68.206.250).
17.04. 22:17:00.140    The latency in milliseconds to the server GameSurge Chicago, IL (108.174.48.100): 286.
17.04. 22:17:00.151    Attempting to DNS resolve GameSurge Newark, NJ (Gameservers.NJ.US.GameSurge.net).
17.04. 22:17:00.176    DNS resolved GameSurge Newark, NJ (Gameservers.NJ.US.GameSurge.net): 208.167.237.120
17.04. 22:17:00.191    Attempting to ping GameSurge Newark, NJ (208.167.237.120).
17.04. 22:17:00.290    Pinging the server GameSurge London, UK (195.68.206.250) timed out!
17.04. 22:17:00.291    Pinging the server GameSurge (195.68.206.250) timed out!
17.04. 22:17:00.310    Pinging the server GameSurge Newark, NJ (208.167.237.120) timed out!
17.04. 22:17:00.319    Attempting to DNS resolve GameSurge Santa Ana, CA (Krypt.CA.US.GameSurge.net).
17.04. 22:17:00.330    Attempting to ping GameSurge (162.248.94.123).
17.04. 22:17:00.339    Attempting to DNS resolve GameSurge Seattle, WA (NuclearFallout.WA.US.GameSurge.net).
17.04. 22:17:00.351    DNS resolved GameSurge Santa Ana, CA (Krypt.CA.US.GameSurge.net): 209.11.244.82
17.04. 22:17:00.361    Attempting to ping GameSurge Santa Ana, CA (209.11.244.82).
17.04. 22:17:00.376    DNS resolved GameSurge Seattle, WA (NuclearFallout.WA.US.GameSurge.net): 162.248.94.123
17.04. 22:17:00.390    Attempting to ping GameSurge Seattle, WA (162.248.94.123).
17.04. 22:17:00.629    The latency in milliseconds to the server GameSurge Seattle, WA (162.248.94.123): 239.
17.04. 22:17:00.660    Attempting to DNS resolve GameSurge Stockholm, Sweden (Portlane.SE.EU.GameSurge.net).
17.04. 22:17:00.680    DNS resolved GameSurge Stockholm, Sweden (Portlane.SE.EU.GameSurge.net): 91.217.189.76
17.04. 22:17:00.681    Attempting to ping GameSurge Stockholm, Sweden (91.217.189.76).
17.04. 22:17:00.789    Pinging the server GameSurge (162.248.94.123) timed out!
17.04. 22:17:00.801    Pinging the server GameSurge Santa Ana, CA (209.11.244.82) timed out!
17.04. 22:17:00.821    Pinging the server GameSurge Stockholm, Sweden (91.217.189.76) timed out!
17.04. 22:17:00.821    Attempting to ping GameSurge (192.223.27.109).
17.04. 22:17:00.852    Attempting to DNS resolve GameSurge NYC, NY (Prothid.NY.US.GameSurge.Net).
17.04. 22:17:00.869    Attempting to DNS resolve GameSurge Wuppertal, Germany (TAL.DE.EU.GameSurge.net).
17.04. 22:17:00.877    DNS resolved GameSurge NYC, NY (Prothid.NY.US.GameSurge.Net): 192.223.27.109
17.04. 22:17:00.901    DNS resolved GameSurge Wuppertal, Germany (TAL.DE.EU.GameSurge.net): 195.8.250.180
17.04. 22:17:00.909    Attempting to ping GameSurge NYC, NY (192.223.27.109).
17.04. 22:17:00.921    Skipped a duplicate IP from GameSurge Wuppertal, Germany (195.8.250.180).
17.04. 22:17:00.934    Attempting to DNS resolve GameSurge IP 208.167.237.120 (208.167.237.120).
17.04. 22:17:00.950    DNS resolved GameSurge IP 208.167.237.120 (208.167.237.120): 208.167.237.120
17.04. 22:17:00.954    Attempting to ping GameSurge IP 208.167.237.120 (208.167.237.120).
17.04. 22:17:01.124    The latency in milliseconds to the server GameSurge (192.223.27.109): 272.
17.04. 22:17:01.140    Attempting to ping GameSurge (91.217.189.76).
17.04. 22:17:01.190    The latency in milliseconds to the server GameSurge NYC, NY (192.223.27.109): 268.
17.04. 22:17:01.201    Attempting to DNS resolve GameSurge IP 192.223.27.109 (192.223.27.109).
17.04. 22:17:01.214    DNS resolved GameSurge IP 192.223.27.109 (192.223.27.109): 192.223.27.109
17.04. 22:17:01.229    Skipped a duplicate IP from GameSurge IP 192.223.27.109 (192.223.27.109).
17.04. 22:17:01.244    Attempting to DNS resolve GameSurge IP 108.174.48.100 (108.174.48.100).
17.04. 22:17:01.260    Attempting to DNS resolve GameSurge IP 208.146.35.105 (208.146.35.105).
17.04. 22:17:01.260    DNS resolved GameSurge IP 108.174.48.100 (108.174.48.100): 108.174.48.100
17.04. 22:17:01.279    DNS resolved GameSurge IP 208.146.35.105 (208.146.35.105): 208.146.35.105
17.04. 22:17:01.291    Skipped a duplicate IP from GameSurge IP 108.174.48.100 (108.174.48.100).
17.04. 22:17:01.309    Pinging the server GameSurge IP 208.167.237.120 (208.167.237.120) timed out!
17.04. 22:17:01.314    Pinging the server GameSurge (91.217.189.76) timed out!
17.04. 22:17:01.329    Attempting to ping GameSurge IP 208.146.35.105 (208.146.35.105).
17.04. 22:17:01.334    Attempting to DNS resolve GameSurge IP 195.8.250.180 (195.8.250.180).
17.04. 22:17:01.350    Attempting to DNS resolve GameSurge IP 91.217.189.76 (91.217.189.76).
17.04. 22:17:01.361    Attempting to ping GameSurge (108.174.48.100).
17.04. 22:17:01.371    DNS resolved GameSurge IP 195.8.250.180 (195.8.250.180): 195.8.250.180
17.04. 22:17:01.380    DNS resolved GameSurge IP 91.217.189.76 (91.217.189.76): 91.217.189.76
17.04. 22:17:01.391    Skipped a duplicate IP from GameSurge IP 195.8.250.180 (195.8.250.180).
17.04. 22:17:01.411    Attempting to ping GameSurge IP 91.217.189.76 (91.217.189.76).
17.04. 22:17:01.420    Attempting to DNS resolve GameSurge IP 195.68.206.250 (195.68.206.250).
17.04. 22:17:01.432    DNS resolved GameSurge IP 195.68.206.250 (195.68.206.250): 195.68.206.250
17.04. 22:17:01.442    Attempting to ping GameSurge IP 195.68.206.250 (195.68.206.250).
17.04. 22:17:01.701    The latency in milliseconds to the server GameSurge IP 91.217.189.76 (91.217.189.76): 284.
17.04. 22:17:01.790    Pinging the server GameSurge IP 208.146.35.105 (208.146.35.105) timed out!
17.04. 22:17:01.800    Pinging the server GameSurge (108.174.48.100) timed out!
17.04. 22:17:01.820    Pinging the server GameSurge IP 195.68.206.250 (195.68.206.250) timed out!
17.04. 22:17:04.849    Attempting connection to 162.248.94.123:6667
17.04. 22:17:04.862    Connecting to 162.248.94.123 port 6667 timed out!
17.04. 22:17:07.121    Attempting connection to 162.248.94.123:5960
17.04. 22:17:07.130    Succesfully connected to 162.248.94.123 on port 5960
17.04. 22:17:07.140    Registering.
...
  </pre>
</details>