### PR TITLE
Allow to disable sides per game mode

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -985,8 +985,11 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                     returnValue[disallowedSideIndex] = true;
             }
 
-            foreach (int disallowedSideIndex in GameMode.DisallowedPlayerSides)
-                returnValue[disallowedSideIndex] = true;
+            if (GameMode != null)
+            {
+                foreach (int disallowedSideIndex in GameMode.DisallowedPlayerSides)
+                    returnValue[disallowedSideIndex] = true;
+            }
 
             foreach (var checkBox in CheckBoxes)
                 checkBox.ApplyDisallowedSideIndex(returnValue);

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -375,15 +375,9 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             AddChild(btnPickRandomMap);
         }
 
-        private void BtnPickRandomMap_LeftClick(object sender, EventArgs e)
-        {
-            PickRandomMap();
-        }
+        private void BtnPickRandomMap_LeftClick(object sender, EventArgs e) => PickRandomMap();
 
-        private void TbMapSearch_InputReceived(object sender, EventArgs e)
-        {
-            ListMaps();
-        }
+        private void TbMapSearch_InputReceived(object sender, EventArgs e) => ListMaps();
 
         private void Dropdown_SelectedIndexChanged(object sender, EventArgs e)
         {
@@ -988,10 +982,11 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 // Co-Op map disallowed side logic
 
                 foreach (int disallowedSideIndex in Map.CoopInfo.DisallowedPlayerSides)
-                {
                     returnValue[disallowedSideIndex] = true;
-                }
             }
+
+            foreach (int disallowedSideIndex in GameMode.DisallowedPlayerSides)
+                returnValue[disallowedSideIndex] = true;
 
             foreach (var checkBox in CheckBoxes)
                 checkBox.ApplyDisallowedSideIndex(returnValue);
@@ -1078,7 +1073,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 else
                     pInfo = AIPlayers[i - Players.Count];
 
-                pHouseInfo.RandomizeSide(pInfo, Map, SideCount, random, GetDisallowedSides(), RandomSelectors, RandomSelectorCount);
+                pHouseInfo.RandomizeSide(pInfo, SideCount, random, GetDisallowedSides(), RandomSelectors, RandomSelectorCount);
 
                 pHouseInfo.RandomizeColor(pInfo, freeColors, MPColors, random);
                 pHouseInfo.RandomizeStart(pInfo, Map,
@@ -1132,14 +1127,10 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             WriteSpawnIniAdditions(spawnIni);
 
             foreach (GameLobbyCheckBox chkBox in CheckBoxes)
-            {
                 chkBox.ApplySpawnINICode(spawnIni);
-            }
 
             foreach (GameLobbyDropDown dd in DropDowns)
-            {
                 dd.ApplySpawnIniCode(spawnIni);
-            }
 
             // Apply forced options from GameOptions.ini
 
@@ -1287,10 +1278,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             return false;
         }
 
-        protected virtual string GetIPAddressForPlayer(PlayerInfo player)
-        {
-            return "0.0.0.0";
-        }
+        protected virtual string GetIPAddressForPlayer(PlayerInfo player) => "0.0.0.0";
 
         /// <summary>
         /// Override this in a derived class to write game lobby specific code to
@@ -1491,10 +1479,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             UpdateDiscordPresence(true);
         }
 
