### PR TITLE
fix issues with joining games

### DIFF
--- a/DXMainClient/DXGUI/Generic/TopBar.cs
+++ b/DXMainClient/DXGUI/Generic/TopBar.cs
@@ -80,6 +80,8 @@ namespace DTAClient.DXGUI.Generic
 
         private bool lanMode;
 
+        public EventHandler LogoutEvent;
+
         public void AddPrimarySwitchable(ISwitchable switchable)
         {
             primarySwitches.Add(switchable);
@@ -288,6 +290,7 @@ namespace DTAClient.DXGUI.Generic
         private void BtnLogout_LeftClick(object sender, EventArgs e)
         {
             connectionManager.Disconnect();
+            LogoutEvent?.Invoke(this, null);
             SwitchToPrimary();
         }
 

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
@@ -52,6 +52,8 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 new StringCommandHandler(ProgramConstants.GAME_INVITE_CTCP_COMMAND, HandleGameInviteCommand),
                 new NoParamCommandHandler(ProgramConstants.GAME_INVITATION_FAILED_CTCP_COMMAND, HandleGameInvitationFailedNotification)
             };
+
+            topBar.LogoutEvent += LogoutEvent;
         }
 
         private CnCNetManager connectionManager;
@@ -134,6 +136,11 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
         private void GameList_ClientRectangleUpdated(object sender, EventArgs e)
         {
             panelGameFilters.ClientRectangle = lbGameList.ClientRectangle;
+        }
+
+        private void LogoutEvent(object sender, EventArgs e)
+        {
+            isJoiningGame = false;
         }
         
         public override void Initialize()
@@ -755,7 +762,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
         private string GetJoinGameErrorBase()
         {
             if (isJoiningGame)
-                return "Cannot join game - joining game in progress";
+                return "Cannot join game - joining game in progress. If you believe this is an error, please log out and back in.";
 
             if (ProgramConstants.IsInGame)
                 return "Cannot join game while the main game executable is running.";


### PR DESCRIPTION
1. The logic to join a game was getting game indexes from two different locations. The game list box has a HostedGames list, which is ALL games on the server, and an Items list, which is the list of games actually being rendered in the UI. 

The result was the inability to join a game if game filters were being applied. The most common way this would happen is if someone sent you a "game invite". The logic would use HostedGames to find the index of the game to join, but then the code would attempt to use the filtered UI list to validate the game's existence. The indexes wouldn't match up and you would either join the WRONG game or the game index would be out of bounds and no join would happen at all.

2. There is an issue where a message is not received or handled when leaving a game. The result is that the user is no longer able to join any games until they restart the client. This allows them to log out and back in to resolve the issue. The error message regarding this has also been updated to provide them that helpful info.