### PR TITLE
Make client FPS user-configurable

### DIFF
--- a/ClientCore/Settings/UserINISettings.cs
+++ b/ClientCore/Settings/UserINISettings.cs
@@ -60,6 +60,7 @@ namespace ClientCore
             ClientResolutionX = new IntSetting(iniFile, VIDEO, "ClientResolutionX", Screen.PrimaryScreen.Bounds.Width);
             ClientResolutionY = new IntSetting(iniFile, VIDEO, "ClientResolutionY", Screen.PrimaryScreen.Bounds.Height);
             BorderlessWindowedClient = new BoolSetting(iniFile, VIDEO, "BorderlessWindowedClient", true);
+            ClientFPS = new IntSetting(iniFile, VIDEO, "ClientFPS", 60);
 
             ScoreVolume = new DoubleSetting(iniFile, AUDIO, "ScoreVolume", 0.7);
             SoundVolume = new DoubleSetting(iniFile, AUDIO, "SoundVolume", 0.7);
@@ -130,6 +131,7 @@ namespace ClientCore
         public IntSetting ClientResolutionX { get; private set; }
         public IntSetting ClientResolutionY { get; private set; }
         public BoolSetting BorderlessWindowedClient { get; private set; }
+        public IntSetting ClientFPS { get; private set; }
 
         /*********/
         /* AUDIO */

--- a/ClientGUI/DarkeningPanel.cs
+++ b/ClientGUI/DarkeningPanel.cs
@@ -10,7 +10,7 @@ namespace ClientGUI
     /// </summary>
     public class DarkeningPanel : XNAPanel
     {
-        private const float ALPHA_RATE = 0.6f;
+        public const float ALPHA_RATE = 0.6f;
 
         public DarkeningPanel(WindowManager windowManager) : base(windowManager)
         {

--- a/DXMainClient/DXGUI/Generic/GameInProgressWindow.cs
+++ b/DXMainClient/DXGUI/Generic/GameInProgressWindow.cs
@@ -19,7 +19,6 @@ namespace DTAClient.DXGUI
     /// </summary>
     public class GameInProgressWindow : XNAPanel
     {
-        private const double FPS = 60.0;
         private const double POWER_SAVING_FPS = 5.0;
 
         public GameInProgressWindow(WindowManager windowManager) : base(windowManager)
@@ -70,7 +69,7 @@ namespace DTAClient.DXGUI
 
             window.CenterOnParent();
 
-            Game.TargetElapsedTime = TimeSpan.FromMilliseconds(1000.0 / FPS);
+            Game.TargetElapsedTime = TimeSpan.FromMilliseconds(1000.0 / UserINISettings.Instance.ClientFPS);
 
             Visible = false;
             Enabled = false;
@@ -133,7 +132,7 @@ namespace DTAClient.DXGUI
             else
                 WindowManager.Cursor.Visible = true;
             ProgramConstants.IsInGame = false;
-            Game.TargetElapsedTime = TimeSpan.FromMilliseconds(1000.0 / FPS);
+            Game.TargetElapsedTime = TimeSpan.FromMilliseconds(1000.0 / UserINISettings.Instance.ClientFPS);
             if (UserINISettings.Instance.MinimizeWindowsOnGameStart)
                 WindowManager.MaximizeWindow();
 

--- a/DXMainClient/DXGUI/Generic/MainMenuDarkeningPanel.cs
+++ b/DXMainClient/DXGUI/Generic/MainMenuDarkeningPanel.cs
@@ -18,7 +18,6 @@ namespace DTAClient.DXGUI.Generic
             this.discordHandler = discordHandler;
             DrawBorders = false;
             DrawMode = ControlDrawMode.UNIQUE_RENDER_TARGET;
-            AlphaRate = 0.0f;
         }
 
         private DiscordHandler discordHandler;
@@ -30,24 +29,15 @@ namespace DTAClient.DXGUI.Generic
         public UpdateWindow UpdateWindow;
         public ExtrasWindow ExtrasWindow;
 
-        const float BG_ALPHA_APPEAR_RATE = 0.1f;
-        const float BG_ALPHA_DISAPPEAR_RATE = -0.1f;
-
-        float bgAlphaRate = -0.1f;
-
         public override void Initialize()
         {
             base.Initialize();
 
             Name = "DarkeningPanel";
-            //BorderColor = UISettings.WindowBorderColor;
             BorderColor = UISettings.ActiveSettings.PanelBorderColor;
             BackgroundTexture = AssetLoader.CreateTexture(new Color(0, 0, 0, 128), 1, 1);
-            //ClientRectangle = new Rectangle(0, 0, 1, 1);
             PanelBackgroundDrawMode = PanelBackgroundImageDrawMode.STRETCHED;
             Alpha = 1.0f;
-
-            //ClientRectangle = new Rectangle(0, 0, WindowManager.Instance.RenderResolutionX, WindowManager.Instance.RenderResolutionY);
 
             CampaignSelector = new CampaignSelector(WindowManager, discordHandler);
             AddChild(CampaignSelector);
@@ -93,7 +83,7 @@ namespace DTAClient.DXGUI.Generic
             Enabled = true;
             Visible = true;
 
-            bgAlphaRate = BG_ALPHA_APPEAR_RATE;
+            AlphaRate = DarkeningPanel.ALPHA_RATE;
 
             if (control != null)
             {
@@ -105,7 +95,7 @@ namespace DTAClient.DXGUI.Generic
 
         public void Hide()
         {
-            bgAlphaRate = BG_ALPHA_DISAPPEAR_RATE;
+            AlphaRate = -DarkeningPanel.ALPHA_RATE;
 
             foreach (XNAControl child in Children)
             {
@@ -117,8 +107,6 @@ namespace DTAClient.DXGUI.Generic
         public override void Update(GameTime gameTime)
         {
             base.Update(gameTime);
-
-            Alpha += bgAlphaRate;
 
             if (Alpha <= 0f)
             {


### PR DESCRIPTION
This PR does three things:

1) Makes client FPS user-configurable through `[Video] ClientFPS=`. Defaults to 60. This can be useful for users that have high refresh rate monitors and for people who want to lower the client's CPU usage at the expense of input smoothness.

2) Fixes MainMenuDarkeningPanel's alpha rate so it does not depend on the client's frame rate

3) Normalizes the alpha rate to be the same for MainMenuDarkeningPanel and the common DarkeningPanel