### PR TITLE
Reimplement InternalSideIndices and SpectatorInternalSideIndex GameOptions.ini keys

### DIFF
--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -140,7 +140,11 @@ namespace ClientCore
 
         #region Game options
 
-        public string Sides => gameOptions_ini.GetStringValue(GENERAL, "Sides", "GDI,Nod,Allies,Soviet");
+        public string Sides => gameOptions_ini.GetStringValue(GENERAL, nameof(Sides), "GDI,Nod,Allies,Soviet");
+        
+        public string InternalSideIndices => gameOptions_ini.GetStringValue(GENERAL, nameof(InternalSideIndices), string.Empty);
+
+        public string SpectatorInternalSideIndex => gameOptions_ini.GetStringValue(GENERAL, nameof(SpectatorInternalSideIndex), string.Empty);
 
         #endregion
 

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -1076,10 +1076,10 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             settings.SetStringValue("UIMapName", Map.Name);
             settings.SetIntValue("PlayerCount", Players.Count);
             int myIndex = Players.FindIndex(c => c.Name == ProgramConstants.PLAYERNAME);
-            settings.SetIntValue("Side", houseInfos[myIndex].SideIndex);
+            settings.SetIntValue("Side", houseInfos[myIndex].InternalSideIndex);
             settings.SetBooleanValue("IsSpectator", houseInfos[myIndex].IsSpectator);
             settings.SetIntValue("Color", houseInfos[myIndex].ColorIndex);
-            settings.SetStringValue("CustomLoadScreen", LoadingScreenController.GetLoadScreenName(houseInfos[myIndex].SideIndex));
+            settings.SetStringValue("CustomLoadScreen", LoadingScreenController.GetLoadScreenName(houseInfos[myIndex].InternalSideIndex));
             settings.SetIntValue("AIPlayers", AIPlayers.Count);
             settings.SetIntValue("Seed", RandomSeed);
             if (GetPvPTeamCount() > 1)
@@ -1127,7 +1127,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 string sectionName = "Other" + otherId;
 
                 spawnIni.SetStringValue(sectionName, "Name", pInfo.Name);
-                spawnIni.SetIntValue(sectionName, "Side", pHouseInfo.SideIndex);
+                spawnIni.SetIntValue(sectionName, "Side", pHouseInfo.InternalSideIndex);
                 spawnIni.SetBooleanValue(sectionName, "IsSpectator", pHouseInfo.IsSpectator);
                 spawnIni.SetIntValue(sectionName, "Color", pHouseInfo.ColorIndex);
                 spawnIni.SetStringValue(sectionName, "Ip", GetIPAddressForPlayer(pInfo));
@@ -1156,7 +1156,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                     string keyName = "Multi" + multiId;
 
                     spawnIni.SetIntValue("HouseHandicaps", keyName, AIPlayers[aiId].AILevel);
-                    spawnIni.SetIntValue("HouseCountries", keyName, houseInfos[Players.Count + aiId].SideIndex);
+                    spawnIni.SetIntValue("HouseCountries", keyName, houseInfos[Players.Count + aiId].InternalSideIndex);
                     spawnIni.SetIntValue("HouseColors", keyName, houseInfos[Players.Count + aiId].ColorIndex);
                 }
             }

--- a/DXMainClient/Domain/Multiplayer/PlayerHouseInfo.cs
+++ b/DXMainClient/Domain/Multiplayer/PlayerHouseInfo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using ClientCore;
 
@@ -7,6 +7,24 @@ namespace DTAClient.Domain.Multiplayer
     public class PlayerHouseInfo
     {
         public int SideIndex { get; set; }
+
+        /// <summary>
+        /// A side (or, more correctly, house or country depending on the game)
+        /// index that is used in rules file of the game.
+        /// </summary>
+        public int InternalSideIndex
+        {
+            get
+            {
+                if (IsSpectator && !string.IsNullOrEmpty(ClientConfiguration.Instance.SpectatorInternalSideIndex))
+                    return int.Parse(ClientConfiguration.Instance.SpectatorInternalSideIndex);
+                
+                if (!string.IsNullOrEmpty(ClientConfiguration.Instance.InternalSideIndices))
+                    return Array.ConvertAll(ClientConfiguration.Instance.InternalSideIndices.Split(','), int.Parse)[SideIndex];
+
+                return SideIndex;
+            }
+        }
         public int ColorIndex { get; set; }
         public int StartingWaypoint { get; set; }
 


### PR DESCRIPTION
`InternalSideIndices` (in `GameOptions.ini`, `[General]` section) is used to override default side IDs with the ones defined in lookup string. It's also now possible to override the side for spectator (and thus supply custom music, sidebar etc.) via explicitly specifying random side index via `SpectatorInternalSideIndex`, for example:

```ini
Sides=USA,United Kingdom,France...
InternalSideIds=0,4,2,...
SpectatorInternalSideId=16
```