### PR TITLE
Refine name checking code and Add feature AutoRemoveNonASCIIFromName

### DIFF
--- a/ClientCore/Settings/UserINISettings.cs
+++ b/ClientCore/Settings/UserINISettings.cs
@@ -105,7 +105,8 @@ namespace ClientCore
             PreloadMapPreviews = new BoolSetting(iniFile, VIDEO, "PreloadMapPreviews", false);
             ForceLowestDetailLevel = new BoolSetting(iniFile, VIDEO, "ForceLowestDetailLevel", false);
             MinimizeWindowsOnGameStart = new BoolSetting(iniFile, OPTIONS, "MinimizeWindowsOnGameStart", true);
-            AutoRemoveUnderscoresFromName = new BoolSetting(iniFile, OPTIONS, "AutoRemoveUnderscoresFromName", true);
+            AutoRemoveUnderscoresFromName = new BoolSetting(iniFile, OPTIONS, "AutoRemoveUnderscoresFromName", true); 
+            AutoRemoveNonASCIIFromName = new BoolSetting(iniFile, OPTIONS, "AutoRemoveNonASCIIFromName", true);
         }
 
         public IniFile SettingsIni { get; private set; }
@@ -203,6 +204,8 @@ namespace ClientCore
         public BoolSetting MinimizeWindowsOnGameStart { get; private set; }
 
         public BoolSetting AutoRemoveUnderscoresFromName { get; private set; }
+
+        public BoolSetting AutoRemoveNonASCIIFromName { get; private set; }
 
         public bool IsGameFollowed(string gameName)
         {

--- a/ClientCore/Settings/UserINISettings.cs
+++ b/ClientCore/Settings/UserINISettings.cs
@@ -106,7 +106,7 @@ namespace ClientCore
             ForceLowestDetailLevel = new BoolSetting(iniFile, VIDEO, "ForceLowestDetailLevel", false);
             MinimizeWindowsOnGameStart = new BoolSetting(iniFile, OPTIONS, "MinimizeWindowsOnGameStart", true);
             AutoRemoveUnderscoresFromName = new BoolSetting(iniFile, OPTIONS, "AutoRemoveUnderscoresFromName", true); 
-            AutoRemoveNonASCIIFromName = new BoolSetting(iniFile, OPTIONS, "AutoRemoveNonASCIIFromName", true);
+            AutoRemoveNonASCIIFromName = new BoolSetting(iniFile, OPTIONS, "AutoRemoveNonASCIIFromName", false);
         }
 
         public IniFile SettingsIni { get; private set; }

--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -136,8 +136,7 @@ namespace DTAClient.DXGUI
 
             if (UserINISettings.Instance.AutoRemoveUnderscoresFromName)
             {
-                while (playerName.EndsWith("_"))
-                    playerName = playerName.Substring(0, playerName.Length - 1);
+                playerName = playerName.TrimEnd(new char[] { '_' });
             }
 
             if (String.IsNullOrEmpty(playerName))

--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -124,19 +124,24 @@ namespace DTAClient.DXGUI
             Components.Add(wm);
 
             string playerName = UserINISettings.Instance.PlayerName.Value.Trim();
-            
+
+            if (String.IsNullOrEmpty(playerName))
+                playerName = WindowsIdentity.GetCurrent().Name.Split(new char[] { '\\' }, 2)[1];
+
+            if (UserINISettings.Instance.AutoRemoveNonASCIIFromName)
+            {
+                byte[] playerNameAsciiBytes = System.Text.Encoding.ASCII.GetBytes(playerName);
+                playerName = System.Text.Encoding.ASCII.GetString(playerNameAsciiBytes);
+            }
+
             if (UserINISettings.Instance.AutoRemoveUnderscoresFromName)
             {
                 while (playerName.EndsWith("_"))
                     playerName = playerName.Substring(0, playerName.Length - 1);
             }
 
-            if (string.IsNullOrEmpty(playerName))
-            {
-                playerName = WindowsIdentity.GetCurrent().Name;
-
-                playerName = playerName.Substring(playerName.IndexOf("\\") + 1);
-            }
+            if (String.IsNullOrEmpty(playerName))
+                playerName = "NewPlayer";
 
             playerName = Renderer.GetSafeString(NameValidator.GetValidOfflineName(playerName), 0);
 

