### PR TITLE
Game List Sort and Filters

### DIFF
--- a/ClientCore/ClientCore.csproj
+++ b/ClientCore/ClientCore.csproj
@@ -259,6 +259,7 @@
     <Compile Include="ProfanityFilter.cs" />
     <Compile Include="SavedGameManager.cs" />
     <Compile Include="Settings\IIniSetting.cs" />
+    <Compile Include="Settings\IntRangeSetting.cs" />
     <Compile Include="Settings\UserINISettings.cs" />
     <Compile Include="Settings\BoolSetting.cs" />
     <Compile Include="Settings\DoubleSetting.cs" />

--- a/ClientCore/Settings/IntRangeSetting.cs
+++ b/ClientCore/Settings/IntRangeSetting.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Rampastring.Tools;
+
+namespace ClientCore.Settings
+{
+    /// <summary>
+    /// Similar to IntSetting, this setting forces a min and max value upon getting and setting.
+    /// </summary>
+    public class IntRangeSetting : IntSetting
+    {
+        private readonly int MinValue;
+        private readonly int MaxValue;
+
+        public IntRangeSetting(IniFile iniFile, string iniSection, string iniKey, int defaultValue, int minValue, int maxValue) : base(iniFile, iniSection, iniKey, defaultValue)
+        {
+            MinValue = minValue;
+            MaxValue = maxValue;
+        }
+
+        /// <summary>
+        /// Checks the validity of the value. If the value is invalid, return the default value of this setting.
+        /// Otherwise, return the set value.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        private int NormalizeValue(int value)
+        {
+            return InvalidValue(value) ? DefaultValue : value;
+        }
+
+        private bool InvalidValue(int value)
+        {
+            return value < MinValue || value > MaxValue;
+        }
+
+        protected override int Get()
+        {
+            return NormalizeValue(IniFile.GetIntValue(IniSection, IniKey, DefaultValue));
+        }
+
+        protected override void Set(int value)
+        {
+            IniFile.SetIntValue(IniSection, IniKey, NormalizeValue(value));
+        }
+    }
+}

--- a/ClientCore/Settings/UserINISettings.cs
+++ b/ClientCore/Settings/UserINISettings.cs
@@ -15,6 +15,13 @@ namespace ClientCore
         private const string AUDIO = "Audio";
         private const string CUSTOM_SETTINGS = "CustomSettings";
         private const string COMPATIBILITY = "Compatibility";
+        private const string GAME_FILTERS = "GameFilters";
+
+        private const bool DEFAULT_SHOW_FRIENDS_ONLY_GAMES = false;
+        private const bool DEFAULT_HIDE_LOCKED_GAMES = false;
+        private const bool DEFAULT_HIDE_PASSWORDED_GAMES = false;
+        private const bool DEFAULT_HIDE_INCOMPATIBLE_GAMES = false;
+        private const int DEFAULT_MAX_PLAYER_COUNT = 8;
 
         public static UserINISettings Instance
         {
@@ -110,6 +117,13 @@ namespace ClientCore
             ForceLowestDetailLevel = new BoolSetting(iniFile, VIDEO, "ForceLowestDetailLevel", false);
             MinimizeWindowsOnGameStart = new BoolSetting(iniFile, OPTIONS, "MinimizeWindowsOnGameStart", true);
             AutoRemoveUnderscoresFromName = new BoolSetting(iniFile, OPTIONS, "AutoRemoveUnderscoresFromName", true);
+
+            SortAlpha = new BoolSetting(iniFile, GAME_FILTERS, "SortAlpha", false);
+            ShowFriendGamesOnly = new BoolSetting(iniFile, GAME_FILTERS, "ShowFriendGamesOnly", DEFAULT_SHOW_FRIENDS_ONLY_GAMES);
+            HideLockedGames = new BoolSetting(iniFile, GAME_FILTERS, "HideLockedGames", DEFAULT_HIDE_LOCKED_GAMES);
+            HidePasswordedGames = new BoolSetting(iniFile, GAME_FILTERS, "HidePasswordedGames", DEFAULT_HIDE_PASSWORDED_GAMES);
+            HideIncompatibleGames = new BoolSetting(iniFile, GAME_FILTERS, "HideIncompatibleGames", DEFAULT_HIDE_INCOMPATIBLE_GAMES);
+            MaxPlayerCount = new IntRangeSetting(iniFile, GAME_FILTERS, "MaxPlayerCount", DEFAULT_MAX_PLAYER_COUNT, 2, 8);
         }
 
         public IniFile SettingsIni { get; private set; }
@@ -184,6 +198,22 @@ namespace ClientCore
         public BoolSetting EnableMapSharing { get; private set; }
 
         public BoolSetting AlwaysDisplayTunnelList { get; private set; }
+        
+        /*********************/
+        /* GAME LIST FILTERS */
+        /*********************/
+
+        public BoolSetting SortAlpha { get; private set; }
+        
+        public BoolSetting ShowFriendGamesOnly { get; private set; }
+        
+        public BoolSetting HideLockedGames { get; private set; }
+        
+        public BoolSetting HidePasswordedGames { get; private set; }
+        
+        public BoolSetting HideIncompatibleGames { get; private set; }
+        
+        public IntRangeSetting MaxPlayerCount { get; private set; }
 
         /********/
         /* MISC */
@@ -208,7 +238,7 @@ namespace ClientCore
         public BoolSetting MinimizeWindowsOnGameStart { get; private set; }
 
         public BoolSetting AutoRemoveUnderscoresFromName { get; private set; }
-
+        
         public bool IsGameFollowed(string gameName)
         {
             return SettingsIni.GetBooleanValue("Channels", gameName, false);
@@ -257,6 +287,24 @@ namespace ClientCore
             SettingsIni.WriteIniFile();
 
             SettingsSaved?.Invoke(this, EventArgs.Empty);
+        }
+
+        public bool IsGameFiltersApplied()
+        {
+            return ShowFriendGamesOnly.Value != DEFAULT_SHOW_FRIENDS_ONLY_GAMES ||
+                   HideLockedGames.Value != DEFAULT_HIDE_LOCKED_GAMES ||
+                   HidePasswordedGames.Value != DEFAULT_HIDE_PASSWORDED_GAMES ||
+                   HideIncompatibleGames.Value != DEFAULT_HIDE_INCOMPATIBLE_GAMES ||
+                   MaxPlayerCount.Value != DEFAULT_MAX_PLAYER_COUNT;
+        }
+
+        public void ResetGameFilters()
+        {
+            ShowFriendGamesOnly.Value = DEFAULT_SHOW_FRIENDS_ONLY_GAMES;
+            HideLockedGames.Value = DEFAULT_HIDE_LOCKED_GAMES;
+            HideIncompatibleGames.Value = DEFAULT_HIDE_INCOMPATIBLE_GAMES;
+            HidePasswordedGames.Value = DEFAULT_HIDE_PASSWORDED_GAMES;
+            MaxPlayerCount.Value = DEFAULT_MAX_PLAYER_COUNT;
         }
     }
 }

--- a/ClientGUI/ClientGUI.csproj
+++ b/ClientGUI/ClientGUI.csproj
@@ -143,6 +143,7 @@
     <Compile Include="XNAClientDropDown.cs" />
     <Compile Include="XNAClientPreferredItemDropDown.cs" />
     <Compile Include="XNAClientTabControl.cs" />
+    <Compile Include="XNAClientToggleButton.cs" />
     <Compile Include="XNAExtraPanel.cs" />
     <Compile Include="XNALinkButton.cs" />
     <Compile Include="XNAMessageBox.cs" />

--- a/ClientGUI/UIDesignConstants.cs
+++ b/ClientGUI/UIDesignConstants.cs
@@ -19,7 +19,10 @@ namespace ClientGUI
         public const int CONTROL_HORIZONTAL_MARGIN = 6;
 
         public const int BUTTON_HEIGHT = 23;
+        public const int BUTTON_WIDTH_75 = 75;
         public const int BUTTON_WIDTH_92 = 92;
+        public const int BUTTON_WIDTH_121 = 121;
         public const int BUTTON_WIDTH_133 = 133;
+        public const int BUTTON_WIDTH_160 = 160;
     }
 }

