### PR TITLE
Fix auto-ready option keeping ready status on even while in-game

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -763,7 +763,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 sb.Append(";");
                 if (!pInfo.IsAI)
                 {
-                    if (pInfo.AutoReady)
+                    if (pInfo.AutoReady && !pInfo.IsInGame)
                         sb.Append(2);
                     else
                         sb.Append(Convert.ToInt32(pInfo.Ready));

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -1553,7 +1553,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         {
             for (int i = 1; i < Players.Count; i++)
             {
-                if (!Players[i].AutoReady)
+                if (!Players[i].AutoReady || Players[i].IsInGame)
                     Players[i].Ready = false;
             }
         }

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
@@ -485,7 +485,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 sb.Append(pInfo.ColorId);
                 sb.Append(pInfo.StartingLocation);
                 sb.Append(pInfo.TeamId);
-                if (pInfo.AutoReady)
+                if (pInfo.AutoReady && !pInfo.IsInGame)
                     sb.Append(2);
                 else
                     sb.Append(Convert.ToInt32(pInfo.IsAI || pInfo.Ready));

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
@@ -284,6 +284,10 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 GenerateGameID();
                 DdGameMode_SelectedIndexChanged(null, EventArgs.Empty); // Refresh ranks
             }
+            else if (chkAutoReady.Checked)
+            {
+                RequestReadyStatus();
+            }
         }
 
         private void GenerateGameID()


### PR DESCRIPTION
Auto-ready checkbox, when toggled on, used to keep players' ready status on even while they were in-game. With this fix, the status should be stripped when starting a game but re-instated after exiting the game.