### PR TITLE
Favorite maps

### DIFF
--- a/ClientCore/ClientCore.csproj
+++ b/ClientCore/ClientCore.csproj
@@ -260,6 +260,7 @@
     <Compile Include="SavedGameManager.cs" />
     <Compile Include="Settings\IIniSetting.cs" />
     <Compile Include="Settings\IntRangeSetting.cs" />
+    <Compile Include="Settings\StringListSetting.cs" />
     <Compile Include="Settings\UserINISettings.cs" />
     <Compile Include="Settings\BoolSetting.cs" />
     <Compile Include="Settings\DoubleSetting.cs" />

--- a/ClientCore/Settings/StringListSetting.cs
+++ b/ClientCore/Settings/StringListSetting.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Rampastring.Tools;
+
+namespace ClientCore.Settings
+{
+    /// <summary>
+    /// This is a setting that can be stored as a comma separated list of strings.
+    /// </summary>
+    public class StringListSetting : INISetting<List<string>>
+    {
+        public StringListSetting(IniFile iniFile, string iniSection, string iniKey, List<string> defaultValue) : base(iniFile, iniSection, iniKey, defaultValue)
+        {
+        }
+
+        protected override List<string> Get()
+        {
+            string value = IniFile.GetStringValue(IniSection, IniKey, "");
+            return string.IsNullOrWhiteSpace(value) ? DefaultValue : value.Split(',').ToList();
+        }
+
+        protected override void Set(List<string> value)
+        {
+            IniFile.SetStringValue(IniSection, IniKey, string.Join(",", value));
+        }
+
+        public override void Write()
+        {
+            IniFile.SetStringValue(IniSection, IniKey, string.Join(",", Get()));
+        }
+
+        public void Add(string value)
+        {
+            var values = Get().Concat(new []{value}).ToList();
+            Set(values);
+        }
+
+        public void Remove(string value)
+        {
+            var values = Get().Where(v => !string.Equals(v, value, StringComparison.InvariantCultureIgnoreCase)).ToList();
+            Set(values);
+        }
+    }
+}

--- a/ClientCore/Settings/UserINISettings.cs
+++ b/ClientCore/Settings/UserINISettings.cs
@@ -1,6 +1,7 @@
 ﻿using ClientCore.Settings;
 using Rampastring.Tools;
 using System;
+using System.Collections.Generic;
 using System.Windows.Forms;
 
 namespace ClientCore
@@ -125,6 +126,8 @@ namespace ClientCore
             HidePasswordedGames = new BoolSetting(iniFile, GAME_FILTERS, "HidePasswordedGames", DEFAULT_HIDE_PASSWORDED_GAMES);
             HideIncompatibleGames = new BoolSetting(iniFile, GAME_FILTERS, "HideIncompatibleGames", DEFAULT_HIDE_INCOMPATIBLE_GAMES);
             MaxPlayerCount = new IntRangeSetting(iniFile, GAME_FILTERS, "MaxPlayerCount", DEFAULT_MAX_PLAYER_COUNT, 2, 8);
+
+            FavoriteMapSHAs = new StringListSetting(iniFile, OPTIONS, "FavoriteMapSHAs", new List<string>());
         }
 
         public IniFile SettingsIni { get; private set; }
@@ -242,11 +245,32 @@ namespace ClientCore
 
         public BoolSetting AutoRemoveUnderscoresFromName { get; private set; }
         
+        public StringListSetting FavoriteMapSHAs { get; private set; }
+        
         public bool IsGameFollowed(string gameName)
         {
             return SettingsIni.GetBooleanValue("Channels", gameName, false);
         }
 