--- a/ClientGUI/XNAClientToggleButton.cs
+++ b/ClientGUI/XNAClientToggleButton.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.Xna.Framework.Graphics;
+using Rampastring.XNAUI;
+using Rampastring.XNAUI.XNAControls;
+
+namespace ClientGUI
+{
+    /// <summary>
+    /// This is a combination of a checkbox and a standard button. You must specify
+    /// the Checked and Unchecked Textures to render for each button state.
+    /// </summary>
+    public class XNAClientToggleButton : XNAButton
+    {
+        public Texture2D CheckedTexture { get; set; }
+        public Texture2D UncheckedTexture { get; set; }
+
+        private bool _checked { get; set; }
+
+        public override void Initialize()
+        {
+            if (CheckedTexture == null)
+                throw new ArgumentNullException(nameof(CheckedTexture));
+
+            if (UncheckedTexture == null)
+                throw new ArgumentNullException(nameof(UncheckedTexture));
+
+            UpdateIdleTexture();
+
+            if (HoverSoundEffect == null)
+                HoverSoundEffect = new EnhancedSoundEffect("button.wav");
+
+            base.Initialize();
+
+            if (Width == 0)
+                Width = IdleTexture.Width;
+        }
+
+        public bool Checked
+        {
+            get => _checked;
+            set
+            {
+                _checked = value;
+                UpdateIdleTexture();
+            }
+        }
+
+        private void UpdateIdleTexture()
+        {
+            IdleTexture = _checked ? CheckedTexture : UncheckedTexture;
+        }
+
+        public XNAClientToggleButton(WindowManager windowManager) : base(windowManager)
+        {
+        }
+    }
+}

--- a/DTAConfig/DTAConfig.csproj
+++ b/DTAConfig/DTAConfig.csproj
@@ -291,7 +291,6 @@
     <Compile Include="OptionPanels\CnCNetOptionsPanel.cs" />
     <Compile Include="OptionPanels\ComponentsPanel.cs" />
     <Compile Include="OptionPanels\DisplayOptionsPanel.cs" />
-    <Compile Include="OptionPanels\GameFilterOptionsPanel.cs" />
     <Compile Include="OptionPanels\GameOptionsPanel.cs" />
     <Compile Include="HotkeyConfigurationWindow.cs" />
     <Compile Include="CustomSettings\FileSettingCheckBox.cs" />

--- a/DTAConfig/DTAConfig.csproj
+++ b/DTAConfig/DTAConfig.csproj
@@ -291,6 +291,7 @@
     <Compile Include="OptionPanels\CnCNetOptionsPanel.cs" />
     <Compile Include="OptionPanels\ComponentsPanel.cs" />
     <Compile Include="OptionPanels\DisplayOptionsPanel.cs" />
+    <Compile Include="OptionPanels\GameFilterOptionsPanel.cs" />
     <Compile Include="OptionPanels\GameOptionsPanel.cs" />
     <Compile Include="HotkeyConfigurationWindow.cs" />
     <Compile Include="CustomSettings\FileSettingCheckBox.cs" />

--- a/DTAConfig/HotkeyConfigurationWindow.cs
+++ b/DTAConfig/HotkeyConfigurationWindow.cs
@@ -146,7 +146,7 @@ namespace DTAConfig
             var btnAssign = new XNAClientButton(WindowManager);
             btnAssign.Name = "btnAssign";
             btnAssign.ClientRectangle = new Rectangle(lblDescription.X,
-                lblCurrentlyAssignedTo.Bottom + 24, 121, 23);
+                lblCurrentlyAssignedTo.Bottom + 24, UIDesignConstants.BUTTON_WIDTH_121, UIDesignConstants.BUTTON_HEIGHT);
             btnAssign.Text = "Assign Hotkey";
             btnAssign.LeftClick += BtnAssign_LeftClick;
 
@@ -167,13 +167,13 @@ namespace DTAConfig
 
             var btnSave = new XNAClientButton(WindowManager);
             btnSave.Name = "btnSave";
-            btnSave.ClientRectangle = new Rectangle(12, lbHotkeys.Bottom + 12, 92, 23);
+            btnSave.ClientRectangle = new Rectangle(12, lbHotkeys.Bottom + 12, UIDesignConstants.BUTTON_WIDTH_92, UIDesignConstants.BUTTON_HEIGHT);
             btnSave.Text = "Save";
             btnSave.LeftClick += BtnSave_LeftClick;
 
             var btnResetAllKeys = new XNAClientButton(WindowManager);
             btnResetAllKeys.Name = "btnResetAllToDefaults";
-            btnResetAllKeys.ClientRectangle = new Rectangle(0, btnSave.Y, 121, 23);
+            btnResetAllKeys.ClientRectangle = new Rectangle(0, btnSave.Y, UIDesignConstants.BUTTON_WIDTH_121, UIDesignConstants.BUTTON_HEIGHT);
             btnResetAllKeys.Text = "Reset All Keys";
             btnResetAllKeys.LeftClick += BtnResetToDefaults_LeftClick;
             AddChild(btnResetAllKeys);
@@ -181,7 +181,7 @@ namespace DTAConfig
 
             var btnCancel = new XNAClientButton(WindowManager);
             btnCancel.Name = "btnExit";
-            btnCancel.ClientRectangle = new Rectangle(Width - 104, btnSave.Y, 92, 23);
+            btnCancel.ClientRectangle = new Rectangle(Width - 104, btnSave.Y, UIDesignConstants.BUTTON_WIDTH_92, UIDesignConstants.BUTTON_HEIGHT);
             btnCancel.Text = "Cancel";
             btnCancel.LeftClick += BtnCancel_LeftClick;
 

--- a/DTAConfig/OptionPanels/ComponentsPanel.cs
+++ b/DTAConfig/OptionPanels/ComponentsPanel.cs
@@ -56,7 +56,7 @@ namespace DTAConfig.OptionPanels
                 var btn = new XNAClientButton(WindowManager);
                 btn.Name = "btn" + c.ININame;
                 btn.ClientRectangle = new Rectangle(Width - 145,
-                    12 + componentIndex * 35, 133, 23);
+                    12 + componentIndex * 35, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
                 btn.Text = buttonText;
                 btn.Tag = c;
                 btn.LeftClick += Btn_LeftClick;

--- a/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
@@ -259,7 +259,7 @@ namespace DTAConfig.OptionPanels
             btnGameCompatibilityFix.Name = "btnGameCompatibilityFix";
             btnGameCompatibilityFix.ClientRectangle = new Rectangle(
                 lblGameCompatibilityFix.Right + 20,
-                lblGameCompatibilityFix.Y - 4, 133, 23);
+                lblGameCompatibilityFix.Y - 4, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnGameCompatibilityFix.FontIndex = 1;
             btnGameCompatibilityFix.Text = "Enable";
             btnGameCompatibilityFix.LeftClick += BtnGameCompatibilityFix_LeftClick;

