### PR TITLE
Improvements to TunnelSelectionWindow & GameCreationWindow

### DIFF
--- a/ClientGUI/UIDesignConstants.cs
+++ b/ClientGUI/UIDesignConstants.cs
@@ -20,5 +20,6 @@ namespace ClientGUI
 
         public const int BUTTON_HEIGHT = 23;
         public const int BUTTON_WIDTH_92 = 92;
+        public const int BUTTON_WIDTH_133 = 133;
     }
 }

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetGameLoadingLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetGameLoadingLobby.cs
@@ -115,6 +115,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             DarkeningPanel.AddAndInitializeWithControl(WindowManager, tunnelSelectionWindow);
             tunnelSelectionWindow.CenterOnParent();
             tunnelSelectionWindow.Disable();
+            tunnelSelectionWindow.TunnelSelected += TunnelSelectionWindow_TunnelSelected;
 
             btnChangeTunnel = new XNAClientButton(WindowManager);
             btnChangeTunnel.Name = nameof(btnChangeTunnel);
@@ -375,12 +376,10 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
         {
             tunnelSelectionWindow.Open(description,
                 tunnelHandler.CurrentTunnel?.Address);
-            tunnelSelectionWindow.TunnelSelected += TunnelSelectionWindow_TunnelSelected;
         }
 
         private void TunnelSelectionWindow_TunnelSelected(object sender, TunnelEventArgs e)
         {
-            tunnelSelectionWindow.TunnelSelected -= TunnelSelectionWindow_TunnelSelected;
             channel.SendCTCPMessage($"{CHANGE_TUNNEL_SERVER_MESSAGE} {e.Tunnel.Address}:{e.Tunnel.Port}",
                 QueuedMessageType.SYSTEM_MESSAGE, 10);
             HandleTunnelServerChange(e.Tunnel);

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/GameCreationWindow.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/GameCreationWindow.cs
@@ -29,101 +29,130 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
         private XNATextBox tbGameName;
         private XNAClientDropDown ddMaxPlayers;
         private XNATextBox tbPassword;
-        
+
         private XNALabel lblRoomName;
         private XNALabel lblMaxPlayers;
         private XNALabel lblPassword;
-        
+
         private XNALabel lblTunnelServer;
         private TunnelListBox lbTunnelList;
-        
+
         private XNAClientButton btnCreateGame;
         private XNAClientButton btnCancel;
         private XNAClientButton btnLoadMPGame;
         private XNAClientButton btnDisplayAdvancedOptions;
-        
+
         private TunnelHandler tunnelHandler;
 
         public override void Initialize()
         {
+            lbTunnelList = new TunnelListBox(WindowManager, tunnelHandler);
+            lbTunnelList.Name = nameof(lbTunnelList);
+
             Name = "GameCreationWindow";
-            ClientRectangle = new Rectangle(0, 0, 490, 188);
+            Width = lbTunnelList.Width + UIDesignConstants.EMPTY_SPACE_SIDES * 2 +
+                UIDesignConstants.CONTROL_HORIZONTAL_MARGIN * 2;
             BackgroundTexture = AssetLoader.LoadTexture("gamecreationoptionsbg.png");
 
-            btnCreateGame = new XNAClientButton(WindowManager);
-            btnCreateGame.ClientRectangle = new Rectangle(12, 159, 133, 23);
-            btnCreateGame.Text = "Create Game";
-            btnCreateGame.LeftClick += BtnCreateGame_LeftClick;
-
-            btnCancel = new XNAClientButton(WindowManager);
-            btnCancel.ClientRectangle = new Rectangle(345, btnCreateGame.Y, 133, 23);
-            btnCancel.Text = "Cancel";
-            btnCancel.LeftClick += BtnCancel_LeftClick;
-
-            btnLoadMPGame = new XNAClientButton(WindowManager);
-            btnLoadMPGame.ClientRectangle = new Rectangle(178, btnCreateGame.Y, 133, 23);
-            btnLoadMPGame.Text = "Load Game";
-            btnLoadMPGame.LeftClick += BtnLoadMPGame_LeftClick;
-
-            btnDisplayAdvancedOptions = new XNAClientButton(WindowManager);
-            btnDisplayAdvancedOptions.ClientRectangle = new Rectangle(12, 124, 160, 23);
-            btnDisplayAdvancedOptions.Text = "Advanced Options";
-            btnDisplayAdvancedOptions.LeftClick += BtnDisplayAdvancedOptions_LeftClick;
-
             tbGameName = new XNATextBox(WindowManager);
+            tbGameName.Name = nameof(tbGameName);
             tbGameName.MaximumTextLength = 23;
-            tbGameName.ClientRectangle = new Rectangle(Width - 162, 12, 150, 21);
+            tbGameName.ClientRectangle = new Rectangle(Width - 150 - UIDesignConstants.EMPTY_SPACE_SIDES -
+                UIDesignConstants.CONTROL_HORIZONTAL_MARGIN, UIDesignConstants.EMPTY_SPACE_TOP +
+                UIDesignConstants.CONTROL_VERTICAL_MARGIN, 150, 21);
             tbGameName.Text = ProgramConstants.PLAYERNAME + "'s Game";
 
             lblRoomName = new XNALabel(WindowManager);
-            lblRoomName.ClientRectangle = new Rectangle(12, tbGameName.Y + 1, 0, 0);
+            lblRoomName.Name = nameof(lblRoomName);
+            lblRoomName.ClientRectangle = new Rectangle(UIDesignConstants.EMPTY_SPACE_SIDES +
+                UIDesignConstants.CONTROL_HORIZONTAL_MARGIN, tbGameName.Y + 1, 0, 0);
             lblRoomName.Text = "Game room name:";
 
             ddMaxPlayers = new XNAClientDropDown(WindowManager);
-            ddMaxPlayers.ClientRectangle = new Rectangle(tbGameName.X, 53, 
+            ddMaxPlayers.Name = nameof(ddMaxPlayers);
+            ddMaxPlayers.ClientRectangle = new Rectangle(tbGameName.X, tbGameName.Bottom + 20,
                 tbGameName.Width, 21);
             for (int i = 8; i > 1; i--)
                 ddMaxPlayers.AddItem(i.ToString());
             ddMaxPlayers.SelectedIndex = 0;
 
             lblMaxPlayers = new XNALabel(WindowManager);
-            lblMaxPlayers.ClientRectangle = new Rectangle(12, ddMaxPlayers.Y + 1, 0, 0);
+            lblMaxPlayers.Name = nameof(lblMaxPlayers);
+            lblMaxPlayers.ClientRectangle = new Rectangle(UIDesignConstants.EMPTY_SPACE_SIDES +
+                UIDesignConstants.CONTROL_HORIZONTAL_MARGIN, ddMaxPlayers.Y + 1, 0, 0);
             lblMaxPlayers.Text = "Maximum number of players:";
 
             tbPassword = new XNATextBox(WindowManager);
+            tbPassword.Name = nameof(tbPassword);
             tbPassword.MaximumTextLength = 20;
-            tbPassword.ClientRectangle = new Rectangle(tbGameName.X, 94, 
+            tbPassword.ClientRectangle = new Rectangle(tbGameName.X, ddMaxPlayers.Bottom + 20,
                 tbGameName.Width, 21);
 
             lblPassword = new XNALabel(WindowManager);
-            lblPassword.ClientRectangle = new Rectangle(12, tbPassword.Y + 1, 0, 0);
+            lblPassword.Name = nameof(lblPassword);
+            lblPassword.ClientRectangle = new Rectangle(UIDesignConstants.EMPTY_SPACE_SIDES +
+                UIDesignConstants.CONTROL_HORIZONTAL_MARGIN, tbPassword.Y + 1, 0, 0);
             lblPassword.Text = "Password (leave blank for none):";
 
+            btnDisplayAdvancedOptions = new XNAClientButton(WindowManager);
+            btnDisplayAdvancedOptions.Name = nameof(btnDisplayAdvancedOptions);
+            btnDisplayAdvancedOptions.ClientRectangle = new Rectangle(UIDesignConstants.EMPTY_SPACE_SIDES +
+                UIDesignConstants.CONTROL_HORIZONTAL_MARGIN, lblPassword.Bottom + UIDesignConstants.CONTROL_VERTICAL_MARGIN * 3, 160, 23);
+            btnDisplayAdvancedOptions.Text = "Advanced Options";
+            btnDisplayAdvancedOptions.LeftClick += BtnDisplayAdvancedOptions_LeftClick;
+
             lblTunnelServer = new XNALabel(WindowManager);
-            lblTunnelServer.ClientRectangle = new Rectangle(12, 134, 0, 0);
+            lblTunnelServer.Name = nameof(lblTunnelServer);
+            lblTunnelServer.ClientRectangle = new Rectangle(UIDesignConstants.EMPTY_SPACE_SIDES +
+                UIDesignConstants.CONTROL_HORIZONTAL_MARGIN, lblPassword.Bottom + UIDesignConstants.CONTROL_VERTICAL_MARGIN * 4, 0, 0);
             lblTunnelServer.Text = "Tunnel server:";
             lblTunnelServer.Enabled = false;
             lblTunnelServer.Visible = false;
 
-            lbTunnelList = new TunnelListBox(WindowManager, tunnelHandler);
-            lbTunnelList.X = 12;
-            lbTunnelList.Y = 154;
+            lbTunnelList.X = UIDesignConstants.EMPTY_SPACE_SIDES +
+                UIDesignConstants.CONTROL_HORIZONTAL_MARGIN;
+            lbTunnelList.Y = lblTunnelServer.Bottom + UIDesignConstants.CONTROL_VERTICAL_MARGIN;
             lbTunnelList.Disable();
             lbTunnelList.ListRefreshed += LbTunnelList_ListRefreshed;
 
-            AddChild(btnCreateGame);
-            AddChild(btnCancel);
-            if (!ClientConfiguration.Instance.DisableMultiplayerGameLoading)
-                AddChild(btnLoadMPGame);
-            AddChild(btnDisplayAdvancedOptions);
+            btnCreateGame = new XNAClientButton(WindowManager);
+            btnCreateGame.Name = nameof(btnCreateGame);
+            btnCreateGame.ClientRectangle = new Rectangle(UIDesignConstants.EMPTY_SPACE_SIDES +
+                UIDesignConstants.CONTROL_HORIZONTAL_MARGIN, btnDisplayAdvancedOptions.Bottom + UIDesignConstants.CONTROL_VERTICAL_MARGIN * 3,
+                UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
+            btnCreateGame.Text = "Create Game";
+            btnCreateGame.LeftClick += BtnCreateGame_LeftClick;
+
+            btnCancel = new XNAClientButton(WindowManager);
+            btnCancel.Name = nameof(btnCancel);
+            btnCancel.ClientRectangle = new Rectangle(Width - UIDesignConstants.BUTTON_WIDTH_133 - UIDesignConstants.EMPTY_SPACE_SIDES -
+                UIDesignConstants.CONTROL_HORIZONTAL_MARGIN, btnCreateGame.Y, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
+            btnCancel.Text = "Cancel";
+            btnCancel.LeftClick += BtnCancel_LeftClick;
+
+            int btnLoadMPGameX = btnCreateGame.Right + (btnCancel.X - btnCreateGame.Right) / 2 - UIDesignConstants.BUTTON_WIDTH_133 / 2;
+
+            btnLoadMPGame = new XNAClientButton(WindowManager);
+            btnLoadMPGame.Name = nameof(btnLoadMPGame);
+            btnLoadMPGame.ClientRectangle = new Rectangle(btnLoadMPGameX, btnCreateGame.Y, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
+            btnLoadMPGame.Text = "Load Game";
+            btnLoadMPGame.LeftClick += BtnLoadMPGame_LeftClick;
+
+            Height = btnCreateGame.Bottom + UIDesignConstants.CONTROL_VERTICAL_MARGIN + UIDesignConstants.EMPTY_SPACE_BOTTOM;
+
             AddChild(tbGameName);
             AddChild(lblRoomName);
+            AddChild(ddMaxPlayers);
             AddChild(lblMaxPlayers);
             AddChild(tbPassword);
             AddChild(lblPassword);
+            AddChild(btnDisplayAdvancedOptions);
             AddChild(lblTunnelServer);
             AddChild(lbTunnelList);
-            AddChild(ddMaxPlayers);
+            AddChild(btnCreateGame);
+            if (!ClientConfiguration.Instance.DisableMultiplayerGameLoading)
+                AddChild(btnLoadMPGame);
+            AddChild(btnCancel);
 
             base.Initialize();
 
@@ -171,7 +200,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 return;
             }
 
-            IniFile spawnSGIni = new IniFile(ProgramConstants.GamePath + 
+            IniFile spawnSGIni = new IniFile(ProgramConstants.GamePath +
                 ProgramConstants.SAVED_GAME_SPAWN_INI);
 
             string password = Utilities.CalculateSHA1ForString(
@@ -195,7 +224,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
             if (new ProfanityFilter().IsOffensive(gameName))
             {
-                XNAMessageBox.Show(WindowManager, "Offensive game name", 
+                XNAMessageBox.Show(WindowManager, "Offensive game name",
                     "Please enter a less offensive game name.");
                 return;
             }
@@ -205,7 +234,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 return;
             }
 
-            GameCreated?.Invoke(this, new GameCreationEventArgs(gameName, 
+            GameCreated?.Invoke(this, new GameCreationEventArgs(gameName,
                 int.Parse(ddMaxPlayers.SelectedItem.Text), tbPassword.Text,
                 tunnelHandler.Tunnels[lbTunnelList.SelectedIndex]));
         }
@@ -214,20 +243,17 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
         {
             Name = "GameCreationWindow_Advanced";
 
-            ClientRectangle = new Rectangle(X, Y,
-                Width, 420);
-
             btnCreateGame.ClientRectangle = new Rectangle(btnCreateGame.X,
-                Height - 29, btnCreateGame.Width,
-                btnCreateGame.Height);
+                lbTunnelList.Bottom + UIDesignConstants.CONTROL_VERTICAL_MARGIN * 3,
+                btnCreateGame.Width, btnCreateGame.Height);
 
             btnCancel.ClientRectangle = new Rectangle(btnCancel.X,
-                Height - 29, btnCancel.Width,
-                btnCancel.Height);
+                btnCreateGame.Y, btnCancel.Width, btnCancel.Height);
 
             btnLoadMPGame.ClientRectangle = new Rectangle(btnLoadMPGame.X,
-                Height - 29, btnLoadMPGame.Width,
-                btnLoadMPGame.Height);
+                btnCreateGame.Y, btnLoadMPGame.Width, btnLoadMPGame.Height);
+
+            Height = btnCreateGame.Bottom + UIDesignConstants.CONTROL_VERTICAL_MARGIN + UIDesignConstants.EMPTY_SPACE_BOTTOM;
 
             lblTunnelServer.Enable();
             lbTunnelList.Enable();
@@ -248,7 +274,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             if (!File.Exists(ProgramConstants.GamePath + ProgramConstants.SAVED_GAME_SPAWN_INI))
                 return false;
 
-            IniFile iniFile = new IniFile(ProgramConstants.GamePath + 
+            IniFile iniFile = new IniFile(ProgramConstants.GamePath +
                 ProgramConstants.SAVED_GAME_SPAWN_INI);
 
             if (iniFile.GetStringValue("Settings", "Name", string.Empty) != ProgramConstants.PLAYERNAME)

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/TunnelListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/TunnelListBox.cs
@@ -25,8 +25,10 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
             SelectedIndexChanged += TunnelListBox_SelectedIndexChanged;
 
+            int headerHeight = (int)Renderer.GetTextDimensions("Name", HeaderFontIndex).Y;
+
             Width = 466;
-            Height = 200;
+            Height = LineHeight * 12 + headerHeight + 3;
             PanelBackgroundDrawMode = PanelBackgroundImageDrawMode.STRETCHED;
             BackgroundTexture = AssetLoader.CreateTexture(new Color(0, 0, 0, 128), 1, 1);
             AddColumn("Name", 230);
@@ -61,6 +63,17 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 isManuallySelectedTunnel = true;
                 manuallySelectedTunnelAddress = address;
             }
+        }
+
+        /// <summary>
+        /// Gets whether or not a tunnel from the list with the given address is selected.
+        /// </summary>
+        /// <param name="address">The address of the tunnel server</param>
+        /// <returns>True if tunnel with given address is selected, otherwise false.</returns>
+        public bool IsTunnelSelected(string address)
+        {
+            int index = tunnelHandler.Tunnels.FindIndex(t => t.Address == address);
+            return index == SelectedIndex;
         }
 
         private void TunnelHandler_TunnelsRefreshed(object sender, EventArgs e)

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/TunnelListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/TunnelListBox.cs
@@ -70,11 +70,8 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
         /// </summary>
         /// <param name="address">The address of the tunnel server</param>
         /// <returns>True if tunnel with given address is selected, otherwise false.</returns>
-        public bool IsTunnelSelected(string address)
-        {
-            int index = tunnelHandler.Tunnels.FindIndex(t => t.Address == address);
-            return index == SelectedIndex;
-        }
+        public bool IsTunnelSelected(string address) =>
+            tunnelHandler.Tunnels.FindIndex(t => t.Address == address) == SelectedIndex;
 
         private void TunnelHandler_TunnelsRefreshed(object sender, EventArgs e)
         {

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/TunnelSelectionWindow.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/TunnelSelectionWindow.cs
@@ -90,15 +90,10 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             TunnelSelected?.Invoke(this, new TunnelEventArgs(tunnel));
         }
 
-        private void BtnCancel_LeftClick(object sender, EventArgs e)
-        {
-            Disable();
-        }
+        private void BtnCancel_LeftClick(object sender, EventArgs e) => Disable();
 
-        private void LbTunnelList_SelectedIndexChanged(object sender, EventArgs e)
-        {
+        private void LbTunnelList_SelectedIndexChanged(object sender, EventArgs e) =>
             btnApply.AllowClick = !lbTunnelList.IsTunnelSelected(originalTunnelAddress) && lbTunnelList.IsValidIndexSelected();
-        }
 
         /// <summary>
         /// Sets the window's description and selects the tunnel server

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/TunnelSelectionWindow.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/TunnelSelectionWindow.cs
@@ -25,6 +25,9 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
         private readonly TunnelHandler tunnelHandler;
         private TunnelListBox lbTunnelList;
         private XNALabel lblDescription;
+        private XNAClientButton btnApply;
+
+        private string originalTunnelAddress;
 
         public override void Initialize()
         {
@@ -37,30 +40,41 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             PanelBackgroundDrawMode = PanelBackgroundImageDrawMode.STRETCHED;
 
             lblDescription = new XNALabel(WindowManager);
-            lblDescription.Name = "lblDescription";
+            lblDescription.Name = nameof(lblDescription);
             lblDescription.Text = "Line 1" + Environment.NewLine + "Line 2";
-            lblDescription.X = UIDesignConstants.EMPTY_SPACE_SIDES;
-            lblDescription.Y = UIDesignConstants.EMPTY_SPACE_TOP;
+            lblDescription.X = UIDesignConstants.EMPTY_SPACE_SIDES + UIDesignConstants.CONTROL_HORIZONTAL_MARGIN;
+            lblDescription.Y = UIDesignConstants.EMPTY_SPACE_TOP + UIDesignConstants.CONTROL_VERTICAL_MARGIN;
             AddChild(lblDescription);
 
             lbTunnelList = new TunnelListBox(WindowManager, tunnelHandler);
-            lbTunnelList.Name = "lbTunnelList";
+            lbTunnelList.Name = nameof(lbTunnelList);
             lbTunnelList.Y = lblDescription.Bottom + UIDesignConstants.CONTROL_VERTICAL_MARGIN;
-            lbTunnelList.X = UIDesignConstants.EMPTY_SPACE_SIDES;
+            lbTunnelList.X = UIDesignConstants.EMPTY_SPACE_SIDES + UIDesignConstants.CONTROL_HORIZONTAL_MARGIN;
             AddChild(lbTunnelList);
+            lbTunnelList.SelectedIndexChanged += LbTunnelList_SelectedIndexChanged;
 
-            var btnApply = new XNAClientButton(WindowManager);
-            btnApply.Name = "btnApply";
+            btnApply = new XNAClientButton(WindowManager);
+            btnApply.Name = nameof(btnApply);
             btnApply.Width = UIDesignConstants.BUTTON_WIDTH_92;
             btnApply.Height = UIDesignConstants.BUTTON_HEIGHT;
             btnApply.Text = "Apply";
-            btnApply.Y = lbTunnelList.Bottom + UIDesignConstants.CONTROL_VERTICAL_MARGIN;
+            btnApply.X = UIDesignConstants.EMPTY_SPACE_SIDES + UIDesignConstants.CONTROL_HORIZONTAL_MARGIN;
+            btnApply.Y = lbTunnelList.Bottom + UIDesignConstants.CONTROL_VERTICAL_MARGIN * 3;
             AddChild(btnApply);
             btnApply.LeftClick += BtnApply_LeftClick;
 
-            Width = lbTunnelList.Right + UIDesignConstants.EMPTY_SPACE_SIDES;
-            Height = btnApply.Bottom + UIDesignConstants.EMPTY_SPACE_BOTTOM;
-            btnApply.CenterOnParentHorizontally();
+            var btnCancel = new XNAClientButton(WindowManager);
+            btnCancel.Name = nameof(btnCancel);
+            btnCancel.Width = UIDesignConstants.BUTTON_WIDTH_92;
+            btnCancel.Height = UIDesignConstants.BUTTON_HEIGHT;
+            btnCancel.Text = "Cancel";
+            btnCancel.Y = btnApply.Y;
+            AddChild(btnCancel);
+            btnCancel.LeftClick += BtnCancel_LeftClick;
+
+            Width = lbTunnelList.Right + UIDesignConstants.CONTROL_HORIZONTAL_MARGIN + UIDesignConstants.EMPTY_SPACE_SIDES;
+            Height = btnApply.Bottom + UIDesignConstants.CONTROL_VERTICAL_MARGIN + UIDesignConstants.EMPTY_SPACE_BOTTOM;
+            btnCancel.X = Width - btnCancel.Width - UIDesignConstants.EMPTY_SPACE_SIDES - UIDesignConstants.CONTROL_HORIZONTAL_MARGIN;
 
             base.Initialize();
         }
@@ -68,11 +82,22 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
         private void BtnApply_LeftClick(object sender, EventArgs e)
         {
             Disable();
+
             if (!lbTunnelList.IsValidIndexSelected())
                 return;
 
             CnCNetTunnel tunnel = tunnelHandler.Tunnels[lbTunnelList.SelectedIndex];
             TunnelSelected?.Invoke(this, new TunnelEventArgs(tunnel));
+        }
+
+        private void BtnCancel_LeftClick(object sender, EventArgs e)
+        {
+            Disable();
+        }
+
+        private void LbTunnelList_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            btnApply.AllowClick = !lbTunnelList.IsTunnelSelected(originalTunnelAddress) && lbTunnelList.IsValidIndexSelected();
         }
 
         /// <summary>
@@ -84,12 +109,22 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
         public void Open(string description, string tunnelAddress = null)
         {
             lblDescription.Text = description;
+            originalTunnelAddress = tunnelAddress;
 
             if (!string.IsNullOrWhiteSpace(tunnelAddress))
                 lbTunnelList.SelectTunnel(tunnelAddress);
             else
                 lbTunnelList.SelectedIndex = -1;
 
+            if (lbTunnelList.SelectedIndex > -1)
+            {
+                lbTunnelList.SetTopIndex(0);
+
+                while (lbTunnelList.SelectedIndex > lbTunnelList.LastIndex)
+                    lbTunnelList.TopIndex++;
+            }
+
+            btnApply.AllowClick = false;
             Enable();
         }
     }

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -161,6 +161,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             DarkeningPanel.AddAndInitializeWithControl(WindowManager, tunnelSelectionWindow);
             tunnelSelectionWindow.CenterOnParent();
             tunnelSelectionWindow.Disable();
+            tunnelSelectionWindow.TunnelSelected += TunnelSelectionWindow_TunnelSelected;
 
             mapSharingConfirmationPanel = new MapSharingConfirmationPanel(WindowManager);
             MapPreviewBox.AddChild(mapSharingConfirmationPanel);
@@ -284,12 +285,10 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         {
             tunnelSelectionWindow.Open(description,
                 tunnelHandler.CurrentTunnel?.Address);
-            tunnelSelectionWindow.TunnelSelected += TunnelSelectionWindow_TunnelSelected;
         }
 
         private void TunnelSelectionWindow_TunnelSelected(object sender, TunnelEventArgs e)
         {
-            tunnelSelectionWindow.TunnelSelected -= TunnelSelectionWindow_TunnelSelected;
             channel.SendCTCPMessage($"{CHANGE_TUNNEL_SERVER_MESSAGE} {e.Tunnel.Address}:{e.Tunnel.Port}",
                 QueuedMessageType.SYSTEM_MESSAGE, 10);
             HandleTunnelServerChange(e.Tunnel);


### PR DESCRIPTION
**TunnelSelectionWindow:**
- Add Cancel button that can be used to exit the window without applying changes.
- Apply button is disabled when currently selected tunnel is the original one.
- Tunnel lists scrolls to the selected tunnel on opening the window.
- Less cramped control spacing.

![tunnelselectionwindow](https://user-images.githubusercontent.com/1392346/100229115-638a3300-2f2c-11eb-8c6a-d654875d1193.png)

**GameCreationWindow:**
- Improve control spacing, especially regarding the buttons & bottom edge of the window.
- Set window width based on width of TunnelListBox and use global constants for control positions & sizes where possible.
- Set window height based on contents.
- Set names for controls to allow adjusting attributes from INI if needed.

![gamecreationwindow](https://user-images.githubusercontent.com/1392346/100229243-9fbd9380-2f2c-11eb-994e-18cb08cc8aaf.png)
![gamecreationwindow_advanced](https://user-images.githubusercontent.com/1392346/100229249-a0eec080-2f2c-11eb-9a0e-8aad4a9cce44.png)


Additionally `TunnelListBox` default height is now set to better match the contents and the way listbox scrolling currently works.

Main reason for changing `GameCreationWindow` here is that if in future one needs to adjust size of `TunnelListBox` for any reason, default size of `GameCreationWindow` and positioning of its child controls will now automatically match afterwards.

Resolves #191 