+        public void ToggleFavoriteMap(string mapSHA)
+        {
+            if (string.IsNullOrEmpty(mapSHA))
+                return;
+            
+            if (!IsFavoriteMap(mapSHA))
+                FavoriteMapSHAs.Add(mapSHA);
+            else
+                FavoriteMapSHAs.Remove(mapSHA);
+            
+            Instance.SaveSettings();
+        }
+
+        /// <summary>
+        /// Checks if a specified map SHA belongs to the favorite map list.
+        /// </summary>
+        /// <param name="mapSha">The SHA of the map.</param>
+        public bool IsFavoriteMap(string mapSha) => FavoriteMapSHAs.Value.Contains(mapSha);
+        
         public void ReloadSettings()
         {
             SettingsIni.Reload();

--- a/DXMainClient/DXMainClient.csproj
+++ b/DXMainClient/DXMainClient.csproj
@@ -515,6 +515,7 @@
     <Compile Include="Online\CnCNetUserData.cs" />
     <Compile Include="Online\EventArguments\ChannelCTCPEventArgs.cs" />
     <Compile Include="Online\EventArguments\CnCNetPrivateMessageEventArgs.cs" />
+    <Compile Include="Online\EventArguments\FavoriteMapEventArgs.cs" />
     <Compile Include="Online\EventArguments\PrivateCTCPEventArgs.cs" />
     <Compile Include="Online\EventArguments\PrivateMessageEventArgs.cs" />
     <Compile Include="Online\EventArguments\UnreadMessageCountEventArgs.cs" />

--- a/DXMainClient/Domain/Multiplayer/CoopMapInfo.cs
+++ b/DXMainClient/Domain/Multiplayer/CoopMapInfo.cs
@@ -1,14 +1,19 @@
 ﻿using Rampastring.Tools;
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace DTAClient.Domain.Multiplayer
 {
     public class CoopMapInfo
     {
+        [JsonProperty]
         public List<CoopHouseInfo> EnemyHouses = new List<CoopHouseInfo>();
+        [JsonProperty]
         public List<CoopHouseInfo> AllyHouses = new List<CoopHouseInfo>();
+        [JsonProperty]
         public List<int> DisallowedPlayerSides = new List<int>();
+        [JsonProperty]
         public List<int> DisallowedPlayerColors = new List<int>();
 
         public void SetHouseInfos(IniSection iniSection)

--- a/DXMainClient/Domain/Multiplayer/Map.cs
+++ b/DXMainClient/Domain/Multiplayer/Map.cs
@@ -30,7 +30,7 @@ namespace DTAClient.Domain.Multiplayer
     /// <summary>
     /// A multiplayer map.
     /// </summary>
-    public class Map
+    public class Map: IEquatable<Map>
     {
         private const int MAX_PLAYERS = 8;
 
@@ -751,6 +751,9 @@ namespace DTAClient.Domain.Multiplayer
             return new Point(pixelX, pixelY);
         }
 
-
+        public bool Equals(Map other)
+        {
+            return string.Equals(SHA1, other.SHA1, StringComparison.InvariantCultureIgnoreCase);
+        }
     }
 }

--- a/DXMainClient/Domain/Multiplayer/Map.cs
+++ b/DXMainClient/Domain/Multiplayer/Map.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using Newtonsoft.Json;
 using Utilities = Rampastring.Tools.Utilities;
 
 namespace DTAClient.Domain.Multiplayer
@@ -33,25 +34,29 @@ namespace DTAClient.Domain.Multiplayer
     {
         private const int MAX_PLAYERS = 8;
 
-        public Map(string path, bool official)
+        public Map(string baseFilePath, string customMapFilePath = null)
         {
-            BaseFilePath = path;
-            Official = official;
+            BaseFilePath = baseFilePath;
+            CustomMapFilePath = customMapFilePath;
+            Official = string.IsNullOrEmpty(CustomMapFilePath);
         }
 
         /// <summary>
         /// The name of the map.
         /// </summary>
+        [JsonProperty]
         public string Name { get; private set; }
 
         /// <summary>
         /// The maximum amount of players supported by the map.
         /// </summary>
+        [JsonProperty]
         public int MaxPlayers { get; private set; }
 
         /// <summary>
         /// The minimum amount of players supported by the map.
         /// </summary>
+        [JsonProperty]
         public int MinPlayers { get; private set; }
 
         /// <summary>
@@ -59,43 +64,51 @@ namespace DTAClient.Domain.Multiplayer
         /// If false (which is the default), MaxPlayers is only used for randomizing
         /// players to starting waypoints.
         /// </summary>
+        [JsonProperty]
         public bool EnforceMaxPlayers { get; private set; }
 
         /// <summary>
         /// Controls if the map is meant for a co-operation game mode
         /// (enables briefing logic and forcing options, among others).
         /// </summary>
+        [JsonProperty]
         public bool IsCoop { get; private set; }
 
         /// <summary>
         /// If set, this map won't be automatically transferred over CnCNet when
         /// a player doesn't have it.
         /// </summary>
+        [JsonIgnore]
         public bool Official { get; private set; }
 
         /// <summary>
         /// Contains co-op information.
         /// </summary>
+        [JsonProperty]
         public CoopMapInfo CoopInfo { get; private set; }
 
         /// <summary>
         /// The briefing of the map.
         /// </summary>
+        [JsonProperty]
         public string Briefing { get; private set; }
 
         /// <summary>
         /// The author of the map.
         /// </summary>
+        [JsonProperty]
         public string Author { get; private set; }
 
         /// <summary>
         /// The calculated SHA1 of the map.
         /// </summary>
+        [JsonIgnore]
         public string SHA1 { get; private set; }
 
         /// <summary>
         /// The path to the map file.
         /// </summary>
+        [JsonProperty]
         public string BaseFilePath { get; private set; }
 
         /// <summary>
@@ -107,71 +120,95 @@ namespace DTAClient.Domain.Multiplayer
         /// <summary>
         /// The file name of the preview image.
         /// </summary>
+        [JsonProperty]
         public string PreviewPath { get; private set; }
 
         /// <summary>
         /// If set, this map cannot be played on Skirmish.
         /// </summary>
+        [JsonProperty]
         public bool MultiplayerOnly { get; private set; }
 
         /// <summary>
         /// If set, this map cannot be played with AI players.
         /// </summary>
+        [JsonProperty]
         public bool HumanPlayersOnly { get; private set; }
 
         /// <summary>
         /// If set, players are forced to random starting locations on this map.
         /// </summary>
+        [JsonProperty]
         public bool ForceRandomStartLocations { get; private set; }
 
         /// <summary>
         /// If set, players are forced to different teams on this map.
         /// </summary>
+        [JsonProperty]
         public bool ForceNoTeams { get; private set; }
 
         /// <summary>
         /// The name of an extra INI file in INI\Map Code\ that should be
         /// embedded into this map's INI code when a game is started.
         /// </summary>
+        [JsonProperty]
         public string ExtraININame { get; private set; }
 
         /// <summary>
         /// The game modes that the map is listed for.
         /// </summary>
+        [JsonProperty]
         public string[] GameModes;
 
         /// <summary>
         /// The forced UnitCount for the map. -1 means none.
         /// </summary>
+        [JsonProperty]
         int UnitCount = -1;
 
         /// <summary>
         /// The forced starting credits for the map. -1 means none.
         /// </summary>
+        [JsonProperty]
         int Credits = -1;
 
+        [JsonProperty]
         int NeutralHouseColor = -1;
 
+        [JsonProperty]
         int SpecialHouseColor = -1;
 
+        [JsonProperty]
         int Bases = -1;
 
+        [JsonProperty]
         string[] localSize;
 
+        [JsonProperty]
         string[] actualSize;
 
-        IniFile mapIni;
+        private IniFile CustomMapIni;
 
+        [JsonProperty]
+        private string CustomMapFilePath;
+
+        [JsonProperty]
         List<string> waypoints = new List<string>();
 
         /// <summary>
         /// The pixel coordinates of the map's player starting locations.
         /// </summary>
+        [JsonProperty]
         List<Point> startingLocations;
 
         public Texture2D PreviewTexture { get; set; }
 
         private bool extractCustomPreview = true;
+
+        public void CalculateSHA()
+        {
+            SHA1 = Utilities.CalculateSHA1ForFile(CompleteFilePath);
+        }
 
         /// <summary>
         /// If false, the preview shouldn't be extracted for this (custom) map.
@@ -190,8 +227,12 @@ namespace DTAClient.Domain.Multiplayer
 
         private List<KeyValuePair<string, string>> ForcedSpawnIniOptions = new List<KeyValuePair<string, string>>(0);
 
-
-        public bool SetInfoFromINI(IniFile iniFile)
+        /// <summary>
+        /// This is used to load a map from the MPMaps.ini (default name) file.
+        /// </summary>
+        /// <param name="iniFile"></param>
+        /// <returns></returns>
+        public bool SetInfoFromMpMapsINI(IniFile iniFile)
         {
             try
             {
@@ -212,7 +253,7 @@ namespace DTAClient.Domain.Multiplayer
                 PreviewPath = Path.GetDirectoryName(BaseFilePath) + "/" +
                     section.GetStringValue("PreviewImage", Path.GetFileNameWithoutExtension(BaseFilePath) + ".png");
                 Briefing = section.GetStringValue("Briefing", string.Empty).Replace("@", Environment.NewLine);
-                SHA1 = Utilities.CalculateSHA1ForFile(CompleteFilePath);
+                CalculateSHA();
                 IsCoop = section.GetBooleanValue("IsCoopMission", false);
                 Credits = section.GetIntValue("Credits", -1);
                 UnitCount = section.GetIntValue("UnitCount", -1);
@@ -346,39 +387,41 @@ namespace DTAClient.Domain.Multiplayer
             return GetIsoTilePixelCoord(mapPoint.X, mapPoint.Y, actualSize, localSize, previewSize, level);
         }
 
-
-        public void WriteInfoToIniSection(IniSection iniSection)
+        /// <summary>
+        /// Due to caching, this may not have been loaded on application start.
+        /// This function provides the ability to load when needed.
+        /// </summary>
+        /// <returns></returns>
+        private IniFile GetCustomMapIniFile()
         {
-            // TODO necessary for custom map caching
-            throw new NotImplementedException();
+            if (CustomMapIni != null) return CustomMapIni;
+            
+            CustomMapIni = new IniFile {FileName = CustomMapFilePath};
+            CustomMapIni.AddSection("Basic");
+            CustomMapIni.AddSection("Map");
+            CustomMapIni.AddSection("Waypoints");
+            CustomMapIni.AddSection("Preview");
+            CustomMapIni.AddSection("PreviewPack");
+            CustomMapIni.AddSection("ForcedOptions");
+            CustomMapIni.AddSection("ForcedSpawnIniOptions");
+            CustomMapIni.AllowNewSections = false;
+            CustomMapIni.Parse();
+
+            return CustomMapIni;
         }
 
         /// <summary>
         /// Loads map information from a TS/RA2 map INI file.
-        /// Returns true if succesful, otherwise false.
+        /// Returns true if successful, otherwise false.
         /// </summary>
-        /// <param name="path">The full path to the map INI file.</param>
-        public bool SetInfoFromMap(string path)
+        public bool SetInfoFromCustomMap()
         {
-            if (!File.Exists(path))
+            if (!File.Exists(CustomMapFilePath))
                 return false;
 
             try
             {
-                IniFile iniFile = new IniFile();
-                iniFile.FileName = path;
-                iniFile.AddSection("Basic");
-                iniFile.AddSection("Map");
-                iniFile.AddSection("Waypoints");
-                iniFile.AddSection("Preview");
-                iniFile.AddSection("PreviewPack");
-                iniFile.AddSection("ForcedOptions");
-                iniFile.AddSection("ForcedSpawnIniOptions");
-                iniFile.AllowNewSections = false;
-
-                iniFile.Parse();
-
-                mapIni = iniFile;
+                IniFile iniFile = GetCustomMapIniFile();
 
                 var basicSection = iniFile.GetSection("Basic");
 
@@ -395,7 +438,7 @@ namespace DTAClient.Domain.Multiplayer
 
                 if (GameModes.Length == 0)
                 {
-                    Logger.Log("Custom map " + path + " has no game modes!");
+                    Logger.Log("Custom map " + CustomMapFilePath + " has no game modes!");
                     return false;
                 }
                 
@@ -414,7 +457,7 @@ namespace DTAClient.Domain.Multiplayer
                 //PreviewPath = Path.GetDirectoryName(BaseFilePath) + "/" +
                 //    iniFile.GetStringValue(BaseFilePath, "PreviewImage", Path.GetFileNameWithoutExtension(BaseFilePath) + ".png");
                 Briefing = basicSection.GetStringValue("Briefing", string.Empty).Replace("@", Environment.NewLine);
-                SHA1 = Utilities.CalculateSHA1ForFile(path);
+                CalculateSHA();
                 IsCoop = basicSection.GetBooleanValue("IsCoopMission", false);
                 Credits = basicSection.GetIntValue("Credits", -1);
                 UnitCount = basicSection.GetIntValue("UnitCount", -1);
@@ -423,7 +466,7 @@ namespace DTAClient.Domain.Multiplayer
                 HumanPlayersOnly = basicSection.GetBooleanValue("HumanPlayersOnly", false);
                 ForceRandomStartLocations = basicSection.GetBooleanValue("ForceRandomStartLocations", false);
                 ForceNoTeams = basicSection.GetBooleanValue("ForceNoTeams", false);
-                PreviewPath = Path.ChangeExtension(path.Substring(ProgramConstants.GamePath.Length), ".png");
+                PreviewPath = Path.ChangeExtension(CustomMapFilePath.Substring(ProgramConstants.GamePath.Length), ".png");
                 MultiplayerOnly = basicSection.GetBooleanValue("ClientMultiplayerOnly", false);
 
                 string bases = basicSection.GetStringValue("Bases", string.Empty);
@@ -455,7 +498,7 @@ namespace DTAClient.Domain.Multiplayer
 
                 for (int i = 0; i < MAX_PLAYERS; i++)
                 {
-                    string waypoint = mapIni.GetStringValue("Waypoints", i.ToString(), string.Empty);
+                    string waypoint = GetCustomMapIniFile().GetStringValue("Waypoints", i.ToString(), string.Empty);
 
                     if (string.IsNullOrEmpty(waypoint))
                         break;
@@ -470,7 +513,7 @@ namespace DTAClient.Domain.Multiplayer
             }
             catch
             {
-                Logger.Log("Loading custom map " + path + " failed!");
+                Logger.Log("Loading custom map " + CustomMapFilePath + " failed!");
                 return false;
             }
         }
@@ -523,7 +566,7 @@ namespace DTAClient.Domain.Multiplayer
             if (!Official)
             {
                 // Extract preview from the map itself
-                System.Drawing.Bitmap preview = MapPreviewExtractor.ExtractMapPreview(mapIni);
+                System.Drawing.Bitmap preview = MapPreviewExtractor.ExtractMapPreview(GetCustomMapIniFile());
 
                 if (preview != null)
                 {

--- a/DXMainClient/Online/EventArguments/FavoriteMapEventArgs.cs
+++ b/DXMainClient/Online/EventArguments/FavoriteMapEventArgs.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using DTAClient.Domain.Multiplayer;
+
+namespace DTAClient.Online.EventArguments
+{
+    public class FavoriteMapEventArgs : EventArgs
+    {
+        public readonly Map Map;
+
+        public FavoriteMapEventArgs(Map map)
+        {
+            Map = map;
+        }
+    }
+}


### PR DESCRIPTION
This was built on the Improved Map Loader feature that is in another pull request, to avoid inevitable code conflicts when the other PR gets merged. This is currently in a draft state until then.

- Favorites are stored in the UserIniSettings as a list of map SHAs
- Favorite maps are toggled by a star icon button in the upper right corner of the map preview box in the game lobby. The star icon is filled in when the current map is a favorite and just the outline of the icon when the map is not a favorite. 
- "Favorites" is added as a GameMode and is added as the first GameMode when the entire list is constructed by the MapLoader. This allows the existing Index based reference of the currently selected GameMode to continue to work as it currently does.
- When a map is UNfavorited while viewing the Favorites GameMode and there are no more favorite maps in the list, the user is left still viewing the Favorites GameMode with no maps listed and the map preview box/currently selected map cleared.
- When a map is UNfavorited while viewing the Favorites GameMode and there are other favorite maps available, the map at index 0 is selected.
- The star icon button reflects whether or not the map is a favorite, regardless of what GameMode is currently selected.
- "Favorites" cannot be added by a map maker to the GameModes setting of the map ini. The application will ignore this to avoid map makers from being able to auto-favorite their maps for all users.