--- a/DTAConfig/OptionPanels/GameFilterOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/GameFilterOptionsPanel.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using ClientCore;
+using ClientGUI;
+using Microsoft.Xna.Framework;
+using Rampastring.XNAUI;
+using Rampastring.XNAUI.XNAControls;
+
+namespace DTAConfig.OptionPanels
+{
+    class GameFilterOptionsPanel : XNAOptionsPanel
+    {
+        private const int minPlayerCount = 2;
+        private const int maxPlayerCount = 8;
+
+        private XNAClientCheckBox chkBoxSortAlpha;
+        private XNAClientCheckBox chkBoxFriendsOnly;
+        private XNAClientCheckBox chkBoxHideLockedGames;
+        private XNAClientCheckBox chkBoxHidePasswordedGames;
+        private XNAClientCheckBox chkBoxHideIncompatibleGames;
+        private XNAClientDropDown ddMaxPlayerCount;
+        private UserINISettings userIniSettings;
+
+        public GameFilterOptionsPanel(WindowManager windowManager, UserINISettings userIniSettings) : base(windowManager, userIniSettings)
+        {
+            this.userIniSettings = userIniSettings;
+        }
+
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            Name = "GameFiltersWindow";
+
+            const int gap = 12;
+
+            chkBoxSortAlpha = new XNAClientCheckBox(WindowManager);
+            chkBoxSortAlpha.Name = nameof(chkBoxSortAlpha);
+            chkBoxSortAlpha.Text = "Sort Alphabetically";
+            chkBoxSortAlpha.ClientRectangle = new Rectangle(
+                gap, gap,
+                0, 0
+            );
+
+            chkBoxFriendsOnly = new XNAClientCheckBox(WindowManager);
+            chkBoxFriendsOnly.Name = nameof(chkBoxFriendsOnly);
+            chkBoxFriendsOnly.Text = "Show Friend Games Only";
+            chkBoxFriendsOnly.ClientRectangle = new Rectangle(
+                gap, chkBoxSortAlpha.Y + UIDesignConstants.BUTTON_HEIGHT + gap,
+                0, 0
+            );
+
+            chkBoxHideLockedGames = new XNAClientCheckBox(WindowManager);
+            chkBoxHideLockedGames.Name = nameof(chkBoxHideLockedGames);
+            chkBoxHideLockedGames.Text = "Hide Locked Games";
+            chkBoxHideLockedGames.ClientRectangle = new Rectangle(
+                gap, chkBoxFriendsOnly.Y + UIDesignConstants.BUTTON_HEIGHT + gap,
+                0, 0
+            );
+
+            chkBoxHidePasswordedGames = new XNAClientCheckBox(WindowManager);
+            chkBoxHidePasswordedGames.Name = nameof(chkBoxHidePasswordedGames);
+            chkBoxHidePasswordedGames.Text = "Hide Passworded Games";
+            chkBoxHidePasswordedGames.ClientRectangle = new Rectangle(
+                gap, chkBoxHideLockedGames.Y + UIDesignConstants.BUTTON_HEIGHT + gap,
+                0, 0
+            );
+
+            chkBoxHideIncompatibleGames = new XNAClientCheckBox(WindowManager);
+            chkBoxHideIncompatibleGames.Name = nameof(chkBoxHideIncompatibleGames);
+            chkBoxHideIncompatibleGames.Text = "Hide Incompatible Games";
+            chkBoxHideIncompatibleGames.ClientRectangle = new Rectangle(
+                gap, chkBoxHidePasswordedGames.Y + UIDesignConstants.BUTTON_HEIGHT + gap,
+                0, 0
+            );
+
+            ddMaxPlayerCount = new XNAClientDropDown(WindowManager);
+            ddMaxPlayerCount.Name = nameof(ddMaxPlayerCount);
+            ddMaxPlayerCount.ClientRectangle = new Rectangle(
+                gap, chkBoxHideIncompatibleGames.Y + UIDesignConstants.BUTTON_HEIGHT + gap,
+                40, UIDesignConstants.BUTTON_HEIGHT
+            );
+            for (var i = minPlayerCount; i <= maxPlayerCount; i++)
+            {
+                ddMaxPlayerCount.AddItem(i.ToString());
+            }
+
+            var lblMaxPlayerCount = new XNALabel(WindowManager);
+            lblMaxPlayerCount.Name = nameof(lblMaxPlayerCount);
+            lblMaxPlayerCount.Text = "Max Player Count";
+            lblMaxPlayerCount.ClientRectangle = new Rectangle(
+                ddMaxPlayerCount.X + ddMaxPlayerCount.Width + gap, ddMaxPlayerCount.Y,
+                0, UIDesignConstants.BUTTON_HEIGHT
+            );
+
+            var btnResetDefaults = new XNAClientButton(WindowManager);
+            btnResetDefaults.Name = nameof(btnResetDefaults);
+            btnResetDefaults.Text = "Reset Defaults";
+            btnResetDefaults.ClientRectangle = new Rectangle(
+                gap, ddMaxPlayerCount.Y + UIDesignConstants.BUTTON_HEIGHT + gap,
+                UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT
+            );
+            btnResetDefaults.LeftClick += ResetDefaults;
+
+            AddChild(chkBoxSortAlpha);
+            AddChild(chkBoxFriendsOnly);
+            AddChild(chkBoxHideLockedGames);
+            AddChild(chkBoxHidePasswordedGames);
+            AddChild(chkBoxHideIncompatibleGames);
+            AddChild(lblMaxPlayerCount);
+            AddChild(ddMaxPlayerCount);
+            AddChild(btnResetDefaults);
+        }
+
+        public override bool Save()
+        {
+            userIniSettings.SortAlpha.Value = chkBoxSortAlpha.Checked;
+            userIniSettings.ShowFriendGamesOnly.Value = chkBoxFriendsOnly.Checked;
+            userIniSettings.HideLockedGames.Value = chkBoxHideLockedGames.Checked;
+            userIniSettings.HidePasswordedGames.Value = chkBoxHidePasswordedGames.Checked;
+            userIniSettings.HideIncompatibleGames.Value = chkBoxHideIncompatibleGames.Checked;
+            userIniSettings.MaxPlayerCount.Value = int.Parse(ddMaxPlayerCount.SelectedItem.Text);
+
+            return false;
+        }
+
+        public override void Load()
+        {
+            base.Load();
+
+            chkBoxSortAlpha.Checked = userIniSettings.SortAlpha.Value;
+            chkBoxFriendsOnly.Checked = userIniSettings.ShowFriendGamesOnly.Value;
+            chkBoxHideLockedGames.Checked = userIniSettings.HideLockedGames.Value;
+            chkBoxHidePasswordedGames.Checked = userIniSettings.HidePasswordedGames.Value;
+            chkBoxHideIncompatibleGames.Checked = userIniSettings.HideIncompatibleGames.Value;
+            ddMaxPlayerCount.SelectedIndex = ddMaxPlayerCount.Items.FindIndex(i => i.Text == userIniSettings.MaxPlayerCount.Value.ToString());
+        }
+
+        public void ResetDefaults(object sender, EventArgs e)
+        {
+            userIniSettings.ResetGameFilters();
+            Load();
+        }
+    }
+}

--- a/DTAConfig/OptionPanels/GameOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/GameOptionsPanel.cs
@@ -165,7 +165,7 @@ namespace DTAConfig.OptionPanels
 
             var btnConfigureHotkeys = new XNAClientButton(WindowManager);
             btnConfigureHotkeys.Name = "btnConfigureHotkeys";
-            btnConfigureHotkeys.ClientRectangle = new Rectangle(lblPlayerName.X, lblNotice.Bottom + 36, 160, 23);
+            btnConfigureHotkeys.ClientRectangle = new Rectangle(lblPlayerName.X, lblNotice.Bottom + 36, UIDesignConstants.BUTTON_WIDTH_160, UIDesignConstants.BUTTON_HEIGHT);
             btnConfigureHotkeys.Text = "Configure Hotkeys";
             btnConfigureHotkeys.LeftClick += BtnConfigureHotkeys_LeftClick;
 

--- a/DTAConfig/OptionPanels/UpdaterOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/UpdaterOptionsPanel.cs
@@ -44,15 +44,15 @@ namespace DTAConfig.OptionPanels
             var btnMoveUp = new XNAClientButton(WindowManager);
             btnMoveUp.Name = "btnMoveUp";
             btnMoveUp.ClientRectangle = new Rectangle(lbUpdateServerList.X,
-                lbUpdateServerList.Bottom + 12, 133, 23);
+                lbUpdateServerList.Bottom + 12, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnMoveUp.Text = "Move Up";
             btnMoveUp.LeftClick += btnMoveUp_LeftClick;
 
             var btnMoveDown = new XNAClientButton(WindowManager);
             btnMoveDown.Name = "btnMoveDown";
             btnMoveDown.ClientRectangle = new Rectangle(
-                lbUpdateServerList.Right - 133,
-                btnMoveUp.Y, 133, 23);
+                lbUpdateServerList.Right - UIDesignConstants.BUTTON_WIDTH_133,
+                btnMoveUp.Y, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnMoveDown.Text = "Move Down";
             btnMoveDown.LeftClick += btnMoveDown_LeftClick;
 
@@ -64,7 +64,7 @@ namespace DTAConfig.OptionPanels
 
             btnForceUpdate = new XNAClientButton(WindowManager);
             btnForceUpdate.Name = "btnForceUpdate";
