### PR TITLE
Close game filter panel from game filter button

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
@@ -376,7 +376,10 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
         private void BtnGameFilterOptions_LeftClick(object sender, EventArgs e)
         {
-            panelGameFilters.Show();
+            if (panelGameFilters.Visible)
+                panelGameFilters.Cancel();
+            else
+                panelGameFilters.Show();
         }
 
         private void RefreshGameSortAlphaBtn()

--- a/DXMainClient/DXGUI/Multiplayer/GameFiltersPanel.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameFiltersPanel.cs
@@ -136,7 +136,7 @@ namespace DTAClient.DXGUI.Multiplayer
 
         private void BtnCancel_LeftClick(object sender, EventArgs e)
         {
-            Disable();
+            Cancel();
         }
 
         private void BtnResetDefaults_LeftClick(object sender, EventArgs e)
@@ -176,6 +176,11 @@ namespace DTAClient.DXGUI.Multiplayer
         {
             Load();
             Enable();
+        }
+
+        public void Cancel()
+        {
+            Disable();
         }
     }
 }


### PR DESCRIPTION
This is just a minor QoL enhancement to the game filters button that is above the game list. I find myself sometimes wondering what my current filters are set to. This gives me the ability to open the game filters and quickly close them from the same button rather than having to go down to the Cancel button.