-        private void GameProcessExited_Callback()
-        {
-            AddCallback(new Action(GameProcessExited), null);
-        }
+        private void GameProcessExited_Callback() => AddCallback(new Action(GameProcessExited), null);
 
         protected virtual void GameProcessExited()
         {

--- a/DXMainClient/Domain/Multiplayer/GameMode.cs
+++ b/DXMainClient/Domain/Multiplayer/GameMode.cs
@@ -37,6 +37,8 @@ namespace DTAClient.Domain.Multiplayer
 
         public bool ForceNoTeams { get; private set; }
 
+        public List<int> DisallowedPlayerSides = new List<int>();
+
         private string mapCodeININame;
 
         private string forcedOptionsSection;
@@ -62,6 +64,13 @@ namespace DTAClient.Domain.Multiplayer
             ForceNoTeams = forcedOptionsIni.GetBooleanValue(Name, "ForceNoTeams", false);
             forcedOptionsSection = forcedOptionsIni.GetStringValue(Name, "ForcedOptions", string.Empty);
             mapCodeININame = forcedOptionsIni.GetStringValue(Name, "MapCodeININame", Name + ".ini");
+
+            string[] disallowedSides = forcedOptionsIni
+                .GetStringValue(Name, "DisallowedPlayerSides", string.Empty)
+                .Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+
+            foreach (string sideIndex in disallowedSides)
+                DisallowedPlayerSides.Add(int.Parse(sideIndex));
 
             ParseForcedOptions(forcedOptionsIni);
 

--- a/DXMainClient/Domain/Multiplayer/PlayerHouseInfo.cs
+++ b/DXMainClient/Domain/Multiplayer/PlayerHouseInfo.cs
@@ -19,7 +19,6 @@ namespace DTAClient.Domain.Multiplayer
         /// and randomizes it if necessary.
         /// </summary>
         /// <param name="pInfo">The PlayerInfo of the player.</param>
-        /// <param name="map">The selected map.</param>
         /// <param name="sideCount">The number of sides in the game.</param>
         /// <param name="random">Random number generator.</param>
         /// <param name="disallowedSideArray">A bool array that determines which side indexes are disallowed by game options.</param>

--- a/DXMainClient/Domain/Multiplayer/PlayerHouseInfo.cs
+++ b/DXMainClient/Domain/Multiplayer/PlayerHouseInfo.cs
@@ -23,7 +23,7 @@ namespace DTAClient.Domain.Multiplayer
         /// <param name="sideCount">The number of sides in the game.</param>
         /// <param name="random">Random number generator.</param>
         /// <param name="disallowedSideArray">A bool array that determines which side indexes are disallowed by game options.</param>
-        public void RandomizeSide(PlayerInfo pInfo, Map map, int sideCount, Random random,
+        public void RandomizeSide(PlayerInfo pInfo, int sideCount, Random random,
             bool[] disallowedSideArray, List<int[]> randomSelectors, int randomCount)
         {
             if (pInfo.SideId == 0 || pInfo.SideId == sideCount + randomCount)
@@ -32,16 +32,8 @@ namespace DTAClient.Domain.Multiplayer
 
                 int sideId;
 
-                while (true)
-                {
-                    sideId = random.Next(0, sideCount);
-
-                    if (disallowedSideArray[sideId])
-                        continue;
-
-                    if (map.CoopInfo == null || !map.CoopInfo.DisallowedPlayerSides.Contains(sideId))
-                        break;
-                }
+                do sideId = random.Next(0, sideCount);
+                while (disallowedSideArray[sideId]);
 
                 SideIndex = sideId;
             }
@@ -53,15 +45,10 @@ namespace DTAClient.Domain.Multiplayer
                     int[] randomsides = randomSelectors[pInfo.SideId - 1];
                     int count = randomsides.Length;
                     int sideId;
-                    while (true)
-                    {
-                        sideId = randomsides[random.Next(0, count)];
-                        if (disallowedSideArray[sideId])
-                            continue;
+                    
+                    do sideId = randomsides[random.Next(0, count)];
+                    while (disallowedSideArray[sideId]);
 
-                        if (map.CoopInfo == null || !map.CoopInfo.DisallowedPlayerSides.Contains(sideId))
-                            break;
-                    }
                     SideIndex = sideId;
                 }
                 else SideIndex = pInfo.SideId - randomCount; // The player has selected a side


### PR DESCRIPTION
As requested by @Crimsonum you can now use `DisallowedPlayerSides` in game mode definitions. The usage is the same as with coop INI tag. Need investigation on how it would work with random selectors.