-            btnForceUpdate.ClientRectangle = new Rectangle(btnMoveDown.X, btnMoveDown.Bottom + 24, 133, 23);
+            btnForceUpdate.ClientRectangle = new Rectangle(btnMoveDown.X, btnMoveDown.Bottom + 24, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnForceUpdate.Text = "Force Update";
             btnForceUpdate.LeftClick += BtnForceUpdate_LeftClick;
 

--- a/DTAConfig/OptionsWindow.cs
+++ b/DTAConfig/OptionsWindow.cs
@@ -68,7 +68,6 @@ namespace DTAConfig
             var updaterOptionsPanel = new UpdaterOptionsPanel(WindowManager, UserINISettings.Instance);
             updaterOptionsPanel.OnForceUpdate += (s, e) => { Disable(); OnForceUpdate?.Invoke(this, EventArgs.Empty); };
 
-
             optionsPanels = new XNAOptionsPanel[]
             {
                 displayOptionsPanel,

--- a/DTAConfig/OptionsWindow.cs
+++ b/DTAConfig/OptionsWindow.cs
@@ -27,7 +27,6 @@ namespace DTAConfig
         private ComponentsPanel componentsPanel;
 
         private DisplayOptionsPanel displayOptionsPanel;
-        private GameFilterOptionsPanel gameFilterOptionsPanel;
         private XNAControl topBar;
 
         private GameCollection gameCollection;
@@ -35,7 +34,7 @@ namespace DTAConfig
         public override void Initialize()
         {
             Name = "OptionsWindow";
-            ClientRectangle = new Rectangle(0, 0, 668, 435);
+            ClientRectangle = new Rectangle(0, 0, 576, 435);
             BackgroundTexture = AssetLoader.LoadTextureUncached("optionsbg.png");
 
             tabControl = new XNAClientTabControl(WindowManager);
@@ -49,7 +48,6 @@ namespace DTAConfig
             tabControl.AddTab("CnCNet", UIDesignConstants.BUTTON_WIDTH_92);
             tabControl.AddTab("Updater", UIDesignConstants.BUTTON_WIDTH_92);
             tabControl.AddTab("Components", UIDesignConstants.BUTTON_WIDTH_92);
-            tabControl.AddTab("Game Filters", UIDesignConstants.BUTTON_WIDTH_92);
             tabControl.SelectedIndexChanged += TabControl_SelectedIndexChanged;
 
             var btnCancel = new XNAClientButton(WindowManager);
@@ -70,7 +68,6 @@ namespace DTAConfig
             var updaterOptionsPanel = new UpdaterOptionsPanel(WindowManager, UserINISettings.Instance);
             updaterOptionsPanel.OnForceUpdate += (s, e) => { Disable(); OnForceUpdate?.Invoke(this, EventArgs.Empty); };
 
-            gameFilterOptionsPanel = new GameFilterOptionsPanel(WindowManager, UserINISettings.Instance);
 
             optionsPanels = new XNAOptionsPanel[]
             {
@@ -79,8 +76,7 @@ namespace DTAConfig
                 new GameOptionsPanel(WindowManager, UserINISettings.Instance, topBar),
                 new CnCNetOptionsPanel(WindowManager, UserINISettings.Instance, gameCollection),
                 updaterOptionsPanel,
-                componentsPanel,
-                gameFilterOptionsPanel
+                componentsPanel
             };
 
             if (ClientConfiguration.Instance.ModMode || CUpdater.UPDATEMIRRORS == null || CUpdater.UPDATEMIRRORS.Count < 1)
@@ -293,12 +289,6 @@ namespace DTAConfig
 #if TS
             displayOptionsPanel.PostInit();
 #endif
-        }
-
-        public void ShowGameFilters()
-        {
-            tabControl.SelectedTab = 6;
-            Enable();
         }
     }
 }

--- a/DTAConfig/OptionsWindow.cs
+++ b/DTAConfig/OptionsWindow.cs
@@ -27,6 +27,7 @@ namespace DTAConfig
         private ComponentsPanel componentsPanel;
 
         private DisplayOptionsPanel displayOptionsPanel;
+        private GameFilterOptionsPanel gameFilterOptionsPanel;
         private XNAControl topBar;
 
         private GameCollection gameCollection;
@@ -34,7 +35,7 @@ namespace DTAConfig
         public override void Initialize()
         {
             Name = "OptionsWindow";
-            ClientRectangle = new Rectangle(0, 0, 576, 435);
+            ClientRectangle = new Rectangle(0, 0, 668, 435);
             BackgroundTexture = AssetLoader.LoadTextureUncached("optionsbg.png");
 
             tabControl = new XNAClientTabControl(WindowManager);
@@ -42,24 +43,25 @@ namespace DTAConfig
             tabControl.ClientRectangle = new Rectangle(12, 12, 0, 23);
             tabControl.FontIndex = 1;
             tabControl.ClickSound = new EnhancedSoundEffect("button.wav");
-            tabControl.AddTab("Display", 92);
-            tabControl.AddTab("Audio", 92);
-            tabControl.AddTab("Game", 92);
-            tabControl.AddTab("CnCNet", 92);
-            tabControl.AddTab("Updater", 92);
-            tabControl.AddTab("Components", 92);
+            tabControl.AddTab("Display", UIDesignConstants.BUTTON_WIDTH_92);
+            tabControl.AddTab("Audio", UIDesignConstants.BUTTON_WIDTH_92);
+            tabControl.AddTab("Game", UIDesignConstants.BUTTON_WIDTH_92);
+            tabControl.AddTab("CnCNet", UIDesignConstants.BUTTON_WIDTH_92);
+            tabControl.AddTab("Updater", UIDesignConstants.BUTTON_WIDTH_92);
+            tabControl.AddTab("Components", UIDesignConstants.BUTTON_WIDTH_92);
+            tabControl.AddTab("Game Filters", UIDesignConstants.BUTTON_WIDTH_92);
             tabControl.SelectedIndexChanged += TabControl_SelectedIndexChanged;
 
             var btnCancel = new XNAClientButton(WindowManager);
             btnCancel.Name = "btnCancel";
             btnCancel.ClientRectangle = new Rectangle(Width - 104,
-                Height - 35, 92, 23);
+                Height - 35, UIDesignConstants.BUTTON_WIDTH_92, UIDesignConstants.BUTTON_HEIGHT);
             btnCancel.Text = "Cancel";
             btnCancel.LeftClick += BtnBack_LeftClick;
 
             var btnSave = new XNAClientButton(WindowManager);
             btnSave.Name = "btnSave";
-            btnSave.ClientRectangle = new Rectangle(12, btnCancel.Y, 92, 23);
+            btnSave.ClientRectangle = new Rectangle(12, btnCancel.Y, UIDesignConstants.BUTTON_WIDTH_92, UIDesignConstants.BUTTON_HEIGHT);
             btnSave.Text = "Save";
             btnSave.LeftClick += BtnSave_LeftClick;
 
@@ -68,6 +70,8 @@ namespace DTAConfig
             var updaterOptionsPanel = new UpdaterOptionsPanel(WindowManager, UserINISettings.Instance);
             updaterOptionsPanel.OnForceUpdate += (s, e) => { Disable(); OnForceUpdate?.Invoke(this, EventArgs.Empty); };
 
+            gameFilterOptionsPanel = new GameFilterOptionsPanel(WindowManager, UserINISettings.Instance);
+
             optionsPanels = new XNAOptionsPanel[]
             {
                 displayOptionsPanel,
@@ -75,7 +79,8 @@ namespace DTAConfig
                 new GameOptionsPanel(WindowManager, UserINISettings.Instance, topBar),
                 new CnCNetOptionsPanel(WindowManager, UserINISettings.Instance, gameCollection),
                 updaterOptionsPanel,
-                componentsPanel
+                componentsPanel,
+                gameFilterOptionsPanel
             };
 
             if (ClientConfiguration.Instance.ModMode || CUpdater.UPDATEMIRRORS == null || CUpdater.UPDATEMIRRORS.Count < 1)
@@ -288,6 +293,12 @@ namespace DTAConfig
 #if TS
             displayOptionsPanel.PostInit();
 #endif
+        }
+
+        public void ShowGameFilters()
+        {
+            tabControl.SelectedTab = 6;
+            Enable();
         }
     }
 }

--- a/DXMainClient/DXGUI/Generic/CampaignSelector.cs
+++ b/DXMainClient/DXGUI/Generic/CampaignSelector.cs
@@ -145,7 +145,7 @@ namespace DTAClient.DXGUI.Generic
 
             btnLaunch = new XNAClientButton(WindowManager);
             btnLaunch.Name = "btnLaunch";
