### PR TITLE
Update privacy notification copy, removes redundant reasoning

### DIFF
--- a/DXMainClient/DXGUI/Generic/PrivacyNotification.cs
+++ b/DXMainClient/DXGUI/Generic/PrivacyNotification.cs
@@ -26,7 +26,7 @@ namespace DTAClient.DXGUI.Generic
             lblDescription.Name = nameof(lblDescription);
             lblDescription.X = UIDesignConstants.EMPTY_SPACE_SIDES;
             lblDescription.Y = UIDesignConstants.EMPTY_SPACE_TOP;
-            lblDescription.Text = Renderer.FixText("By using the client you agree to the CnCNet Terms & Conditions as well as the CnCNet Privacy Policy. Privacy-related options can be configured in the client options.",
+            lblDescription.Text = Renderer.FixText("By using this application you agree to the CnCNet Terms & Conditions as well as the CnCNet Privacy Policy. Privacy-related options can be configured in the client settings.",
                 lblDescription.FontIndex, WindowManager.RenderResolutionX - (UIDesignConstants.EMPTY_SPACE_SIDES * 2)).Text;
             AddChild(lblDescription);
 
@@ -53,18 +53,10 @@ namespace DTAClient.DXGUI.Generic
             lblPrivacyPolicy.LeftClick += (s, e) => Process.Start(lblPrivacyPolicy.Text);
             AddChild(lblPrivacyPolicy);
 
-            var lblExplanation = new XNALabel(WindowManager);
-            lblExplanation.Name = nameof(lblExplanation);
-            lblExplanation.X = UIDesignConstants.EMPTY_SPACE_SIDES;
-            lblExplanation.Y = lblMoreInformation.Bottom + UIDesignConstants.CONTROL_VERTICAL_MARGIN * 2;
-            lblExplanation.Text = "No worries, we're not actually using your data for anything evil, but we have to display this message due to regulations.";
-            lblExplanation.TextColor = UISettings.ActiveSettings.SubtleTextColor;
-            AddChild(lblExplanation);
-
             var btnOK = new XNAClientButton(WindowManager);
             btnOK.Name = nameof(btnOK);
             btnOK.Width = 75;
-            btnOK.Y = lblExplanation.Y;
+            btnOK.Y = lblMoreInformation.Y;
             btnOK.X = WindowManager.RenderResolutionX - btnOK.Width - UIDesignConstants.CONTROL_HORIZONTAL_MARGIN;
             btnOK.Text = "Got it";
             AddChild(btnOK);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6104940/79636007-adc45e00-816c-11ea-9009-9b52bd01915d.png)

**Text reworded as per Crimsonum's suggestion.** 

From 
```
By using the client you agree to the CnCNet Terms & Conditions as well as the CnCNet Privacy Policy. Privacy-related options can be configured in the client options.
```
to:
```
By using this application you agree to the CnCNet Terms & Conditions as well as the CnCNet Privacy Policy. Privacy-related options can be configured in the client settings.
```

**Removes this bit entirely, as it's not needed.**
```
No worries, we're not actually using your data for anything evil, but we have to display this message due to regulations.
```