### PR TITLE
Fixup to map preview extractor rework

### DIFF
--- a/ClientCore/ClientCore.csproj
+++ b/ClientCore/ClientCore.csproj
@@ -162,9 +162,6 @@
     <Reference Include="Ionic.Zip">
       <HintPath>..\References\Ionic.Zip.dll</HintPath>
     </Reference>
-    <Reference Include="MapThumbnailExtractor">
-      <HintPath>..\References\MapThumbnailExtractor.dll</HintPath>
-    </Reference>
     <Reference Include="Rampastring.Tools, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\References\Rampastring.Tools.dll</HintPath>

--- a/DXMainClient/Domain/Multiplayer/MapPreviewExtractor.cs
+++ b/DXMainClient/Domain/Multiplayer/MapPreviewExtractor.cs
@@ -99,12 +99,12 @@ namespace DTAClient.Domain.Multiplayer
                     read += 2;
                     readBytes += 4;
 
+                    if (sizeCompressed == 0 || sizeUncompressed == 0)
+                        break;
+
                     if (readBytes + sizeCompressed > dataSource.Length ||
                         writtenBytes + sizeUncompressed > dataDest.Length)
                         return false;
-
-                    if (sizeCompressed == 0 || sizeUncompressed == 0)
-                        break;
 
                     MiniLZO.Decompress(read, sizeCompressed, write, ref sizeUncompressed);
 

--- a/DXMainClient/Domain/Multiplayer/MiniLZO.cs
+++ b/DXMainClient/Domain/Multiplayer/MiniLZO.cs
@@ -381,7 +381,7 @@ namespace DTAClient.Domain.Multiplayer
 						if (t > 0) do *op++ = *m_pos++; while (--t > 0);
 					}
 					else {
-					copy_match:
+					//copy_match: // Not referenced.
 						*op++ = *m_pos++; *op++ = *m_pos++;
 						do *op++ = *m_pos++; while (--t > 0);
 					}
@@ -389,7 +389,7 @@ namespace DTAClient.Domain.Multiplayer
 					t = (uint)(ip[-2] & 3);
 					if (t == 0)
 						break;
-				match_next:
+				//match_next: // Not referenced.
 					*op++ = *ip++;
 					if (t > 1) { *op++ = *ip++; if (t > 2) { *op++ = *ip++; } }
 					t = *ip++;


### PR DESCRIPTION
- Fix decompression code to not fail on data that contains padding.
- Remove obsolete reference to MapThumbnailExtractor.dll from ClientCore.
- Comment out unreferenced labels in MiniLZO that were generating warnings.