-            btnLaunch.ClientRectangle = new Rectangle(12, Height - 35, 133, 23);
+            btnLaunch.ClientRectangle = new Rectangle(12, Height - 35, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnLaunch.Text = "Launch";
             btnLaunch.AllowClick = false;
             btnLaunch.LeftClick += BtnLaunch_LeftClick;
@@ -153,7 +153,7 @@ namespace DTAClient.DXGUI.Generic
             var btnCancel = new XNAClientButton(WindowManager);
             btnCancel.Name = "btnCancel";
             btnCancel.ClientRectangle = new Rectangle(Width - 145,
-                btnLaunch.Y, 133, 23);
+                btnLaunch.Y, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnCancel.Text = "Cancel";
             btnCancel.LeftClick += BtnCancel_LeftClick;
 

--- a/DXMainClient/DXGUI/Generic/CheaterWindow.cs
+++ b/DXMainClient/DXGUI/Generic/CheaterWindow.cs
@@ -45,7 +45,7 @@ namespace DTAClient.DXGUI.Generic
             var btnCancel = new XNAClientButton(WindowManager);
             btnCancel.Name = "btnCancel";
             btnCancel.ClientRectangle = new Rectangle(Width - 104,
-                Height - 35, 92, 23);
+                Height - 35, UIDesignConstants.BUTTON_WIDTH_92, UIDesignConstants.BUTTON_HEIGHT);
             btnCancel.Text = "Cancel";
             btnCancel.LeftClick += BtnCancel_LeftClick;
 

--- a/DXMainClient/DXGUI/Generic/ExtrasWindow.cs
+++ b/DXMainClient/DXGUI/Generic/ExtrasWindow.cs
@@ -23,25 +23,25 @@ namespace DTAClient.DXGUI.Generic
 
             var btnExStatistics = new XNAClientButton(WindowManager);
             btnExStatistics.Name = "btnExStatistics";
-            btnExStatistics.ClientRectangle = new Rectangle(76, 17, 133, 23);
+            btnExStatistics.ClientRectangle = new Rectangle(76, 17, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnExStatistics.Text = "Statistics";
             btnExStatistics.LeftClick += BtnExStatistics_LeftClick;
 
             var btnExMapEditor = new XNAClientButton(WindowManager);
             btnExMapEditor.Name = "btnExMapEditor";
-            btnExMapEditor.ClientRectangle = new Rectangle(76, 59, 133, 23);
+            btnExMapEditor.ClientRectangle = new Rectangle(76, 59, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnExMapEditor.Text = "Map Editor";
             btnExMapEditor.LeftClick += BtnExMapEditor_LeftClick;
 
             var btnExCredits = new XNAClientButton(WindowManager);
             btnExCredits.Name = "btnExCredits";
-            btnExCredits.ClientRectangle = new Rectangle(76, 101, 133, 23);
+            btnExCredits.ClientRectangle = new Rectangle(76, 101, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnExCredits.Text = "Credits";
             btnExCredits.LeftClick += BtnExCredits_LeftClick;
 
             var btnExCancel = new XNAClientButton(WindowManager);
             btnExCancel.Name = "btnExCancel";
-            btnExCancel.ClientRectangle = new Rectangle(76, 160, 133, 23);
+            btnExCancel.ClientRectangle = new Rectangle(76, 160, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnExCancel.Text = "Cancel";
             btnExCancel.LeftClick += BtnExCancel_LeftClick;
 

--- a/DXMainClient/DXGUI/Generic/LoadingScreen.cs
+++ b/DXMainClient/DXGUI/Generic/LoadingScreen.cs
@@ -108,7 +108,7 @@ namespace DTAClient.DXGUI.Generic
                 topBar, cncnetManager, tunnelHandler, mapLoader.GameModes, gameCollection, discordHandler);
             var cncnetLobby = new CnCNetLobby(WindowManager, cncnetManager, 
                 cncnetGameLobby, cncnetGameLoadingLobby, topBar, pmWindow, tunnelHandler,
-                gameCollection, cncnetUserData);
+                gameCollection, cncnetUserData, optionsWindow);
             var gipw = new GameInProgressWindow(WindowManager);
 
             var skirmishLobby = new SkirmishLobby(WindowManager, topBar, mapLoader.GameModes, discordHandler);

--- a/DXMainClient/DXGUI/Generic/MainMenu.cs
+++ b/DXMainClient/DXGUI/Generic/MainMenu.cs
@@ -218,7 +218,7 @@ namespace DTAClient.DXGUI.Generic
             lblUpdateStatus = new XNALinkLabel(WindowManager);
             lblUpdateStatus.Name = nameof(lblUpdateStatus);
             lblUpdateStatus.LeftClick += LblUpdateStatus_LeftClick;
-            lblUpdateStatus.ClientRectangle = new Rectangle(0, 0, 160, 20);
+            lblUpdateStatus.ClientRectangle = new Rectangle(0, 0, UIDesignConstants.BUTTON_WIDTH_160, 20);
 
             AddChild(btnNewCampaign);
             AddChild(btnLoadGame);

--- a/DXMainClient/DXGUI/Generic/StatisticsWindow.cs
+++ b/DXMainClient/DXGUI/Generic/StatisticsWindow.cs
@@ -94,8 +94,8 @@ namespace DTAClient.DXGUI.Generic
             tabControl.ClientRectangle = new Rectangle(12, 10, 0, 0);
             tabControl.ClickSound = new EnhancedSoundEffect("button.wav");
             tabControl.FontIndex = 1;
-            tabControl.AddTab("Game Statistics", 133);
-            tabControl.AddTab("Total Statistics", 133);
+            tabControl.AddTab("Game Statistics", UIDesignConstants.BUTTON_WIDTH_133);
+            tabControl.AddTab("Total Statistics", UIDesignConstants.BUTTON_WIDTH_133);
             tabControl.SelectedIndexChanged += TabControl_SelectedIndexChanged;
 
             XNALabel lblFilter = new XNALabel(WindowManager);
@@ -128,13 +128,13 @@ namespace DTAClient.DXGUI.Generic
 
             var btnReturnToMenu = new XNAClientButton(WindowManager);
             btnReturnToMenu.Name = nameof(btnReturnToMenu);
-            btnReturnToMenu.ClientRectangle = new Rectangle(270, 486, 160, 23);
+            btnReturnToMenu.ClientRectangle = new Rectangle(270, 486, UIDesignConstants.BUTTON_WIDTH_160, UIDesignConstants.BUTTON_HEIGHT);
             btnReturnToMenu.Text = "Return to Main Menu";
             btnReturnToMenu.LeftClick += BtnReturnToMenu_LeftClick;
 
             var btnClearStatistics = new XNAClientButton(WindowManager);
             btnClearStatistics.Name = nameof(btnClearStatistics);
-            btnClearStatistics.ClientRectangle = new Rectangle(12, 486, 160, 23);
+            btnClearStatistics.ClientRectangle = new Rectangle(12, 486, UIDesignConstants.BUTTON_WIDTH_160, UIDesignConstants.BUTTON_HEIGHT);
             btnClearStatistics.Text = "Clear Statistics";
             btnClearStatistics.LeftClick += BtnClearStatistics_LeftClick;
             btnClearStatistics.Visible = false;

--- a/DXMainClient/DXGUI/Generic/TopBar.cs
+++ b/DXMainClient/DXGUI/Generic/TopBar.cs
@@ -122,19 +122,19 @@ namespace DTAClient.DXGUI.Generic
 
             btnMainButton = new XNAClientButton(WindowManager);
             btnMainButton.Name = "btnMainButton";
-            btnMainButton.ClientRectangle = new Rectangle(12, 9, 160, 23);
+            btnMainButton.ClientRectangle = new Rectangle(12, 9, UIDesignConstants.BUTTON_WIDTH_160, UIDesignConstants.BUTTON_HEIGHT);
             btnMainButton.Text = "Main Menu (F2)";
             btnMainButton.LeftClick += BtnMainButton_LeftClick;
 
             btnCnCNetLobby = new XNAClientButton(WindowManager);
             btnCnCNetLobby.Name = "btnCnCNetLobby";
-            btnCnCNetLobby.ClientRectangle = new Rectangle(184, 9, 160, 23);
+            btnCnCNetLobby.ClientRectangle = new Rectangle(184, 9, UIDesignConstants.BUTTON_WIDTH_160, UIDesignConstants.BUTTON_HEIGHT);
             btnCnCNetLobby.Text = "CnCNet Lobby (F3)";
             btnCnCNetLobby.LeftClick += BtnCnCNetLobby_LeftClick;
 
             btnPrivateMessages = new XNAClientButton(WindowManager);
             btnPrivateMessages.Name = "btnPrivateMessages";
-            btnPrivateMessages.ClientRectangle = new Rectangle(356, 9, 160, 23);
+            btnPrivateMessages.ClientRectangle = new Rectangle(356, 9, UIDesignConstants.BUTTON_WIDTH_160, UIDesignConstants.BUTTON_HEIGHT);
             btnPrivateMessages.Text = "Private Messages (F4)";
             btnPrivateMessages.LeftClick += BtnPrivateMessages_LeftClick;
 

--- a/DXMainClient/DXGUI/Generic/UpdateWindow.cs
+++ b/DXMainClient/DXGUI/Generic/UpdateWindow.cs
@@ -111,7 +111,7 @@ namespace DTAClient.DXGUI.Generic
             lblUpdaterStatus.ClientRectangle = new Rectangle(12, 240, 0, 0);
 
             var btnCancel = new XNAClientButton(WindowManager);
-            btnCancel.ClientRectangle = new Rectangle(301, 240, 133, 23);
+            btnCancel.ClientRectangle = new Rectangle(301, 240, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnCancel.Text = "Cancel";
             btnCancel.LeftClick += BtnCancel_LeftClick;
 

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetGameLoadingLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetGameLoadingLobby.cs
@@ -120,7 +120,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             btnChangeTunnel = new XNAClientButton(WindowManager);
             btnChangeTunnel.Name = nameof(btnChangeTunnel);
             btnChangeTunnel.ClientRectangle = new Rectangle(btnLeaveGame.Right - btnLeaveGame.Width - 145,
-                btnLeaveGame.Y, 133, 23);
+                btnLeaveGame.Y, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnChangeTunnel.Text = "Change Tunnel";
             btnChangeTunnel.LeftClick += BtnChangeTunnel_LeftClick;
             AddChild(btnChangeTunnel);

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/GameCreationWindow.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/GameCreationWindow.cs
@@ -97,7 +97,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             btnDisplayAdvancedOptions = new XNAClientButton(WindowManager);
             btnDisplayAdvancedOptions.Name = nameof(btnDisplayAdvancedOptions);
             btnDisplayAdvancedOptions.ClientRectangle = new Rectangle(UIDesignConstants.EMPTY_SPACE_SIDES +
-                UIDesignConstants.CONTROL_HORIZONTAL_MARGIN, lblPassword.Bottom + UIDesignConstants.CONTROL_VERTICAL_MARGIN * 3, 160, 23);
+                UIDesignConstants.CONTROL_HORIZONTAL_MARGIN, lblPassword.Bottom + UIDesignConstants.CONTROL_VERTICAL_MARGIN * 3, UIDesignConstants.BUTTON_WIDTH_160, UIDesignConstants.BUTTON_HEIGHT);
             btnDisplayAdvancedOptions.Text = "Advanced Options";
             btnDisplayAdvancedOptions.LeftClick += BtnDisplayAdvancedOptions_LeftClick;
 

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/PasswordRequestWindow.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/PasswordRequestWindow.cs
@@ -45,14 +45,14 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             var btnOK = new XNAClientButton(WindowManager);
             btnOK.Name = "btnOK";
             btnOK.ClientRectangle = new Rectangle(lblDescription.X,
-                ClientRectangle.Bottom - 35, 92, 23);
+                ClientRectangle.Bottom - 35, UIDesignConstants.BUTTON_WIDTH_92, UIDesignConstants.BUTTON_HEIGHT);
             btnOK.Text = "OK";
             btnOK.LeftClick += BtnOK_LeftClick;
 
             var btnCancel = new XNAClientButton(WindowManager);
             btnCancel.Name = "btnCancel";
             btnCancel.ClientRectangle = new Rectangle(Width - 104,
-                btnOK.Y, 92, 23);
+                btnOK.Y, UIDesignConstants.BUTTON_WIDTH_92, UIDesignConstants.BUTTON_HEIGHT);
             btnCancel.Text = "Cancel";
             btnCancel.LeftClick += BtnCancel_LeftClick;
 

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/PrivateMessagingWindow.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/PrivateMessagingWindow.cs
@@ -113,9 +113,9 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             tabControl.ClientRectangle = new Rectangle(60, 50, 0, 0);
             tabControl.ClickSound = new EnhancedSoundEffect("button.wav");
             tabControl.FontIndex = 1;
