### PR TITLE
Enable IPv6 connection (dual stack) with Lobby servers on DirectX and OpenGL clients

### DIFF
--- a/DXMainClient/Online/Connection.cs
+++ b/DXMainClient/Online/Connection.cs
@@ -173,7 +173,8 @@ namespace DTAClient.Online
                     {
                         connectionManager.OnAttemptedServerChanged(server.Name);
 
-                        TcpClient client = new TcpClient(AddressFamily.InterNetwork);
+                        TcpClient client = new TcpClient(AddressFamily.InterNetworkV6);
+                        client.Client.DualMode = true;
                         var result = client.BeginConnect(server.Host, server.Ports[i], null, null);
                         result.AsyncWaitHandle.WaitOne(TimeSpan.FromSeconds(3), false);
 
@@ -351,8 +352,7 @@ namespace DTAClient.Online
                         Logger.Log($"Attempting to DNS resolve {serverName} ({serverHostnameOrIPAddress}).");
 
                         // If hostNameOrAddress is an IP address, this address is returned without querying the DNS server.
-                        List<IPAddress> serverIPAddresses = Dns.GetHostAddresses(serverHostnameOrIPAddress)
-                            .Where(item => item.AddressFamily == AddressFamily.InterNetwork).ToList();
+                        List<IPAddress> serverIPAddresses = Dns.GetHostAddresses(serverHostnameOrIPAddress).ToList();
 
                         Logger.Log($"DNS resolved {serverName} ({serverHostnameOrIPAddress}): " +
                             $"{string.Join(", ", serverIPAddresses.Select(item => item.ToString()))}");

--- a/DXMainClient/Online/Connection.cs
+++ b/DXMainClient/Online/Connection.cs
@@ -173,8 +173,12 @@ namespace DTAClient.Online
                     {
                         connectionManager.OnAttemptedServerChanged(server.Name);
 
+#if XNA
+                        TcpClient client = new TcpClient(AddressFamily.InterNetwork);
+#else
                         TcpClient client = new TcpClient(AddressFamily.InterNetworkV6);
                         client.Client.DualMode = true;
+#endif
                         var result = client.BeginConnect(server.Host, server.Ports[i], null, null);
                         result.AsyncWaitHandle.WaitOne(TimeSpan.FromSeconds(3), false);
 
@@ -334,6 +338,11 @@ namespace DTAClient.Online
         /// <returns>A list of available Lobby servers sorted by latency.</returns>
         private IEnumerable<Server> GetAvailableServerList()
         {
+#if XNA
+            Logger.Log($"Finding available Lobby servers (IPv4 only).");
+#else
+            Logger.Log($"Finding available Lobby servers (IPv4 and IPv6).");
+#endif
             List<string> triedIPAddressList = new List<string>();
             Dictionary<Server, long> availableServerAndLatencyDict = new Dictionary<Server, long>();
 
@@ -352,7 +361,12 @@ namespace DTAClient.Online
                         Logger.Log($"Attempting to DNS resolve {serverName} ({serverHostnameOrIPAddress}).");
 
                         // If hostNameOrAddress is an IP address, this address is returned without querying the DNS server.
+#if XNA
+                        List<IPAddress> serverIPAddresses = Dns.GetHostAddresses(serverHostnameOrIPAddress)
+                            .Where(item => item.AddressFamily == AddressFamily.InterNetwork).ToList();
+#else
                         List<IPAddress> serverIPAddresses = Dns.GetHostAddresses(serverHostnameOrIPAddress).ToList();
+#endif
 
                         Logger.Log($"DNS resolved {serverName} ({serverHostnameOrIPAddress}): " +
                             $"{string.Join(", ", serverIPAddresses.Select(item => item.ToString()))}");


### PR DESCRIPTION
Enhance #142 .

Learned from [Dual Mode Sockets - Never create an IPv4 Socket again | ASP.NET Blog](https://devblogs.microsoft.com/aspnet/dual-mode-sockets-never-create-an-ipv4-socket-again/) .

Why `#if XNA`: [`Socket.DualMode`](https://docs.microsoft.com/dotnet/api/system.net.sockets.socket.dualmode) is supported since .NET Framework 4.5, while XNA Framework depends on .NET Framework 4.0, so it is a bit complicated to implement dual-stack connection on XNA.

@Metadorius , thank you for your suggestion.
