### PR TITLE
Features / improvements for Ares build of the client.

### DIFF
--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -269,13 +269,6 @@ namespace ClientCore
 
         public bool UseClientRandomStartLocations => clientDefinitionsIni.GetBooleanValue(SETTINGS, "UseClientRandomStartLocations", false);
 
-        public bool ProcessScreenshots
-#if ARES
-            => clientDefinitionsIni.GetBooleanValue(SETTINGS, "ProcessScreenshots", true);
-#else
-            => false;
-#endif
-
         /// <summary>
         /// Returns the name of the game executable file that is used on
         /// Linux and macOS.

--- a/DXMainClient/DXGUI/Generic/GameInProgressWindow.cs
+++ b/DXMainClient/DXGUI/Generic/GameInProgressWindow.cs
@@ -194,8 +194,8 @@ namespace DTAClient.DXGUI
             if (deletingLogFilesFailed)
                 return;
 
-            CopyErrorLog(ProgramConstants.GamePath + "Client/ErrorLogs", "EXCEPT.TXT", dtn);
-            CopySyncErrorLogs(ProgramConstants.GamePath + "Client/ErrorLogs", dtn);
+            CopyErrorLog(ProgramConstants.ClientUserFilesPath + "GameCrashLogs", "EXCEPT.TXT", dtn);
+            CopySyncErrorLogs(ProgramConstants.ClientUserFilesPath + "SyncErrorLogs", dtn);
 #endif
         }
 
@@ -219,9 +219,7 @@ namespace DTAClient.DXGUI
 
                     Logger.Log("The game crashed! Copying " + filename + " file.");
 
-                    string timeStamp = dateTime.HasValue ? string.Format("_{0}_{1}_{2}_{3}_{4}",
-                        dateTime.Value.Day, dateTime.Value.Month, dateTime.Value.Year,
-                        dateTime.Value.Hour, dateTime.Value.Minute) : "";
+                    string timeStamp = dateTime.HasValue ? dateTime.Value.ToString("_yyyy_MM_dd_HH_mm") : "";
 
                     string filenameCopy = Path.GetFileNameWithoutExtension(filename) +
                         timeStamp + Path.GetExtension(filename);
@@ -260,9 +258,7 @@ namespace DTAClient.DXGUI
 
                         Logger.Log("There was a sync error! Copying file " + filename);
 
-                        string timeStamp = dateTime.HasValue ? string.Format("_{0}_{1}_{2}_{3}_{4}",
-                            dateTime.Value.Day, dateTime.Value.Month, dateTime.Value.Year,
-                            dateTime.Value.Hour, dateTime.Value.Minute) : "";
+                        string timeStamp = dateTime.HasValue ? dateTime.Value.ToString("_yyyy_MM_dd_HH_mm") : "";
 
                         string filenameCopy = Path.GetFileNameWithoutExtension(filename) +
                             timeStamp + Path.GetExtension(filename);
@@ -343,9 +339,9 @@ namespace DTAClient.DXGUI
                 {
                     Directory.CreateDirectory(screenshotsDirectory);
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    Logger.Log("ProcessScreenshots: Failed to create Screenshots directory. Error message: " + e.Message);
+                    Logger.Log("ProcessScreenshots: An error occured trying to create Screenshots directory. Message: " + ex.Message);
                     return;
                 }
             }
@@ -359,9 +355,9 @@ namespace DTAClient.DXGUI
                         ".png", System.Drawing.Imaging.ImageFormat.Png);
                     bitmap.Dispose();
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    Logger.Log("ProcessScreenshots: Failed to save " + Path.GetFileNameWithoutExtension(filename) + ".png. Error message: " + e.Message);
+                    Logger.Log("ProcessScreenshots: Error occured when trying to save " + Path.GetFileNameWithoutExtension(filename) + ".png. Message: " + ex.Message);
                     continue;
                 }
 

--- a/DXMainClient/DXGUI/Generic/GameInProgressWindow.cs
+++ b/DXMainClient/DXGUI/Generic/GameInProgressWindow.cs
@@ -7,6 +7,8 @@ using Rampastring.XNAUI;
 using ClientGUI;
 using System.IO;
 using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace DTAClient.DXGUI
 {
@@ -25,8 +27,14 @@ namespace DTAClient.DXGUI
         }
 
         private bool initialized = false;