-            tabControl.AddTab("Messages", 160);
-            tabControl.AddTab("Friend List", 160);
-            tabControl.AddTab("All Players", 160);
+            tabControl.AddTab("Messages", UIDesignConstants.BUTTON_WIDTH_160);
+            tabControl.AddTab("Friend List", UIDesignConstants.BUTTON_WIDTH_160);
+            tabControl.AddTab("All Players", UIDesignConstants.BUTTON_WIDTH_160);
             tabControl.SelectedIndexChanged += TabControl_SelectedIndexChanged;
 
             lblPlayers = new XNALabel(WindowManager);

--- a/DXMainClient/DXGUI/Multiplayer/GameFiltersPanel.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameFiltersPanel.cs
@@ -5,24 +5,21 @@ using Microsoft.Xna.Framework;
 using Rampastring.XNAUI;
 using Rampastring.XNAUI.XNAControls;
 
-namespace DTAConfig.OptionPanels
+namespace DTAClient.DXGUI.Multiplayer
 {
-    class GameFilterOptionsPanel : XNAOptionsPanel
+    public class GameFiltersPanel : XNAPanel
     {
         private const int minPlayerCount = 2;
         private const int maxPlayerCount = 8;
 
-        private XNAClientCheckBox chkBoxSortAlpha;
         private XNAClientCheckBox chkBoxFriendsOnly;
         private XNAClientCheckBox chkBoxHideLockedGames;
         private XNAClientCheckBox chkBoxHidePasswordedGames;
         private XNAClientCheckBox chkBoxHideIncompatibleGames;
         private XNAClientDropDown ddMaxPlayerCount;
-        private UserINISettings userIniSettings;
 
-        public GameFilterOptionsPanel(WindowManager windowManager, UserINISettings userIniSettings) : base(windowManager, userIniSettings)
+        public GameFiltersPanel(WindowManager windowManager) : base(windowManager)
         {
-            this.userIniSettings = userIniSettings;
         }
 
         public override void Initialize()
@@ -30,22 +27,22 @@ namespace DTAConfig.OptionPanels
             base.Initialize();
 
             Name = "GameFiltersWindow";
+            BackgroundTexture = AssetLoader.CreateTexture(new Color(0, 0, 0), Width, Height);
 
             const int gap = 12;
 
-            chkBoxSortAlpha = new XNAClientCheckBox(WindowManager);
-            chkBoxSortAlpha.Name = nameof(chkBoxSortAlpha);
-            chkBoxSortAlpha.Text = "Sort Alphabetically";
-            chkBoxSortAlpha.ClientRectangle = new Rectangle(
-                gap, gap,
-                0, 0
+            var lblTitle = new XNALabel(WindowManager);
+            lblTitle.Name = nameof(lblTitle);
+            lblTitle.Text = "Game Filters";
+            lblTitle.ClientRectangle = new Rectangle(
+                gap, gap, 120, UIDesignConstants.BUTTON_HEIGHT
             );
 
             chkBoxFriendsOnly = new XNAClientCheckBox(WindowManager);
             chkBoxFriendsOnly.Name = nameof(chkBoxFriendsOnly);
             chkBoxFriendsOnly.Text = "Show Friend Games Only";
             chkBoxFriendsOnly.ClientRectangle = new Rectangle(
-                gap, chkBoxSortAlpha.Y + UIDesignConstants.BUTTON_HEIGHT + gap,
+                gap, lblTitle.Y + UIDesignConstants.BUTTON_HEIGHT + gap,
                 0, 0
             );
 
@@ -99,9 +96,27 @@ namespace DTAConfig.OptionPanels
                 gap, ddMaxPlayerCount.Y + UIDesignConstants.BUTTON_HEIGHT + gap,
                 UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT
             );
-            btnResetDefaults.LeftClick += ResetDefaults;
+            btnResetDefaults.LeftClick += BtnResetDefaults_LeftClick;
 
-            AddChild(chkBoxSortAlpha);
+            var btnSave = new XNAClientButton(WindowManager);
+            btnSave.Name = nameof(btnSave);
+            btnSave.Text = "Save";
+            btnSave.ClientRectangle = new Rectangle(
+                gap, btnResetDefaults.Y + UIDesignConstants.BUTTON_HEIGHT + gap,
+                UIDesignConstants.BUTTON_WIDTH_92, UIDesignConstants.BUTTON_HEIGHT
+            );
+            btnSave.LeftClick += BtnSave_LeftClick;
+
+            var btnCancel = new XNAClientButton(WindowManager);
+            btnCancel.Name = nameof(btnCancel);
+            btnCancel.Text = "Cancel";
+            btnCancel.ClientRectangle = new Rectangle(
+                Width - gap - UIDesignConstants.BUTTON_WIDTH_92, btnSave.Y,
+                UIDesignConstants.BUTTON_WIDTH_92, UIDesignConstants.BUTTON_HEIGHT
+            );
+            btnCancel.LeftClick += BtnCancel_LeftClick;
+
+            AddChild(lblTitle);
             AddChild(chkBoxFriendsOnly);
             AddChild(chkBoxHideLockedGames);
             AddChild(chkBoxHidePasswordedGames);
@@ -109,25 +124,41 @@ namespace DTAConfig.OptionPanels
             AddChild(lblMaxPlayerCount);
             AddChild(ddMaxPlayerCount);
             AddChild(btnResetDefaults);
+            AddChild(btnSave);
+            AddChild(btnCancel);
         }
 
-        public override bool Save()
+        private void BtnSave_LeftClick(object sender, EventArgs e)
         {
-            userIniSettings.SortAlpha.Value = chkBoxSortAlpha.Checked;
+            Save();
+            Disable();
+        }
+
+        private void BtnCancel_LeftClick(object sender, EventArgs e)
+        {
+            Disable();
+        }
+
+        private void BtnResetDefaults_LeftClick(object sender, EventArgs e)
+        {
+            ResetDefaults();
+        }
+
+        private void Save()
+        {
+            var userIniSettings = UserINISettings.Instance;
             userIniSettings.ShowFriendGamesOnly.Value = chkBoxFriendsOnly.Checked;
             userIniSettings.HideLockedGames.Value = chkBoxHideLockedGames.Checked;
             userIniSettings.HidePasswordedGames.Value = chkBoxHidePasswordedGames.Checked;
             userIniSettings.HideIncompatibleGames.Value = chkBoxHideIncompatibleGames.Checked;
             userIniSettings.MaxPlayerCount.Value = int.Parse(ddMaxPlayerCount.SelectedItem.Text);
-
-            return false;
+            
+            UserINISettings.Instance.SaveSettings();
         }
 
-        public override void Load()
+        private void Load()
         {
-            base.Load();
-
-            chkBoxSortAlpha.Checked = userIniSettings.SortAlpha.Value;
+            var userIniSettings = UserINISettings.Instance;
             chkBoxFriendsOnly.Checked = userIniSettings.ShowFriendGamesOnly.Value;
             chkBoxHideLockedGames.Checked = userIniSettings.HideLockedGames.Value;
             chkBoxHidePasswordedGames.Checked = userIniSettings.HidePasswordedGames.Value;
@@ -135,10 +166,16 @@ namespace DTAConfig.OptionPanels
             ddMaxPlayerCount.SelectedIndex = ddMaxPlayerCount.Items.FindIndex(i => i.Text == userIniSettings.MaxPlayerCount.Value.ToString());
         }
 
-        public void ResetDefaults(object sender, EventArgs e)
+        private void ResetDefaults()
         {
-            userIniSettings.ResetGameFilters();
+            UserINISettings.Instance.ResetGameFilters();
             Load();
+        }
+
+        public void Show()
+        {
+            Load();
+            Enable();
         }
     }
 }

