### PR TITLE
Add IRC SSL server support

### DIFF
--- a/DXMainClient/DXMainClient.csproj
+++ b/DXMainClient/DXMainClient.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DTAClient</RootNamespace>
     <AssemblyName>DTAClient</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <XnaPlatform>Windows</XnaPlatform>

--- a/DXMainClient/Online/Server.cs
+++ b/DXMainClient/Online/Server.cs
@@ -5,15 +5,17 @@
     /// </summary>
     public struct Server
     {
-        public Server(string host, string name, int[] ports)
+        public Server(string host, string name, int[] ports, bool useSsl = false)
         {
             Host = host;
             Name = name;
             Ports = ports;
+            UseSsl = useSsl;
         }
 
         public string Host;
         public string Name;
         public int[] Ports;
+        public bool UseSsl { get; }
     }
 }


### PR DESCRIPTION
* Extends the Server structure to also store a `UseSSL` boolean which defaults to `false`.
* After TCP connection to the server is established, attempts to wrap the TCP connection stream into an SSL stream and authenticates the server.
* The Server certificate is validated against the OS-default certificate validation routine.