-        private bool deletingLogFilesFailed = false;
         private bool nativeCursorUsed = false;
+
+#if ARES
+        private List<string> debugSnapshotDirectories;
+        private DateTime debugLogLastWriteTime;
+#else
+        private bool deletingLogFilesFailed = false;
+#endif
 
         public override void Initialize()
         {
@@ -66,10 +74,23 @@ namespace DTAClient.DXGUI
 
             Visible = false;
             Enabled = false;
+
+#if ARES
+            try
+            {
+                if (File.Exists(ProgramConstants.GamePath + "debug/debug.log"))
+                    debugLogLastWriteTime = File.GetLastWriteTimeUtc(ProgramConstants.GamePath + "debug/debug.log");
+            }
+            catch { }
+#endif
         }
 
         private void SharedUILogic_GameProcessStarted()
         {
+
+#if ARES
+            debugSnapshotDirectories = GetAllDebugSnapshotDirectories();
+#else
             try
             {
                 File.Delete(ProgramConstants.GamePath + "EXCEPT.TXT");
@@ -84,6 +105,7 @@ namespace DTAClient.DXGUI
                 Logger.Log("Exception when deleting error log files! Message: " + ex.Message);
                 deletingLogFilesFailed = true;
             }
+#endif
 
             Visible = true;
             Enabled = true;
@@ -94,6 +116,7 @@ namespace DTAClient.DXGUI
             Game.TargetElapsedTime = TimeSpan.FromMilliseconds(1000.0 / POWER_SAVING_FPS);
             if (UserINISettings.Instance.MinimizeWindowsOnGameStart)
                 WindowManager.MinimizeWindow();
+
         }
 
         private void SharedUILogic_GameProcessExited()
@@ -116,10 +139,6 @@ namespace DTAClient.DXGUI
 
             UserINISettings.Instance.ReloadSettings();
 
-#if ARES
-            Task.Factory.StartNew(ProcessScreenshots);
-#endif
-
             if (UserINISettings.Instance.BorderlessWindowedClient)
             {
                 // Hack: Re-set graphics mode
@@ -133,47 +152,183 @@ namespace DTAClient.DXGUI
                 GameClass.SetGraphicsMode(WindowManager);
             }
 
+            DateTime dtn = DateTime.Now;
+
+#if ARES
+            Task.Factory.StartNew(ProcessScreenshots);
+
+            // TODO: Ares debug log handling should be addressed in Ares DLL itself.
+            // For now the following are handled here:
+            // 1. Make a copy of syringe.log in debug snapshot directory on both crash and desync.
+            // 2. Move SYNCX.txt from game directory to debug snapshot directory on desync.
+            // 3. Make a debug snapshot directory & copy debug.log to it on desync even if full crash dump wasn't created.
+            // 4. Handle the empty snapshot directories created on a crash if debug logging was disabled.
+
+            string snapshotDirectory = GetNewestDebugSnapshotDirectory();
+            bool snapshotCreated = snapshotDirectory != null;
+
+            snapshotDirectory = snapshotDirectory ?? ProgramConstants.GamePath + "debug/snapshot-" +
+                dtn.ToString("yyyyMMdd-HHmmss");
+
+            bool debugLogModified = false;
+            string debugLogPath = ProgramConstants.GamePath + "debug/debug.log";
+            DateTime lastWriteTime = new DateTime();
+
+            if (File.Exists(debugLogPath))
+                lastWriteTime = File.GetLastWriteTimeUtc(debugLogPath);
+
+            if (!lastWriteTime.Equals(debugLogLastWriteTime))
+            {
+                debugLogModified = true;
+                debugLogLastWriteTime = lastWriteTime;
+            }
+
+            if (CopySyncErrorLogs(snapshotDirectory, null) || snapshotCreated)
+            {
+                if (File.Exists(debugLogPath) && !File.Exists(snapshotDirectory + "/debug.log") && debugLogModified)
+                    File.Copy(debugLogPath, snapshotDirectory + "/debug.log");
+
+                CopyErrorLog(snapshotDirectory, "syringe.log", null);
+            }
+#else
             if (deletingLogFilesFailed)
                 return;
 
