### PR TITLE
Add support for drawing extra textures on the map preview

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
@@ -15,6 +15,18 @@ using System.Linq;
 
 namespace DTAClient.DXGUI.Multiplayer.GameLobby
 {
+    struct ExtraMapPreviewTexture
+    {
+        public Texture2D Texture;
+        public Point Point;
+
+        public ExtraMapPreviewTexture(Texture2D texture, Point point)
+        {
+            Texture = texture;
+            Point = point;
+        }
+    }
+
     /// <summary>
     /// The picture box for displaying the map preview.
     /// </summary>
@@ -81,7 +93,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
         private Rectangle textureRectangle;
 
-        private Texture2D texture;
+        private Texture2D previewTexture;
 
         private bool disposeTextures = true;
 
@@ -92,6 +104,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         private EnhancedSoundEffect sndClickSound;
 
         private EnhancedSoundEffect sndDropdownSound;
+
+        private List<ExtraMapPreviewTexture> extraTextures = new List<ExtraMapPreviewTexture>(0);
 
         public override void Initialize()
         {
@@ -282,12 +296,14 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         /// </summary>
         private void UpdateMap()
         {
-            if (disposeTextures && texture != null && !texture.IsDisposed)
-                texture.Dispose();
+            if (disposeTextures && previewTexture != null && !previewTexture.IsDisposed)
+                previewTexture.Dispose();
+
+            extraTextures.Clear();
 
             if (Map == null)
             {
-                texture = null;
+                previewTexture = null;
                 briefingBox.Disable();
 
                 contextMenu.Disable();
@@ -300,12 +316,12 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             if (Map.PreviewTexture == null)
             {
-                texture = Map.LoadPreviewTexture();
+                previewTexture = Map.LoadPreviewTexture();
                 disposeTextures = true;
             }
             else
             {
-                texture = Map.PreviewTexture;
+                previewTexture = Map.PreviewTexture;
                 disposeTextures = false;
             }
 
@@ -319,8 +335,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             else
                 briefingBox.Disable();
 
-            double xRatio = (Width - 2) / (double)texture.Width;
-            double yRatio = (Height - 2) / (double)texture.Height;
+            double xRatio = (Width - 2) / (double)previewTexture.Width;
+            double yRatio = (Height - 2) / (double)previewTexture.Height;
 
             double ratio;
 
@@ -333,14 +349,14 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             {
                 ratio = yRatio;
                 textureHeight = Height - 2;
-                textureWidth = (int)(texture.Width * ratio);
+                textureWidth = (int)(previewTexture.Width * ratio);
                 texturePositionX = (int)(Width - 2 - textureWidth) / 2;
             }
             else
             {
                 ratio = xRatio;
                 textureWidth = Width - 2;
-                textureHeight = (int)(texture.Height * ratio);
+                textureHeight = (int)(previewTexture.Height * ratio);
                 texturePositionY = (Height - 2 - textureHeight) / 2 + 1;
             }
 
@@ -349,7 +365,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             textureRectangle = new Rectangle(texturePositionX, texturePositionY,
                 textureWidth, textureHeight);
 
-            List<Point> startingLocations = Map.GetStartingLocationPreviewCoords(new Point(texture.Width, texture.Height));
+            List<Point> startingLocations = Map.GetStartingLocationPreviewCoords(new Point(previewTexture.Width, previewTexture.Height));
 
             for (int i = 0; i < startingLocations.Count && i < Map.MaxPlayers; i++)
             {
@@ -368,6 +384,27 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             {
                 startingLocationIndicators[i].Disable();
             }
+
+
+            foreach (var mapExtraTexture in Map.GetExtraMapPreviewTextures())
+            {
+                // LoadTexture makes use of a texture cache 
+                // so we don't need to cache the textures manually
+                Texture2D extraTexture = AssetLoader.LoadTexture(mapExtraTexture.TextureName);
+                Point location = PreviewTexturePointToControlAreaPoint(
+                    Map.MapPointToMapPreviewPoint(mapExtraTexture.Point,
+                    new Point(previewTexture.Width - (extraTexture.Width / 2),
+                              previewTexture.Height - (extraTexture.Height / 2))),
+                              ratio);
+
+                extraTextures.Add(new ExtraMapPreviewTexture(extraTexture, location));
+            }
+        }
+
+        private Point PreviewTexturePointToControlAreaPoint(Point previewTexturePoint, double scaleRatio)
+        {
+            return new Point(textureRectangle.X + (int)(previewTexturePoint.X * scaleRatio),
+                textureRectangle.Y + (int)(previewTexturePoint.Y * scaleRatio));
         }
 
         public void UpdateStartingLocationTexts()
@@ -469,19 +506,27 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         {
             DrawPanel();
 
-            if (texture != null)
+            if (previewTexture != null)
             {
                 Point renderPoint = GetRenderPoint();
 
                 if (useNearestNeighbour)
                 {
                     Renderer.PushSettings(new SpriteBatchSettings(SpriteSortMode.Deferred, null, SamplerState.PointClamp));
-                    DrawPreviewTexture();
+                    DrawPreviewTexture(renderPoint);
                     Renderer.PopSettings();
                 }
                 else
                 {
-                    DrawPreviewTexture();
+                    DrawPreviewTexture(renderPoint);
+                }
+
+                foreach (var extraTexture in extraTextures)
+                {
+                    Renderer.DrawTexture(extraTexture.Texture,
+                        new Rectangle(renderPoint.X + extraTexture.Point.X,
+                        renderPoint.Y + extraTexture.Point.Y,
+                        extraTexture.Texture.Width, extraTexture.Texture.Height), Color.White);
                 }
             }
 
@@ -491,10 +536,9 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             DrawChildren(gameTime);
         }
 
-        private void DrawPreviewTexture()
+        private void DrawPreviewTexture(Point renderPoint)
         {
-            Point renderPoint = GetRenderPoint();
-            Renderer.DrawTexture(texture,
+            Renderer.DrawTexture(previewTexture,
                 new Rectangle(renderPoint.X + textureRectangle.X,
                 renderPoint.Y + textureRectangle.Y,
                 textureRectangle.Width, textureRectangle.Height),


### PR DESCRIPTION
Adds support for drawing extra textures on the map preview. Example:

![Image](https://cdn.discordapp.com/attachments/545021483295047680/764882656869220382/unknown.png?raw=true "CnCNet Game Lobby")

Works by adding one or more of the following entries under a map's section in MPMaps.ini:

`ExtraTextureN=texture_file_name.png,x_coord,y_coord`

The x_coord and y_coord point to tiles on the map and can be taken directly from FinalSun.

For example, for the result in the image we added an `oilrefn.png` texture to the `Resources` directory in DTA and added this code to the map's section in MPMaps.ini:

```ini
ExtraTexture0=oilrefn.png,93,111
ExtraTexture1=oilrefn.png,113,144
ExtraTexture2=oilrefn.png,168,150
ExtraTexture3=oilrefn.png,150,117
ExtraTexture4=oilrefn.png,157,180
ExtraTexture5=oilrefn.png,134,222
ExtraTexture6=oilrefn.png,97,195
ExtraTexture7=oilrefn.png,104,82
ExtraTexture8=oilrefn.png,113,46
ExtraTexture9=oilrefn.png,150,44
ExtraTexture10=oilrefn.png,246,136
ExtraTexture11=oilrefn.png,26,114
```