### PR TITLE
Favorite maps list

### DIFF
--- a/ClientCore/ClientCore.csproj
+++ b/ClientCore/ClientCore.csproj
@@ -260,6 +260,7 @@
     <Compile Include="SavedGameManager.cs" />
     <Compile Include="Settings\IIniSetting.cs" />
     <Compile Include="Settings\IntRangeSetting.cs" />
+    <Compile Include="Settings\StringListSetting.cs" />
     <Compile Include="Settings\UserINISettings.cs" />
     <Compile Include="Settings\BoolSetting.cs" />
     <Compile Include="Settings\DoubleSetting.cs" />

--- a/ClientCore/Settings/StringListSetting.cs
+++ b/ClientCore/Settings/StringListSetting.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Rampastring.Tools;
+
+namespace ClientCore.Settings
+{
+    /// <summary>
+    /// This is a setting that can be stored as a comma separated list of strings.
+    /// </summary>
+    public class StringListSetting : INISetting<List<string>>
+    {
+        public StringListSetting(IniFile iniFile, string iniSection, string iniKey, List<string> defaultValue) : base(iniFile, iniSection, iniKey, defaultValue)
+        {
+        }
+
+        protected override List<string> Get()
+        {
+            string value = IniFile.GetStringValue(IniSection, IniKey, "");
+            return string.IsNullOrWhiteSpace(value) ? DefaultValue : value.Split(',').ToList();
+        }
+
+        protected override void Set(List<string> value)
+        {
+            IniFile.SetStringValue(IniSection, IniKey, string.Join(",", value));
+        }
+
+        public override void Write()
+        {
+            IniFile.SetStringValue(IniSection, IniKey, string.Join(",", Get()));
+        }
+    }
+}

--- a/ClientCore/Settings/UserINISettings.cs
+++ b/ClientCore/Settings/UserINISettings.cs
@@ -1,6 +1,7 @@
 ﻿using ClientCore.Settings;
 using Rampastring.Tools;
 using System;
+using System.Collections.Generic;
 using System.Windows.Forms;
 
 namespace ClientCore
@@ -125,6 +126,8 @@ namespace ClientCore
             HidePasswordedGames = new BoolSetting(iniFile, GAME_FILTERS, "HidePasswordedGames", DEFAULT_HIDE_PASSWORDED_GAMES);
             HideIncompatibleGames = new BoolSetting(iniFile, GAME_FILTERS, "HideIncompatibleGames", DEFAULT_HIDE_INCOMPATIBLE_GAMES);
             MaxPlayerCount = new IntRangeSetting(iniFile, GAME_FILTERS, "MaxPlayerCount", DEFAULT_MAX_PLAYER_COUNT, 2, 8);
+
+            FavoriteMapSHAs = new StringListSetting(iniFile, OPTIONS, "FavoriteMapSHAs", new List<string>());
         }
 
         public IniFile SettingsIni { get; private set; }
@@ -242,11 +245,30 @@ namespace ClientCore
 
         public BoolSetting AutoRemoveUnderscoresFromName { get; private set; }
         
+        public StringListSetting FavoriteMapSHAs { get; private set; }
+        
         public bool IsGameFollowed(string gameName)
         {
             return SettingsIni.GetBooleanValue("Channels", gameName, false);
         }
 
+        public void ToggleFavoriteMap(string mapSHA)
+        {
+            if (string.IsNullOrEmpty(mapSHA))
+                return;
+            
+            if (!IsFavoriteMap(mapSHA))
+                FavoriteMapSHAs.Value.Add(mapSHA);
+            else
+                FavoriteMapSHAs.Value.Remove(mapSHA);
+        }
+
+        /// <summary>
+        /// Checks if a specified map SHA belongs to the favorite map list.
+        /// </summary>
+        /// <param name="mapSha">The SHA of the map.</param>
+        public bool IsFavoriteMap(string mapSha) => FavoriteMapSHAs.Value.Contains(mapSha);
+        
         public void ReloadSettings()
         {
             SettingsIni.Reload();

--- a/ClientCore/Settings/UserINISettings.cs
+++ b/ClientCore/Settings/UserINISettings.cs
@@ -261,6 +261,8 @@ namespace ClientCore
                 FavoriteMapSHAs.Value.Add(mapSHA);
             else
                 FavoriteMapSHAs.Value.Remove(mapSHA);
+            
+            Instance.SaveSettings();
         }
 
         /// <summary>

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
@@ -187,7 +187,6 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         private void BtnFavMap_LeftClick(object sender, EventArgs e)
         {
             UserINISettings.Instance.ToggleFavoriteMap(Map.SHA1);
-            UserINISettings.Instance.SaveSettings();
             UpdateFavoriteMapBtn();
             LeftClickFavoriteMapBtn?.Invoke(sender, e);
         }

--- a/DXMainClient/Domain/Multiplayer/Map.cs
+++ b/DXMainClient/Domain/Multiplayer/Map.cs
@@ -29,7 +29,7 @@ namespace DTAClient.Domain.Multiplayer
     /// <summary>
     /// A multiplayer map.
     /// </summary>
-    public class Map
+    public class Map: IEquatable<Map>
     {
         private const int MAX_PLAYERS = 8;
 
@@ -708,6 +708,9 @@ namespace DTAClient.Domain.Multiplayer
             return new Point(pixelX, pixelY);
         }
 
-
+        public bool Equals(Map other)
+        {
+            return string.Equals(SHA1, other.SHA1, StringComparison.InvariantCultureIgnoreCase);
+        }
     }
 }


### PR DESCRIPTION
This allows any user to mark a map as a favorite when in any game lobby. 

Favorite maps are stored as a comma separated list of SHAs in the user settings ini file.

There is a new star icon button on the map preview box in the upper right hand corner. When the currently selected map is NOT a favorite, the star icon button appears "empty". When the current selected map IS a favorite, the star icon button appears "full".

The game mode drop down has an item inserted into the first position titled "Favorites". When selected, only maps that are marked as favorites will appear in the map list.

I will post screen shots.