+            CopyErrorLog(ProgramConstants.GamePath + "Client/ErrorLogs", "EXCEPT.TXT", dtn);
+            CopySyncErrorLogs(ProgramConstants.GamePath + "Client/ErrorLogs", dtn);
+#endif
+        }
+
+        /// <summary>
+        /// Attempts to copy a general error log from game directory to another directory.
+        /// </summary>
+        /// <param name="directory">Directory to copy error log to.</param>
+        /// <param name="filename">Filename of the error log.</param>
+        /// <param name="dateTime">Time to to apply as a timestamp to filename. Set to null to not apply a timestamp.</param>
+        /// <returns>True if error log was copied, false otherwise.</returns>
+        private bool CopyErrorLog(string directory, string filename, DateTime? dateTime)
+        {
+            bool copied = false;
+
             try
             {
-                if (!Directory.Exists(ProgramConstants.GamePath + "Client/ErrorLogs"))
-                    Directory.CreateDirectory(ProgramConstants.GamePath + "Client/ErrorLogs");
-
-                DateTime dtn = DateTime.Now;
-
-                if (File.Exists(ProgramConstants.GamePath + "EXCEPT.TXT"))
+                if (File.Exists(ProgramConstants.GamePath + filename))
                 {
-                    Logger.Log("The game crashed! Copying EXCEPT.TXT file.");
+                    if (!Directory.Exists(directory))
+                        Directory.CreateDirectory(directory);
 
-                    File.Copy(ProgramConstants.GamePath + "EXCEPT.TXT",
-                        string.Format(ProgramConstants.GamePath + "Client/ErrorLogs/EXCEPT_{0}_{1}_{2}_{3}_{4}.TXT",
-                        dtn.Day, dtn.Month, dtn.Year, dtn.Hour, dtn.Minute));
+                    Logger.Log("The game crashed! Copying " + filename + " file.");
+
+                    string timeStamp = dateTime.HasValue ? string.Format("_{0}_{1}_{2}_{3}_{4}",
+                        dateTime.Value.Day, dateTime.Value.Month, dateTime.Value.Year,
+                        dateTime.Value.Hour, dateTime.Value.Minute) : "";
+
+                    string filenameCopy = Path.GetFileNameWithoutExtension(filename) +
+                        timeStamp + Path.GetExtension(filename);
+
+                    File.Copy(ProgramConstants.GamePath + filename, directory + "/" + filenameCopy);
+                    copied = true;
                 }
+            }
+            catch (Exception ex)
+            {
+                Logger.Log("An error occured while checking for " + filename + " file. Message: " + ex.Message);
+            }
+            return copied;
+        }
 
+        /// <summary>
+        /// Attempts to copy sync error logs from game directory to another directory.
+        /// </summary>
+        /// <param name="directory">Directory to copy sync error logs to.</param>
+        /// <param name="dateTime">Time to to apply as a timestamp to filename. Set to null to not apply a timestamp.</param>
+        /// <returns>True if any sync logs were copied, false otherwise.</returns>
+        private bool CopySyncErrorLogs(string directory, DateTime? dateTime)
+        {
+            bool copied = false;
+
+            try
+            {
                 for (int i = 0; i < 8; i++)
                 {
-                    string syncFileName = "SYNC" + i + ".TXT";
+                    string filename = "SYNC" + i + ".TXT";
 
-                    if (File.Exists(ProgramConstants.GamePath + syncFileName))
+                    if (File.Exists(ProgramConstants.GamePath + filename))
                     {
-                        Logger.Log("There was a sync error! Copying file " + syncFileName);
+                        if (!Directory.Exists(directory))
+                            Directory.CreateDirectory(directory);
 
-                        File.Copy(ProgramConstants.GamePath + syncFileName,
-                            string.Format(ProgramConstants.GamePath + "Client/ErrorLogs/" + syncFileName + "_{0}_{1}_{2}_{3}_{4}.TXT",
-                            dtn.Day, dtn.Month, dtn.Year, dtn.Hour, dtn.Minute));
-                        File.Delete(ProgramConstants.GamePath + syncFileName);
+                        Logger.Log("There was a sync error! Copying file " + filename);
+
+                        string timeStamp = dateTime.HasValue ? string.Format("_{0}_{1}_{2}_{3}_{4}",
+                            dateTime.Value.Day, dateTime.Value.Month, dateTime.Value.Year,
+                            dateTime.Value.Hour, dateTime.Value.Minute) : "";
+
+                        string filenameCopy = Path.GetFileNameWithoutExtension(filename) +
+                            timeStamp + Path.GetExtension(filename);
+
+                        File.Copy(ProgramConstants.GamePath + filename, directory + "/" + filenameCopy);
+                        copied = true;
+                        File.Delete(ProgramConstants.GamePath + filename);
                     }
                 }
             }
             catch (Exception ex)
             {
-                Logger.Log("An error occured while checking for EXCEPT.TXT and SYNCX.TXT files. Message: " + ex.Message);
+                Logger.Log("An error occured while checking for SYNCX.TXT files. Message: " + ex.Message);
             }
+            return copied;
         }
 
 #if ARES
