### PR TITLE
change Saved Game feature 

### DIFF
--- a/ClientCore/SavedGameManager.cs
+++ b/ClientCore/SavedGameManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+
 using Rampastring.Tools;
 
 namespace ClientCore
@@ -81,10 +82,8 @@ namespace ClientCore
             return false;
         }
 
-        private static string GetSaveGameDirectoryPath()
-        {
-            return ProgramConstants.GamePath + SAVED_GAMES_DIRECTORY;
-        }
+        private static string GetSaveGameDirectoryPath()// Use System.IO.Path Member and NOT use character '/' or '\\'
+            => Path.Combine(ProgramConstants.GamePath, SAVED_GAMES_DIRECTORY);
 
         /// <summary>
         /// Initializes saved MP games for a match.

--- a/ClientCore/SavedGameManager.cs
+++ b/ClientCore/SavedGameManager.cs
@@ -38,7 +38,7 @@ namespace ClientCore
 
         public static int GetSaveGameCount()
         {
-            string saveGameDirectory = GetSaveGameDirectoryPath() + "/";
+            string saveGameDirectory = SaveGameDirectoryPath + "/";
 
             if (!AreSavedGamesAvailable())
                 return 0;
@@ -60,7 +60,7 @@ namespace ClientCore
 
             List<string> timestamps = new List<string>();
 
-            string saveGameDirectory = GetSaveGameDirectoryPath() + "/";
+            string saveGameDirectory = SaveGameDirectoryPath + "/";
 
             for (int i = 0; i < saveGameCount; i++)
             {
@@ -76,13 +76,13 @@ namespace ClientCore
 
         public static bool AreSavedGamesAvailable()
         {
-            if (Directory.Exists(GetSaveGameDirectoryPath()))
+            if (Directory.Exists(SaveGameDirectoryPath))
                 return true;
 
             return false;
         }
 
-        private static string GetSaveGameDirectoryPath()// Use System.IO.Path Member and NOT use character '/' or '\\'
+        private static string SaveGameDirectoryPath // Use System.IO.Path Member and NOT use character '/' or '\\'
             => Path.Combine(ProgramConstants.GamePath, SAVED_GAMES_DIRECTORY);
 
         /// <summary>
@@ -120,7 +120,7 @@ namespace ClientCore
                 return;
             }
 
-            string saveGameDirectory = GetSaveGameDirectoryPath() + "/";
+            string saveGameDirectory = SaveGameDirectoryPath + "/";
 
             if (!File.Exists(saveGameDirectory + "SAVEGAME.NET"))
             {
@@ -187,7 +187,7 @@ namespace ClientCore
             {
                 for (int i = 0; i < 1000; i++)
                 {
-                    File.Delete(GetSaveGameDirectoryPath() +
+                    File.Delete(SaveGameDirectoryPath +
                         "/" + string.Format("SVGM_{0}.NET", i.ToString("D3")));
                 }
             }

--- a/ClientCore/SavedGameManager.cs
+++ b/ClientCore/SavedGameManager.cs
@@ -14,6 +14,27 @@ namespace ClientCore
 
         private static bool saveRenameInProgress = false;
 
+        /// <summary>
+        /// Get Archive Name
+        /// </summary>
+        /// <param name="stream">FileStream</param>
+        /// <returns>Archive Name</returns>
+        public static string GetSaveGameName(Stream stream)
+        {
+            var buffer = new byte[4];
+            stream.Seek(0x08CC, SeekOrigin.Begin);
+            stream.Read(buffer, 0, 4);// Get Name Length.
+
+            if (!BitConverter.IsLittleEndian)
+                Array.Reverse(buffer);
+            buffer = new byte[(BitConverter.ToInt32(buffer, 0) - 1) << 1];
+
+            stream.Read(buffer, 0, buffer.Length);// Get Name.
+            var result = System.Text.Encoding.Unicode.GetString(buffer);
+            Logger.Log($"[SavedGameManager]\tFound Archive: {result}");
+            return result;
+        }
+
         public static int GetSaveGameCount()
         {
             string saveGameDirectory = GetSaveGameDirectoryPath() + "/";
@@ -167,7 +188,7 @@ namespace ClientCore
             {
                 for (int i = 0; i < 1000; i++)
                 {
-                    File.Delete(GetSaveGameDirectoryPath() + 
+                    File.Delete(GetSaveGameDirectoryPath() +
                         "/" + string.Format("SVGM_{0}.NET", i.ToString("D3")));
                 }
             }

--- a/ClientCore/SavedGameManager.cs
+++ b/ClientCore/SavedGameManager.cs
@@ -76,10 +76,7 @@ namespace ClientCore
 
         public static bool AreSavedGamesAvailable()
         {
-            if (Directory.Exists(SaveGameDirectoryPath))
-                return true;
-
-            return false;
+            return Directory.Exists(SaveGameDirectoryPath);
         }
 
         private static string SaveGameDirectoryPath // Use System.IO.Path Member and NOT use character '/' or '\\'

--- a/DXMainClient/Domain/SavedGame.cs
+++ b/DXMainClient/Domain/SavedGame.cs
@@ -30,32 +30,8 @@ namespace DTAClient.Domain
         {
             try
             {
-                using (BinaryReader br = new BinaryReader(File.Open(ProgramConstants.GamePath + SAVED_GAME_PATH + FileName, FileMode.Open, FileAccess.Read)))
-                {
-                    br.BaseStream.Position = 2256; // 00000980
-
-                    string saveGameName = String.Empty;
-                    // Read a UTF-16 LE string, until a null character is met. A null character in UTF-16 LE usually consists of two 0x00 bytes, but it's not always the case.
-                    var saveGameNameBuffer = new List<byte>();
-                    while (true)
-                    {
-                        byte lowByte = br.ReadByte();
-                        byte highByte = br.ReadByte();
-
-                        if (lowByte == 0 && highByte == 0)
-                        {
-                            // TODO: if the character is a surrogate pair (i.e. two 16-bit code units) and one of the 16-bit code units happens to be 0x0000, the string will be truncated.
-                            // However, very few characters are influenced and none of them are common characters. It's so rare that I can't take an example easily.
-                            break;
-                        }
-
-                        saveGameNameBuffer.Add(lowByte);
-                        saveGameNameBuffer.Add(highByte);
-                    }
-
-                    saveGameName = System.Text.Encoding.Unicode.GetString(saveGameNameBuffer.ToArray());
-                    GUIName = saveGameName;
-                }
+                using (var fs = File.Open(ProgramConstants.GamePath + SAVED_GAME_PATH + FileName, FileMode.Open, FileAccess.Read))
+                    GUIName = SavedGameManager.GetSaveGameName(fs);
 
                 LastModified = File.GetLastWriteTime(ProgramConstants.GamePath + SAVED_GAME_PATH + FileName);
                 return true;


### PR DESCRIPTION
some suggestions:
- Use [System.IO.Path](//docs.microsoft.com/dotnet/api/system.io.path) Member and **NOT** use character `'/'` or `'\\'` to cross platform.
- Use Properties instead of Methods.
- Make [.editorconfig](//docs.microsoft.com/visualstudio/ide/create-portable-custom-editor-options) file to constraint the code style.
- Use [nuget](//nuget.org) package instead of reference library.
- Use [Multilingual app toolkit](//docs.microsoft.com/windows/uwp/design/globalizing/use-mat) (well, it will be hard.)