--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -125,27 +125,6 @@ namespace DTAClient.DXGUI
             Components.Add(wm);
 
             string playerName = UserINISettings.Instance.PlayerName.Value.Trim();
-
-            if (String.IsNullOrEmpty(playerName))
-                playerName = WindowsIdentity.GetCurrent().Name.Split(new char[] { '\\' }, 2)[1];
-
-            if (UserINISettings.Instance.AutoRemoveNonASCIIFromName)
-            {
-                byte[] playerNameAsciiBytes = System.Text.Encoding.ASCII.GetBytes(playerName);
-                playerName = System.Text.Encoding.ASCII.GetString(playerNameAsciiBytes);
-
-                // remove invisible ASCII characters, e.g. control characters
-                playerName = new string(playerName.ToList().Where(c => c >= 32 && c <= 127).ToArray());
-            }
-
-            if (UserINISettings.Instance.AutoRemoveUnderscoresFromName)
-            {
-                playerName = playerName.TrimEnd(new char[] { '_' });
-            }
-
-            if (String.IsNullOrWhiteSpace(playerName))
-                playerName = "NewPlayer";
-
             playerName = Renderer.GetSafeString(NameValidator.GetValidOfflineName(playerName), 0);
 
             ProgramConstants.PLAYERNAME = playerName;

--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -8,6 +8,7 @@ using Microsoft.Xna.Framework.Graphics;
 using Rampastring.Tools;
 using Rampastring.XNAUI;
 using System;
+using System.Linq;
 using System.Diagnostics;
 using System.IO;
 using System.Security.Principal;
@@ -132,6 +133,9 @@ namespace DTAClient.DXGUI
             {
                 byte[] playerNameAsciiBytes = System.Text.Encoding.ASCII.GetBytes(playerName);
                 playerName = System.Text.Encoding.ASCII.GetString(playerNameAsciiBytes);
+
+                // remove invisible ASCII characters, e.g. control characters
+                playerName = new string(playerName.ToList().Where(c => c >= 32 && c <= 127).ToArray());
             }
 
             if (UserINISettings.Instance.AutoRemoveUnderscoresFromName)
@@ -139,7 +143,7 @@ namespace DTAClient.DXGUI
                 playerName = playerName.TrimEnd(new char[] { '_' });
             }
 
-            if (String.IsNullOrEmpty(playerName))
+            if (String.IsNullOrWhiteSpace(playerName))
                 playerName = "NewPlayer";
 
             playerName = Renderer.GetSafeString(NameValidator.GetValidOfflineName(playerName), 0);

--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -8,10 +8,8 @@ using Microsoft.Xna.Framework.Graphics;
 using Rampastring.Tools;
 using Rampastring.XNAUI;
 using System;
-using System.Linq;
 using System.Diagnostics;
 using System.IO;
-using System.Security.Principal;
 using System.Windows.Forms;
 
 namespace DTAClient.DXGUI

--- a/DXMainClient/DXGUI/Generic/MainMenu.cs
+++ b/DXMainClient/DXGUI/Generic/MainMenu.cs
@@ -1,4 +1,5 @@
 using ClientCore;
+using ClientCore.CnCNet5;
 using ClientGUI;
 using DTAClient.Domain;
 using DTAClient.Domain.Multiplayer.CnCNet;
@@ -380,7 +381,7 @@ namespace DTAClient.DXGUI.Generic
             }
 
             if (!connectionManager.IsConnected)
-                ProgramConstants.PLAYERNAME = UserINISettings.Instance.PlayerName;
+                ProgramConstants.PLAYERNAME = Renderer.GetSafeString(NameValidator.GetValidOfflineName(UserINISettings.Instance.PlayerName), 0);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR changes the behavior of DTA client:

- If the player name contains non-ASCII characters, replace them with '?'. This can be turned off by set `AutoRemoveNonASCIIFromName` as false in the ini file.
- Remove the unwanted invisible control characters.
- Will also check the new player name saved from the setting dialog.
- Refactor the code of checking offline player name, so that the code can be invoked in two places, i.e. when the client is starting as well as when user saved a new player name.

--------

Explanation of `AutoRemoveNonASCIIFromName`:

When the player name contains any non-ASCII characters, one of the following things happens:
- The name is not correctly displayed. Example: DTA, YR
- The game crashed. Example: Ares 3.0

Merging this PR to the repo solves this issue with minimal changes. And it's mostly benifiticial to users in East Asian.