+        /// <summary>
+        /// Returns the first debug snapshot directory found in Ares debug log directory that was created after last game launch and isn't empty.
+        /// Additionally any empty snapshot directories encountered are deleted.
+        /// </summary>
+        /// <returns>Full path of the debug snapshot directory. If one isn't found, null is returned.</returns>
+        private string GetNewestDebugSnapshotDirectory()
+        {
+            string snapshotDirectory = null;
+
+            if (debugSnapshotDirectories != null)
+            {
+                var newDirectories = GetAllDebugSnapshotDirectories().Except(debugSnapshotDirectories);
+
+                foreach (string directory in newDirectories)
+                {
+                    if (Directory.EnumerateFileSystemEntries(directory).Any())
+                        snapshotDirectory = directory;
+                    else
+                    {
+                        try
+                        {
+                            Directory.Delete(directory);
+                        }
+                        catch { }
+                    }
+                }
+            }
+
+            return snapshotDirectory;
+        }
+
+        /// <summary>
+        /// Returns list of all debug snapshot directories in Ares debug logs directory.
+        /// </summary>
+        /// <returns>List of all debug snapshot directories in Ares debug logs directory. Empty list if none are found or an error was encountered.</returns>
+        private List<string> GetAllDebugSnapshotDirectories()
+        {
+            List<string> directories = new List<string>();
+
+            try
+            {
+                directories.AddRange(Directory.GetDirectories(ProgramConstants.GamePath + "debug", "snapshot-*"));
+            }
+            catch { }
+
+            return directories;
+        }
+
         /// <summary>
         /// Converts BMP screenshots to PNG and copies them from game directory to Screenshots sub-directory.
         /// </summary>

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -3,7 +3,6 @@ using ClientCore.Statistics;
 using ClientGUI;
 using DTAClient.Domain;
 using DTAClient.Domain.Multiplayer;
-using DTAClient.Domain.Multiplayer.CnCNet;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Rampastring.Tools;
@@ -13,7 +12,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading;
 
 
 namespace DTAClient.DXGUI.Multiplayer.GameLobby
@@ -1462,29 +1460,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             CopyPlayerDataToUI();
 
-            if (ClientConfiguration.Instance.ProcessScreenshots)
-            {
-                Logger.Log("GameProcessExited: Processing screenshots.");
-                Thread thread = new Thread(ProcessScreenshots);
-                thread.Start();
-            }
-
             UpdateDiscordPresence(true);
-        }
-
-        private void ProcessScreenshots()
-        {
-            string[] filenames = Directory.GetFiles(ProgramConstants.GamePath, "SCRN*.bmp");
-            string screenshotsDirectory = ProgramConstants.GamePath + "Screenshots";
-            foreach (string filename in filenames)
-            {
-                Directory.CreateDirectory(screenshotsDirectory);
-                System.Drawing.Bitmap bitmap = new System.Drawing.Bitmap(filename);
-                bitmap.Save(screenshotsDirectory + Path.DirectorySeparatorChar + Path.GetFileNameWithoutExtension(filename) + 
-                    ".png", System.Drawing.Imaging.ImageFormat.Png);
-                bitmap.Dispose();
-                File.Delete(filename);
-            }
         }
 
         /// <summary>

