### PR TITLE
Add feature of random loading screen support

### DIFF
--- a/DXMainClient/DXGUI/Generic/LoadingScreen.cs
+++ b/DXMainClient/DXGUI/Generic/LoadingScreen.cs
@@ -40,7 +40,25 @@ namespace DTAClient.DXGUI.Generic
             ClientRectangle = new Rectangle(0, 0, 800, 600);
             Name = "LoadingScreen";
 
-            BackgroundTexture = AssetLoader.LoadTexture("loadingscreen.png");
+            string backgroundName = "loadingscreen.png";
+
+            var rand = new System.Random();
+            for (int i = 0; ; i++)
+            {
+                string currentName = "loadingscreen" + i.ToString(System.Globalization.CultureInfo.InvariantCulture) + ".png";
+                if (!AssetLoader.AssetExists(currentName))
+                {
+                    break;
+                }
+
+                var roll = rand.Next();
+                if (roll % 2 == 0)
+                {
+                    backgroundName = currentName;
+                }
+            }
+
+            BackgroundTexture = AssetLoader.LoadTexture(backgroundName);
 
             base.Initialize();
 

--- a/DXMainClient/DXGUI/Generic/LoadingScreen.cs
+++ b/DXMainClient/DXGUI/Generic/LoadingScreen.cs
@@ -34,6 +34,7 @@ namespace DTAClient.DXGUI.Generic
 
         private Task updaterInitTask = null;
         private Task mapLoadTask = null;
+        
         private string GetBackgroundName(int id)
         {
             if (id == 0)

--- a/DXMainClient/DXGUI/Generic/LoadingScreen.cs
+++ b/DXMainClient/DXGUI/Generic/LoadingScreen.cs
@@ -40,22 +40,32 @@ namespace DTAClient.DXGUI.Generic
             ClientRectangle = new Rectangle(0, 0, 800, 600);
             Name = "LoadingScreen";
 
-            string backgroundName = "loadingscreen.png";
-
-            var rand = new System.Random();
-            for (int i = 0; ; i++)
+            string GetBackgroundName(int id)
             {
-                string currentName = "loadingscreen" + i.ToString(System.Globalization.CultureInfo.InvariantCulture) + ".png";
+                if (id == 0)
+                    return "loadingscreen.png";
+                else
+                    return "loadingscreen" + id.ToString(System.Globalization.CultureInfo.InvariantCulture) + ".png";
+            }
+
+            string backgroundName = GetBackgroundName(0);
+
+            // Randomly select a background picture if there are more than one pictures.
+            int backgroundMaximum = 0;
+            for (int i = 1; ; i++)
+            {
+                string currentName = GetBackgroundName(i);
                 if (!AssetLoader.AssetExists(currentName))
                 {
+                    backgroundMaximum = i - 1;
                     break;
                 }
-
-                var roll = rand.Next();
-                if (roll % 2 == 0)
-                {
-                    backgroundName = currentName;
-                }
+            }
+            if (backgroundMaximum > 0)
+            {
+                var rand = new System.Random();
+                var roll = rand.Next(backgroundMaximum + 1);
+                backgroundName = GetBackgroundName(roll);
             }
 
             BackgroundTexture = AssetLoader.LoadTexture(backgroundName);

--- a/DXMainClient/DXGUI/Generic/LoadingScreen.cs
+++ b/DXMainClient/DXGUI/Generic/LoadingScreen.cs
@@ -34,19 +34,19 @@ namespace DTAClient.DXGUI.Generic
 
         private Task updaterInitTask = null;
         private Task mapLoadTask = null;
+        private string GetBackgroundName(int id)
+        {
+            if (id == 0)
+                return "loadingscreen.png";
+            else
+                return "loadingscreen" + id.ToString(System.Globalization.CultureInfo.InvariantCulture) + ".png";
+        }
 
         public override void Initialize()
         {
             ClientRectangle = new Rectangle(0, 0, 800, 600);
             Name = "LoadingScreen";
 
-            string GetBackgroundName(int id)
-            {
-                if (id == 0)
-                    return "loadingscreen.png";
-                else
-                    return "loadingscreen" + id.ToString(System.Globalization.CultureInfo.InvariantCulture) + ".png";
-            }
 
             string backgroundName = GetBackgroundName(0);
 
@@ -63,8 +63,8 @@ namespace DTAClient.DXGUI.Generic
             }
             if (backgroundMaximum > 0)
             {
-                var rand = new System.Random();
-                var roll = rand.Next(backgroundMaximum + 1);
+                System.Random rand = new System.Random();
+                int roll = rand.Next(backgroundMaximum + 1);
                 backgroundName = GetBackgroundName(roll);
             }
 


### PR DESCRIPTION
This PR add a new feature, where the client starts, it choose one file as the loading screen randomly, of the following picture files:
- `loadingscreen.png`
- ~~`loadingscreen0.png`~~
- `loadingscreen1.png`
- `loadingscreen2.png`
- ... and so on

~~The random code here obeys uniform distribution.~~

There is no breaking change in this PR.