### PR TITLE
Improve player nickname validation on startup & on saving settings

### DIFF
--- a/ClientCore/CnCNet5/NameValidator.cs
+++ b/ClientCore/CnCNet5/NameValidator.cs
@@ -5,6 +5,8 @@ namespace ClientCore.CnCNet5
 {
     public static class NameValidator
     {
+        private static readonly char[] ALLOWED_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_[]|\\{}^`".ToCharArray();
+
         /// <summary>
         /// Checks if the player's nickname is valid for CnCNet.
         /// </summary>
@@ -20,20 +22,18 @@ namespace ClientCore.CnCNet5
             if (profanityFilter.IsOffensive(name))
                 return "Please enter a name that is less offensive.";
 
-            int number = -1;
-            if (int.TryParse(name.Substring(0, 1), out number))
+            if (int.TryParse(name.Substring(0, 1), out _))
                 return "The first character in the player name cannot be a number.";
 
             if (name[0] == '-')
                 return "The first character in the player name cannot be a dash ( - ).";
 
             // Check that there are no invalid chars
-            char[] allowedCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_[]|\\{}^`".ToCharArray();
             char[] nicknameChars = name.ToCharArray();
 
             foreach (char nickChar in nicknameChars)
             {
-                if (!allowedCharacters.Contains(nickChar))
+                if (!ALLOWED_CHARS.Contains(nickChar))
                 {
                     return "Your player name has invalid characters in it." + Environment.NewLine +
                     "Allowed characters are anything from A to Z and numbers.";
@@ -44,6 +44,22 @@ namespace ClientCore.CnCNet5
                 return "Your nickname is too long.";
 
             return null;
+        }
+
+        /// <summary>
+        /// Returns player nickname constrained to maximum allowed length and with invalid characters removed.
+        /// Does not check for offensive words or invalid first characters for CnCNet.
+        /// </summary>
+        /// <param name="name">Player nickname.</param>
+        /// <returns>Player nickname with invalid characters removed and constrained to maximum name length.</returns>
+        public static string GetValidOfflineName(string name)
+        {
+            string validName = new string(name.Trim().Where(c => ALLOWED_CHARS.Contains(c)).ToArray());
+
+            if (validName.Length > ClientConfiguration.Instance.MaxNameLength)
+                return validName.Substring(0, ClientConfiguration.Instance.MaxNameLength);
+            
+            return validName;
         }
     }
 }

--- a/ClientCore/CnCNet5/NameValidator.cs
+++ b/ClientCore/CnCNet5/NameValidator.cs
@@ -5,8 +5,6 @@ namespace ClientCore.CnCNet5
 {
     public static class NameValidator
     {
-        private static readonly char[] ALLOWED_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_[]|\\{}^`".ToCharArray();
-
         /// <summary>
         /// Checks if the player's nickname is valid for CnCNet.
         /// </summary>
@@ -29,11 +27,12 @@ namespace ClientCore.CnCNet5
                 return "The first character in the player name cannot be a dash ( - ).";
 
             // Check that there are no invalid chars
+            char[] allowedCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_[]|\\{}^`".ToCharArray();
             char[] nicknameChars = name.ToCharArray();
 
             foreach (char nickChar in nicknameChars)
             {
-                if (!ALLOWED_CHARS.Contains(nickChar))
+                if (!allowedCharacters.Contains(nickChar))
                 {
                     return "Your player name has invalid characters in it." + Environment.NewLine +
                     "Allowed characters are anything from A to Z and numbers.";
@@ -47,14 +46,16 @@ namespace ClientCore.CnCNet5
         }
 
         /// <summary>
-        /// Returns player nickname constrained to maximum allowed length and with invalid characters removed.
-        /// Does not check for offensive words or invalid first characters for CnCNet.
+        /// Returns player nickname constrained to maximum allowed length and with invalid characters for offline nicknames removed.
+        /// Does not check for offensive words or invalid characters for CnCNet.
         /// </summary>
         /// <param name="name">Player nickname.</param>
-        /// <returns>Player nickname with invalid characters removed and constrained to maximum name length.</returns>
+        /// <returns>Player nickname with invalid offline nickname characters removed and constrained to maximum name length.</returns>
         public static string GetValidOfflineName(string name)
         {
-            string validName = new string(name.Trim().Where(c => ALLOWED_CHARS.Contains(c)).ToArray());
+            char[] disallowedCharacters = ",;".ToCharArray();
+
+            string validName = new string(name.Trim().Where(c => !disallowedCharacters.Contains(c)).ToArray());
 
             if (validName.Length > ClientConfiguration.Instance.MaxNameLength)
                 return validName.Substring(0, ClientConfiguration.Instance.MaxNameLength);

--- a/DTAConfig/OptionPanels/GameOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/GameOptionsPanel.cs
@@ -1,4 +1,5 @@
 ﻿using ClientCore;
+using ClientCore.CnCNet5;
 using ClientGUI;
 using Microsoft.Xna.Framework;
 using Rampastring.XNAUI;
@@ -249,13 +250,10 @@ namespace DTAConfig.OptionPanels
                 IniSettings.TextBackgroundColor.Value = TEXT_BACKGROUND_COLOR_TRANSPARENT;
 #endif
 
-            string playerName = tbPlayerName.Text;
-            playerName = playerName.Replace(",", string.Empty);
-            playerName = Renderer.GetSafeString(playerName, 0);
-            playerName.Trim();
+            string playerName = NameValidator.GetValidOfflineName(tbPlayerName.Text);
 
             if (playerName.Length > 0)
-                IniSettings.PlayerName.Value = tbPlayerName.Text;
+                IniSettings.PlayerName.Value = playerName;
 
             return false;
         }

--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -1,4 +1,5 @@
 ﻿using ClientCore;
+using ClientCore.CnCNet5;
 using DTAClient.Domain;
 using DTAClient.DXGUI.Generic;
 using Microsoft.Xna.Framework;
@@ -136,12 +137,7 @@ namespace DTAClient.DXGUI
                 playerName = playerName.Substring(playerName.IndexOf("\\") + 1);
             }
 
-            playerName = playerName.Replace(",", string.Empty);
-            playerName = Renderer.GetSafeString(playerName, 0);
-            playerName.Trim();
-            int maxNameLength = ClientConfiguration.Instance.MaxNameLength;
-            if (playerName.Length > maxNameLength)
-                playerName = playerName.Substring(0, maxNameLength);
+            playerName = Renderer.GetSafeString(NameValidator.GetValidOfflineName(playerName), 0);
 
             ProgramConstants.PLAYERNAME = playerName;
             UserINISettings.Instance.PlayerName.Value = playerName;


### PR DESCRIPTION
Unifies the validation of player nickname on client startup and when saving settings. Also fixes an error with saving settings where it previously wouldn't save the cleaned up nickname to settings INI, instead using raw text from the player name textbox.

This validation now uses same list of allowed characters as the name check upon attempt to connect to CnCNet, but it won't check for offensive words nor it will remove starting dashes / numbers. If such functionality is desirable, it could be added but I didn't deem it worthwhile.