--- a/DXMainClient/PreStartup.cs
+++ b/DXMainClient/PreStartup.cs
@@ -5,7 +5,6 @@ using System.IO;
 using DTAClient.Domain;
 using Rampastring.Tools;
 using ClientCore;
-using Rampastring.XNAUI;
 using System.Security.AccessControl;
 using System.Security.Principal;
 using System.Collections.Generic;
@@ -48,13 +47,13 @@ namespace DTAClient
 
             CheckPermissions();
 
-            Logger.Initialize(ProgramConstants.GamePath + "Client/", "client.log");
+            Logger.Initialize(ProgramConstants.ClientUserFilesPath, "client.log");
             Logger.WriteLogFile = true;
 
-            if (!Directory.Exists(ProgramConstants.GamePath + "Client"))
-                Directory.CreateDirectory(ProgramConstants.GamePath + "Client");
+            if (!Directory.Exists(ProgramConstants.ClientUserFilesPath))
+                Directory.CreateDirectory(ProgramConstants.ClientUserFilesPath);
 
-            File.Delete(ProgramConstants.GamePath + "Client/client.log");
+            File.Delete(ProgramConstants.ClientUserFilesPath + "client.log");
 
             MainClientConstants.Initialize();
 
@@ -113,15 +112,14 @@ namespace DTAClient
                 Logger.Log("Stacktrace: " + ex.InnerException.StackTrace);
             }
 
-            DateTime dtn = DateTime.Now;
-            string errorLogPath = Environment.CurrentDirectory.Replace("\\", "/") + string.Format("/Client/ErrorLogs/ClientCrashLog_{0}_{1}_{2}_{3}_{4}.txt",
-                dtn.Day, dtn.Month, dtn.Year, dtn.Hour, dtn.Minute);
+            string errorLogPath = Environment.CurrentDirectory.Replace("\\", "/") + "/Client/ClientCrashLogs/ClientCrashLog" +
+                DateTime.Now.ToString("_yyyy_MM_dd_HH_mm") + ".txt";
             bool crashLogCopied = false;
 
             try
             {
-                if (!Directory.Exists(Environment.CurrentDirectory + "/Client/ErrorLogs"))
-                    Directory.CreateDirectory(Environment.CurrentDirectory + "/Client/ErrorLogs");
+                if (!Directory.Exists(Environment.CurrentDirectory + "/Client/ClientCrashLogs"))
+                    Directory.CreateDirectory(Environment.CurrentDirectory + "/Client/ClientCrashLogs");
 
                 File.Copy(Environment.CurrentDirectory + "/Client/client.log", errorLogPath, true);
                 crashLogCopied = true;


### PR DESCRIPTION
All functionality changes below only apply to `AresRelease` and `AresDebug` configurations. Sole exception is that the graphics mode reset hack in `GameInProgressWindow.HandleGameProcessExited` was moved so that the code executes before there's any chance for the method to exit. Previously if deleting the log files on game startup failed for any reason, this reset hack wouldn't be applied on game exit, which didn't seem like intended behaviour.

- Client will now prune Ares debug log files & directories on startup. Any files that were created at least 7 days ago will be deleted and any directories that are empty after deleting files are also removed. The time threshold could be made customizable if a good enough reason to allow it comes up, but I could not think of any.
- Moved `ProcessScreenshots` method from `GameLobbyBase` to `GameInProgressWindow` for consistency as that is where all existing file system operations on game start / exit are performed.
- Deprecated `ProcessScreenshots` setting, as there is practically never a genuine need to turn this feature off.
- Instead of copying any `except.txt` and `SYNC*.txt` files from game directory to `Client\ErrorLogs` on game exit like for other configurations, client will now do the following (ideally these would be handled by Ares itself, but until that happens this is the next best thing):
  - Copies `syringe.log` from game directory to a snapshot directory in `debug` directory on crash & desync.
  - Copies `SYNC*.txt` files from game directory to a snapshot directory in `debug` directory on a desync.
  - In case of a desync occurs and game does not create the snapshot directory (happens if player denies creating a full crash dump), client will create it.
  - If `debug.log` was written to during the game, a snapshot directory was created by either game or client (a crash / desync occured) and `debug.log` wasn't copied to the snapshot directory by game, client will copy it over.