### PR TITLE
Fix game information panel not showing up with latest XNAUI

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameInformationPanel.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameInformationPanel.cs
@@ -17,14 +17,14 @@ namespace DTAClient.DXGUI.Multiplayer
             DrawMode = ControlDrawMode.UNIQUE_RENDER_TARGET;
         }
 
-        XNALabel lblGameInformation;
-        XNALabel lblGameMode;
-        XNALabel lblMap;
-        XNALabel lblGameVersion;
-        XNALabel lblHost;
-        XNALabel lblPing;
-        XNALabel lblPlayers;
-        XNALabel[] lblPlayerNames;
+        private XNALabel lblGameInformation;
+        private XNALabel lblGameMode;
+        private XNALabel lblMap;
+        private XNALabel lblGameVersion;
+        private XNALabel lblHost;
+        private XNALabel lblPing;
+        private XNALabel lblPlayers;
+        private XNALabel[] lblPlayerNames;
 
         public override void Initialize()
         {

--- a/DXMainClient/DXGUI/Multiplayer/GameListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameListBox.cs
@@ -147,10 +147,10 @@ namespace DTAClient.DXGUI.Multiplayer
             HostedGames.Clear();
         }
 
-        protected override int GetRenderTargetWidth() => Width + panelGameInformation.Width;
-
         public override void Initialize()
         {
+            base.Initialize();
+
             txLockedGame = AssetLoader.LoadTexture("lockedgame.png");
             txIncompatibleGame = AssetLoader.LoadTexture("incompatible.png");
             txPasswordedGame = AssetLoader.LoadTexture("passwordedgame.png");
@@ -164,14 +164,12 @@ namespace DTAClient.DXGUI.Multiplayer
             panelGameInformation.Disable();
             panelGameInformation.InputEnabled = false;
             panelGameInformation.Alpha = 0f;
-            AddChild(panelGameInformation);
+            Parent.AddChild(panelGameInformation); // make this a child of our parent so it's not drawn on our rendertarget
 
             HoveredIndexChanged += GameListBox_HoveredIndexChanged;
 
             hoverOnGameColor = AssetLoader.GetColorFromString(
                 ClientConfiguration.Instance.HoverOnGameColor);
-
-            base.Initialize();
 
             loadedGameTextWidth = (int)Renderer.GetTextDimensions(LOADED_GAME_TEXT, FontIndex).X;
         }
@@ -185,8 +183,8 @@ namespace DTAClient.DXGUI.Multiplayer
             }
 
             panelGameInformation.Enable();
-            panelGameInformation.X = Width;
-            panelGameInformation.Y = Math.Min((HoveredIndex - TopIndex) * LineHeight,
+            panelGameInformation.X = Right;
+            panelGameInformation.Y = Y + Math.Min((HoveredIndex - TopIndex) * LineHeight,
                          Height - panelGameInformation.Height);
 
             panelGameInformation.AlphaRate = 0.5f;


### PR DESCRIPTION
As the title says, fixes the game information panel not showing up with latest XNAUI by making the game information panel a child of the CnCNet / LAN lobby instead of the game list box.

I've confirmed the fix to work properly in DTA's fork of the client, but it's best to test it before merging anyway in case I made some mistake in porting over the code.