### PR TITLE
Implement interfering files detection

### DIFF
--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -280,6 +280,11 @@ namespace ClientCore
         /// </summary>
         public string[] RequiredFiles => clientDefinitionsIni.GetStringValue(SETTINGS, "RequiredFiles", String.Empty).Split(',');
 
+        /// <summary>
+        /// List of files that can interfere with the mod functioning.
+        /// </summary>
+        public string[] ForbiddenFiles => clientDefinitionsIni.GetStringValue(SETTINGS, "ForbiddenFiles", String.Empty).Split(',');
+
         #endregion
 
         public OSVersion GetOperatingSystemVersion()

--- a/DXMainClient/DXGUI/Generic/MainMenu.cs
+++ b/DXMainClient/DXGUI/Generic/MainMenu.cs
@@ -409,6 +409,30 @@ namespace DTAClient.DXGUI.Generic
                     "You won't be able to play without those files.");
         }
 
+        private void CheckForbiddenFiles()
+        {
+            List<string> presentFiles = ClientConfiguration.Instance.ForbiddenFiles.ToList()
+                .FindAll(f => !string.IsNullOrWhiteSpace(f) && File.Exists(ProgramConstants.GamePath + f));
+
+            if (presentFiles.Count > 0)
+                XNAMessageBox.Show(WindowManager, "Interfering Files Detected",
+#if TS
+                    "You have installed the mod on top of a Tiberian Sun" + Environment.NewLine +
+                    "copy! This mod is standalone, therefore you have to" + Environment.NewLine +
+                    "install it in an empty folder. Otherwise the mod won't" + Environment.NewLine +
+                    "function correctly." +
+                    Environment.NewLine + Environment.NewLine +
+                    "Please reinstall the mod into an empty folder to play."
+#else
+                    "The following interfering files are present:" +
+                    Environment.NewLine + Environment.NewLine +
+                    String.Join(Environment.NewLine, presentFiles) +
+                    Environment.NewLine + Environment.NewLine +
+                    "The mod won't work correctly without those files removed."
+#endif
+                    );
+        }
+
         /// <summary>
         /// Checks whether the client is running for the first time.
         /// If it is, displays a dialog asking the user if they'd like
@@ -508,6 +532,7 @@ namespace DTAClient.DXGUI.Generic
             }
 
             CheckRequiredFiles();
+            CheckForbiddenFiles();
             CheckIfFirstRun();
         }
 


### PR DESCRIPTION
The new INI key
```ini
ForbiddenFiles=file1.txt,path/to/file2.txt,...
```
defined under `[Settings]` section of `ClientDefinitions.ini` can now be used to list files that are interfering with the mods functionality and should be removed. Any of those files would be mentioned in the message if they are present.
![image](https://user-images.githubusercontent.com/17500545/95690050-aa8ec400-0c1d-11eb-91ba-962d4692d018.png)

For TS build there is a custom message implemented that explains what the standalone mod is and that the user needs to install it in an empty folder, not on top of TS (because for some reason not all users read the installation instructions).
![image](https://user-images.githubusercontent.com/17500545/95689985-4e2ba480-0c1d-11eb-8909-d81c95c22b70.png)

Closes #193.