### PR TITLE
game list box improvements

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
@@ -220,6 +220,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             lbChatMessages.PanelBackgroundDrawMode = PanelBackgroundImageDrawMode.STRETCHED;
             lbChatMessages.BackgroundTexture = AssetLoader.CreateTexture(new Color(0, 0, 0, 128), 1, 1);
             lbChatMessages.LineHeight = 16;
+            lbChatMessages.LeftClick += (sender, args) => lbGameList.SelectedIndex = -1;
 
             tbChatInput = new XNAChatTextBox(WindowManager);
             tbChatInput.Name = nameof(tbChatInput);

--- a/DXMainClient/DXGUI/Multiplayer/GameListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameListBox.cs
@@ -79,7 +79,7 @@ namespace DTAClient.DXGUI.Multiplayer
             if (selectedItem != null)
                 SelectedIndex = Items.FindIndex(item => item.Text.ToUpper() == selectedItem.Text.ToUpper());
 
-            GameListBox_HoveredIndexChanged(this, EventArgs.Empty);
+            GameListBox_SelectedIndexChanged(this, EventArgs.Empty);
         }
 
         /// <summary>
@@ -155,7 +155,7 @@ namespace DTAClient.DXGUI.Multiplayer
             panelGameInformation.Alpha = 0f;
             Parent.AddChild(panelGameInformation); // make this a child of our parent so it's not drawn on our rendertarget
 
-            HoveredIndexChanged += GameListBox_HoveredIndexChanged;
+            SelectedIndexChanged += GameListBox_SelectedIndexChanged;
 
             hoverOnGameColor = AssetLoader.GetColorFromString(
                 ClientConfiguration.Instance.HoverOnGameColor);
@@ -163,9 +163,9 @@ namespace DTAClient.DXGUI.Multiplayer
             loadedGameTextWidth = (int)Renderer.GetTextDimensions(LOADED_GAME_TEXT, FontIndex).X;
         }
 
-        private void GameListBox_HoveredIndexChanged(object sender, EventArgs e)
+        private void GameListBox_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (HoveredIndex < 0 || HoveredIndex >= Items.Count)
+            if (SelectedIndex < 0 || SelectedIndex >= Items.Count)
             {
                 panelGameInformation.AlphaRate = -0.5f;
                 return;
@@ -173,12 +173,11 @@ namespace DTAClient.DXGUI.Multiplayer
 
             panelGameInformation.Enable();
             panelGameInformation.X = Right;
-            panelGameInformation.Y = Y + Math.Min((HoveredIndex - TopIndex) * LineHeight,
-                         Height - panelGameInformation.Height);
+            panelGameInformation.Y = Y;
 
             panelGameInformation.AlphaRate = 0.5f;
 
-            var hostedGame = (GenericHostedGame)Items[HoveredIndex].Tag;
+            var hostedGame = (GenericHostedGame)Items[SelectedIndex].Tag;
 
             panelGameInformation.SetInfo(hostedGame);
         }
@@ -207,13 +206,6 @@ namespace DTAClient.DXGUI.Multiplayer
             }
 
             AddItem(lbItem);
-        }
-
-        public override void OnMouseLeave()
-        {
-            panelGameInformation.AlphaRate = -0.5f;
-
-            base.OnMouseLeave();
         }
 
         public override void Update(GameTime gameTime)


### PR DESCRIPTION
### 1st commit: Maintain selection state on game list
The code originally attempted to maintain the selection state as games were being added and removed, but it was based on the variable HostedGames which is the entire list of games when it comes in from CnCNet. With game filtering now available, this is no longer the proper list of games to determine the selected index from. HostedGames is ALL games before they are filtered. I changed it to look directly at the Items list that IS the list that is rendered.

Furthermore, there was code to maintain this selection state in many locations (one at add, one at remove, etc..). I removed all of them and added it only the the Refresh function that is already called by all of them.

### 2nd commit: Show game info panel on click, instead of hover
As games are appearing in the list, it's nearly impossible to actually read the game information for a hovered game, as the game could easily move while sorting is being applied. Rather than hover, the panel is now shown when a game is selected. Also, the game info panel is always aligned at the top right corner of the game list box, rather than where you are selected. Same issue with games being added or removed, this panel previously moved up and down to "follow" the game that is selected (was hovered).
If you click on the chat box, the game list selection will be cleared and thus the panel will be hidden.