--- a/DXMainClient/DXGUI/Multiplayer/GameListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameListBox.cs
@@ -1,13 +1,12 @@
-﻿using Rampastring.XNAUI.XNAControls;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using Rampastring.XNAUI;
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
-using DTAClient.Domain.Multiplayer;
 using System.Linq;
 using ClientCore;
-using DTAClient.Domain;
+using DTAClient.Domain.Multiplayer;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Rampastring.XNAUI;
+using Rampastring.XNAUI.XNAControls;
 
 namespace DTAClient.DXGUI.Multiplayer
 {
@@ -76,15 +75,9 @@ namespace DTAClient.DXGUI.Multiplayer
         {
             Items.Clear();
 
-            if (GameMatchesFilter != null)
-            {
-                foreach (var hg in HostedGames)
-                {
-                    if (GameMatchesFilter(hg))
-                        AddGameToList(hg);
-                }
-            }
-            else HostedGames.ForEach(AddGameToList);
+            GetSortedAndFilteredGames()
+                .ToList()
+                .ForEach(AddGameToList);
 
             GameListBox_HoveredIndexChanged(this, EventArgs.Empty);
         }
@@ -103,15 +96,32 @@ namespace DTAClient.DXGUI.Multiplayer
 
             HostedGames.Add(game);
 
-            HostedGames = HostedGames.OrderBy(hg => hg.Passworded).OrderBy(hg =>
-                hg.GameVersion != ProgramConstants.GAME_VERSION).OrderBy(hg =>
-                hg.Game.InternalName.ToUpper() == localGameIdentifier.ToUpper()).OrderBy(hg =>
-                hg.Locked).ToList();
-
             Refresh();
 
             if (selectedGame != null)
                 SelectedIndex = HostedGames.FindIndex(hg => hg == selectedGame);
+        }
+
+        private IEnumerable<GenericHostedGame> GetSortedAndFilteredGames()
+        {
+            var sortedGames = GetSortedGames();
+
+            return GameMatchesFilter == null ? sortedGames : sortedGames.Where(hg => GameMatchesFilter(hg));
+        }
+
+        private IEnumerable<GenericHostedGame> GetSortedGames()
+        {
+            var sortedGames =
+                HostedGames
+                    .OrderBy(hg => hg.Locked)
+                    .ThenBy(hg => string.Equals(hg.Game.InternalName, localGameIdentifier, StringComparison.CurrentCultureIgnoreCase))
+                    .ThenBy(hg => hg.GameVersion != ProgramConstants.GAME_VERSION)
+                    .ThenBy(hg => hg.Passworded);
+            
+            if (UserINISettings.Instance.SortAlpha)
+                sortedGames = sortedGames.ThenBy(hg => hg.RoomName);
+
+            return sortedGames;
         }
 
         /// <summary>
@@ -124,17 +134,6 @@ namespace DTAClient.DXGUI.Multiplayer
             {
                 selectedGame = HostedGames[SelectedIndex];
             }
-
-            var orderedGames = HostedGames
-                .OrderBy(hg => hg.Locked)
-                .ThenBy(hg => string.Equals(hg.Game.InternalName, localGameIdentifier, StringComparison.CurrentCultureIgnoreCase))
-                .ThenBy(hg => hg.GameVersion != ProgramConstants.GAME_VERSION)
-                .ThenBy(hg => hg.Passworded);
-
-            if (UserINISettings.Instance.SortAlpha)
-                orderedGames = orderedGames.ThenBy(hg => hg.RoomName);
-
-            HostedGames = orderedGames.ToList();
 
             Refresh();
 

--- a/DXMainClient/DXGUI/Multiplayer/GameListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameListBox.cs
@@ -7,6 +7,7 @@ using Microsoft.Xna.Framework.Graphics;
 using DTAClient.Domain.Multiplayer;
 using System.Linq;
 using ClientCore;
+using DTAClient.Domain;
 
 namespace DTAClient.DXGUI.Multiplayer
 {
@@ -124,10 +125,16 @@ namespace DTAClient.DXGUI.Multiplayer
                 selectedGame = HostedGames[SelectedIndex];
             }
 
-            HostedGames = HostedGames.OrderBy(hg => hg.Passworded).OrderBy(hg =>
-                hg.GameVersion != ProgramConstants.GAME_VERSION).OrderBy(hg =>
-                hg.Game.InternalName.ToUpper() == localGameIdentifier.ToUpper()).OrderBy(hg =>
-                hg.Locked).ToList();
+            var orderedGames = HostedGames
+                .OrderBy(hg => hg.Locked)
+                .ThenBy(hg => string.Equals(hg.Game.InternalName, localGameIdentifier, StringComparison.CurrentCultureIgnoreCase))
+                .ThenBy(hg => hg.GameVersion != ProgramConstants.GAME_VERSION)
+                .ThenBy(hg => hg.Passworded);
+
+            if (UserINISettings.Instance.SortAlpha)
+                orderedGames = orderedGames.ThenBy(hg => hg.RoomName);
+
+            HostedGames = orderedGames.ToList();
 
             Refresh();
 

