### PR TITLE
Resolve the generic hostname last.

### DIFF
--- a/DXMainClient/Online/Connection.cs
+++ b/DXMainClient/Online/Connection.cs
@@ -35,7 +35,6 @@ namespace DTAClient.Online
         /// </summary>
         private static readonly IList<Server> Servers = new List<Server>
         {
-            new Server("irc.gamesurge.net", "GameSurge", new int[1] { 6667 }),
             new Server("Burstfire.UK.EU.GameSurge.net", "GameSurge London, UK", new int[3] { 6667, 6668, 7000 }),
             new Server("ColoCrossing.IL.US.GameSurge.net", "GameSurge Chicago, IL", new int[5] { 6660, 6666, 6667, 6668, 6669 }),
             new Server("Gameservers.NJ.US.GameSurge.net", "GameSurge Newark, NJ", new int[7] { 6665, 6666, 6667, 6668, 6669, 7000, 8080 }),
@@ -51,6 +50,7 @@ namespace DTAClient.Online
             new Server("195.8.250.180", "GameSurge IP 195.8.250.180", new int[7] { 6660, 6666, 6667, 6668, 6669, 7000, 8080 }),
             new Server("91.217.189.76", "GameSurge IP 91.217.189.76", new int[7] { 6660, 6666, 6667, 6668, 6669, 7000, 8080 }),
             new Server("195.68.206.250", "GameSurge IP 195.68.206.250", new int[7] { 6660, 6666, 6667, 6668, 6669, 7000, 8080 }),
+            new Server("irc.gamesurge.net", "GameSurge", new int[1] { 6667 }),
         }.AsReadOnly();
 
         bool _isConnected = false;


### PR DESCRIPTION
If the generic host is resolved as one of the explicit hosts, the server
will only be tried with the generic 6667 port instead of the
server-specific port values, due to the duplicate-checker code filtering
out the explicit host since it's DNS record returns after the generic
one. Placing the generic DNS record as last ensures that all specific
hosts will be resolved beforehand and allows connections in cases
where port 6667 is unreachable due to a network issue.

Fixes #208 