--- a/DXMainClient/DXGUI/Multiplayer/GameLoadingLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLoadingLobbyBase.cs
@@ -165,14 +165,14 @@ namespace DTAClient.DXGUI.Multiplayer
             btnLoadGame = new XNAClientButton(WindowManager);
             btnLoadGame.Name = nameof(btnLoadGame);
             btnLoadGame.ClientRectangle = new Rectangle(lbChatMessages.X,
-                tbChatInput.Bottom + 6, 133, 23);
+                tbChatInput.Bottom + 6, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnLoadGame.Text = "Load Game";
             btnLoadGame.LeftClick += BtnLoadGame_LeftClick;
 
             btnLeaveGame = new XNAClientButton(WindowManager);
             btnLeaveGame.Name = nameof(btnLeaveGame);
             btnLeaveGame.ClientRectangle = new Rectangle(Width - 145,
-                btnLoadGame.Y, 133, 23);
+                btnLoadGame.Y, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnLeaveGame.Text = "Leave Game";
             btnLeaveGame.LeftClick += BtnLeaveGame_LeftClick;
 

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -143,7 +143,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             btnChangeTunnel = new XNAClientButton(WindowManager);
             btnChangeTunnel.Name = nameof(btnChangeTunnel);
             btnChangeTunnel.ClientRectangle = new Rectangle(btnLeaveGame.Right - btnLeaveGame.Width - 145,
-                btnLeaveGame.Y, 133, 23);
+                btnLeaveGame.Y, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnChangeTunnel.Text = "Change Tunnel";
             btnChangeTunnel.LeftClick += BtnChangeTunnel_LeftClick;
             AddChild(btnChangeTunnel);

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -200,13 +200,13 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             btnLeaveGame = new XNAClientButton(WindowManager);
             btnLeaveGame.Name = "btnLeaveGame";
-            btnLeaveGame.ClientRectangle = new Rectangle(Width - 143, Height - 28, 133, 23);
+            btnLeaveGame.ClientRectangle = new Rectangle(Width - 143, Height - 28, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnLeaveGame.Text = "Leave Game";
             btnLeaveGame.LeftClick += BtnLeaveGame_LeftClick;
 
             btnLaunchGame = new GameLaunchButton(WindowManager, RankTextures);
             btnLaunchGame.Name = "btnLaunchGame";
-            btnLaunchGame.ClientRectangle = new Rectangle(12, btnLeaveGame.Y, 133, 23);
+            btnLaunchGame.ClientRectangle = new Rectangle(12, btnLeaveGame.Y, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnLaunchGame.Text = "Launch Game";
             btnLaunchGame.LeftClick += BtnLaunchGame_LeftClick;
 
@@ -307,7 +307,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             btnPickRandomMap = new XNAClientButton(WindowManager);
             btnPickRandomMap.Name = "btnPickRandomMap";
-            btnPickRandomMap.ClientRectangle = new Rectangle(btnLaunchGame.Right + 157 , btnLaunchGame.Y, 133, 23);
+            btnPickRandomMap.ClientRectangle = new Rectangle(btnLaunchGame.Right + 157 , btnLaunchGame.Y, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnPickRandomMap.Text = "Pick Random Map";
             btnPickRandomMap.LeftClick += BtnPickRandomMap_LeftClick;
             btnPickRandomMap.Disable();

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
@@ -191,14 +191,14 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             btnLockGame = new XNAClientButton(WindowManager);
             btnLockGame.Name = "btnLockGame";
             btnLockGame.ClientRectangle = new Rectangle(btnLaunchGame.Right + 12,
-                btnLaunchGame.Y, 133, 23);
+                btnLaunchGame.Y, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnLockGame.Text = "Lock Game";
             btnLockGame.LeftClick += BtnLockGame_LeftClick;
 
             chkAutoReady = new XNAClientCheckBox(WindowManager);
             chkAutoReady.Name = "chkAutoReady";
             chkAutoReady.ClientRectangle = new Rectangle(btnLaunchGame.Right + 12,
-                btnLaunchGame.Y + 2, 133, 23);
+                btnLaunchGame.Y + 2, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             chkAutoReady.Text = "Auto-Ready";
             chkAutoReady.CheckedChanged += ChkAutoReady_CheckedChanged;
             chkAutoReady.Disable();

--- a/DXMainClient/DXGUI/Multiplayer/LANGameCreationWindow.cs
+++ b/DXMainClient/DXGUI/Multiplayer/LANGameCreationWindow.cs
@@ -50,7 +50,7 @@ namespace DTAClient.DXGUI.Multiplayer
 
             btnNewGame = new XNAButton(WindowManager);
             btnNewGame.Name = "btnNewGame";
-            btnNewGame.ClientRectangle = new Rectangle(12, 42, 133, 23);
+            btnNewGame.ClientRectangle = new Rectangle(12, 42, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnNewGame.IdleTexture = AssetLoader.LoadTexture("133pxbtn.png");
             btnNewGame.HoverTexture = AssetLoader.LoadTexture("133pxbtn_c.png");
             btnNewGame.FontIndex = 1;
@@ -61,7 +61,7 @@ namespace DTAClient.DXGUI.Multiplayer
             btnLoadGame = new XNAButton(WindowManager);
             btnLoadGame.Name = "btnLoadGame";
             btnLoadGame.ClientRectangle = new Rectangle(btnNewGame.Right + 12,
-                btnNewGame.Y, 133, 23);
+                btnNewGame.Y, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnLoadGame.IdleTexture = btnNewGame.IdleTexture;
             btnLoadGame.HoverTexture = btnNewGame.HoverTexture;
             btnLoadGame.FontIndex = 1;

--- a/DXMainClient/DXGUI/Multiplayer/LANLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/LANLobby.cs
@@ -104,21 +104,21 @@ namespace DTAClient.DXGUI.Multiplayer
 
             btnNewGame = new XNAClientButton(WindowManager);
             btnNewGame.Name = "btnNewGame";
-            btnNewGame.ClientRectangle = new Rectangle(12, Height - 35, 133, 23);
+            btnNewGame.ClientRectangle = new Rectangle(12, Height - 35, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnNewGame.Text = "Create Game";
             btnNewGame.LeftClick += BtnNewGame_LeftClick;
 
             btnJoinGame = new XNAClientButton(WindowManager);
             btnJoinGame.Name = "btnJoinGame";
             btnJoinGame.ClientRectangle = new Rectangle(btnNewGame.Right + 12,
-                btnNewGame.Y, 133, 23);
+                btnNewGame.Y, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnJoinGame.Text = "Join Game";
             btnJoinGame.LeftClick += BtnJoinGame_LeftClick;
 
             btnMainMenu = new XNAClientButton(WindowManager);
             btnMainMenu.Name = "btnMainMenu";
             btnMainMenu.ClientRectangle = new Rectangle(Width - 145,
-                btnNewGame.Y, 133, 23);
+                btnNewGame.Y, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnMainMenu.Text = "Main Menu";
             btnMainMenu.LeftClick += BtnMainMenu_LeftClick;
 

--- a/DXMainClient/DXMainClient.csproj
+++ b/DXMainClient/DXMainClient.csproj
@@ -472,6 +472,7 @@
     <Compile Include="DXGUI\Multiplayer\CnCNet\PlayerContextMenu.cs" />
     <Compile Include="DXGUI\Multiplayer\CnCNet\TunnelListBox.cs" />
     <Compile Include="DXGUI\Multiplayer\CnCNet\TunnelSelectionWindow.cs" />
+    <Compile Include="DXGUI\Multiplayer\GameFiltersPanel.cs" />
     <Compile Include="DXGUI\Multiplayer\GameInformationPanel.cs" />
     <Compile Include="DXGUI\Generic\GameInProgressWindow.cs" />
     <Compile Include="DXGUI\Multiplayer\GameListBox.cs" />


### PR DESCRIPTION
This provides options for a few things:

- sort alphabetically
- show friend games only
- hide locked games
- hide passworded games
- hide incompatible games
- max player count

It creates a new panel that appears on top of the game list. This panel is where you'll find controls to modify the filters above.

There are two buttons added above the Game List as well. These buttons are a toggle button to quickly enable alphabetical sort and a button to quickly open the game filters panel on top of the game list. This filters toggle button will appear toggled "on" when there are filters enabled that are not the defaults.

All filter settings are stored to the settings ini (ra2md.ini).

The icons required for these new toggle buttons are located in the cncnet-yr-client-package:
https://github.com/CnCNet/cncnet-yr-client-package/pull/46