### PR TITLE
Recent players list

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/RecentPlayerTable.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/RecentPlayerTable.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using DTAClient.Online;
+using Rampastring.XNAUI;
+using Rampastring.XNAUI.XNAControls;
+
+namespace DTAClient.DXGUI.Multiplayer.CnCNet
+{
+    public class RecentPlayerTable : XNAMultiColumnListBox
+    {
+        private readonly CnCNetManager connectionManager;
+
+        public EventHandler<IRCUser> PlayerRightClick;
+
+        public RecentPlayerTable(WindowManager windowManager, CnCNetManager connectionManager) : base(windowManager)
+        {
+            this.connectionManager = connectionManager;
+        }
+
+        public override void Initialize()
+        {
+            AllowRightClickUnselect = false;
+            
+            base.Initialize();
+
+            AddColumn("Player");
+            AddColumn("Game");
+            AddColumn("Date/Time");
+        }
+
+        public void AddRecentPlayer(RecentPlayer recentPlayer)
+        {
+            IRCUser iu = connectionManager.UserList.Find(u => u.Name == recentPlayer.PlayerName);
+            bool isOnline = true;
+
+            if (iu == null)
+            {
+                iu = new IRCUser(recentPlayer.PlayerName);
+                isOnline = false;
+            }
+
+            var textColor = isOnline ? UISettings.ActiveSettings.AltColor : UISettings.ActiveSettings.DisabledItemColor;
+            AddItem(new List<XNAListBoxItem>()
+            {
+                new XNAListBoxItem(recentPlayer.PlayerName, textColor)
+                {
+                    Tag = iu
+                },
+                new XNAListBoxItem(recentPlayer.GameName, textColor),
+                new XNAListBoxItem(recentPlayer.GameTime.ToString("ddd, MMM d, yyyy @ h:mm tt"), textColor)
+            });
+        }
+
+        private XNAPanel CreateColumnHeader(string headerText)
+        {
+            XNALabel xnaLabel = new XNALabel(WindowManager);
+            xnaLabel.FontIndex = HeaderFontIndex;
+            xnaLabel.X = 3;
+            xnaLabel.Y = 2;
+            xnaLabel.Text = headerText;
+            XNAPanel header = new XNAPanel(WindowManager);
+            header.Height = xnaLabel.Height + 3;
+            var width = Width / 3;
+            if (DrawListBoxBorders)
+                header.Width = width + 1;
+            else
+                header.Width = width;
+            header.AddChild(xnaLabel);
+
+            return header;
+        }
+
+        private void AddColumn(string headerText)
+        {
+            var header = CreateColumnHeader(headerText);
+            var xnaListBox = new XNAListBox(WindowManager);
+            xnaListBox.RightClick += ListBox_RightClick;
+            AddColumn(header, xnaListBox);
+        }
+
+        private void ListBox_RightClick(object sender, EventArgs e)
+        {
+            if (HoveredIndex < 0 || HoveredIndex >= ItemCount)
+                return;
+            
+            SelectedIndex = HoveredIndex;
+
+            var selectedItem = GetItem(0, SelectedIndex);
+            PlayerRightClick?.Invoke(this, (IRCUser)selectedItem.Tag);
+        }
+    }
+}

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -633,6 +633,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             }
 
             Players.ForEach(pInfo => pInfo.IsInGame = true);
+            
+            cncnetUserData.AddRecentPlayers(Players.Select(p => p.Name), channel.UIName);
 
             StartGame();
         }
@@ -1211,6 +1213,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             if (UniqueGameID < 0)
                 return;
 
+            var recentPlayers = new List<string>();
+
             for (int i = 1; i < parts.Length; i += 2)
             {
                 if (parts.Length <= i + 1)
@@ -1234,7 +1238,9 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                     return;
 
                 pInfo.Port = port;
+                recentPlayers.Add(pName);
             }
+            cncnetUserData.AddRecentPlayers(recentPlayers, channel.UIName);
 
             StartGame();
         }

--- a/DXMainClient/DXMainClient.csproj
+++ b/DXMainClient/DXMainClient.csproj
@@ -472,6 +472,7 @@
     <Compile Include="DXGUI\Multiplayer\CnCNet\PasswordRequestWindow.cs" />
     <Compile Include="DXGUI\Multiplayer\CnCNet\PlayerContextMenu.cs" />
     <Compile Include="DXGUI\Multiplayer\CnCNet\PlayerContextMenuData.cs" />
+    <Compile Include="DXGUI\Multiplayer\CnCNet\RecentPlayerTable.cs" />
     <Compile Include="DXGUI\Multiplayer\CnCNet\TunnelListBox.cs" />
     <Compile Include="DXGUI\Multiplayer\CnCNet\TunnelSelectionWindow.cs" />
     <Compile Include="DXGUI\Multiplayer\GameFiltersPanel.cs" />
@@ -551,6 +552,7 @@
     <Compile Include="Online\IRCUser.cs" />
     <Compile Include="Online\IUserCollection.cs" />
     <Compile Include="Online\PrivateMessageHandler.cs" />
+    <Compile Include="Online\RecentPlayer.cs" />
     <Compile Include="Online\UnsortedUserCollection.cs" />
     <Compile Include="Online\SortedUserCollection.cs" />
     <Compile Include="Online\PrivateMessageUser.cs" />

--- a/DXMainClient/Online/CnCNetUserData.cs
+++ b/DXMainClient/Online/CnCNetUserData.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Newtonsoft.Json;
 
 namespace DTAClient.Online
 {
@@ -13,13 +14,16 @@ namespace DTAClient.Online
     {
         private const string FRIEND_LIST_PATH = "Client/friend_list";
         private const string IGNORE_LIST_PATH = "Client/ignore_list";
+        private const string RECENT_LIST_PATH = "Client/recent_list";
+
+        private const int RECENT_LIMIT = 50;
 
         /// <summary>
         /// A list which contains names of friended users. If you manipulate this list
         /// directly you have to also invoke UserFriendToggled event handler for every
         /// user name added or removed.
         /// </summary>
-        public List<string> FriendList { get; private set; } = new List<string>();
+        public List<string> FriendList { get; private set;  } = new List<string>();
 
         /// <summary>
         /// A list which contains idents of ignored users. If you manipulate this list
@@ -28,44 +32,116 @@ namespace DTAClient.Online
         /// </summary>
         public List<string> IgnoreList { get; private set; } = new List<string>();
 
+        /// <summary>
+        /// A list which contains names of players from recent games.
+        /// </summary>
+        public List<RecentPlayer> RecentList { get; private set; } = new List<RecentPlayer>();
+
         public event EventHandler<UserNameEventArgs> UserFriendToggled;
         public event EventHandler<IdentEventArgs> UserIgnoreToggled;
 
         public CnCNetUserData(WindowManager windowManager)
         {
-            try
-            {
-                FriendList = File.ReadAllLines(ProgramConstants.GamePath + FRIEND_LIST_PATH).ToList();
-                IgnoreList = File.ReadAllLines(ProgramConstants.GamePath + IGNORE_LIST_PATH).ToList();
-            }
-            catch 
-            {
-                Logger.Log("Loading friend/ignore list failed!");
-            }
+            LoadFriendList();
+            LoadIgnoreList();
+            LoadRecentPlayerList();
 
             windowManager.GameClosing += WindowManager_GameClosing;
         }
 
+        private void LoadFriendList()
+        {
+            try
+            {
+                FriendList = File.ReadAllLines(ProgramConstants.GamePath + FRIEND_LIST_PATH).ToList();
+            }
+            catch
+            {
+                Logger.Log("Loading friend list failed!");
+                FriendList = new List<string>();
+            }
+        }
+
+        private void LoadIgnoreList()
+        {
+            try
+            {
+                IgnoreList = File.ReadAllLines(ProgramConstants.GamePath + IGNORE_LIST_PATH).ToList();
+            }
+            catch
+            {
+                Logger.Log("Loading ignore list failed!");
+                IgnoreList = new List<string>();
+            }
+        }
+
+        private void LoadRecentPlayerList()
+        {
+            try
+            {
+                RecentList = JsonConvert.DeserializeObject<List<RecentPlayer>>(File.ReadAllText(ProgramConstants.GamePath + RECENT_LIST_PATH));
+            }
+            catch
+            {
+                Logger.Log("Loading recent player list failed!");
+                RecentList = new List<RecentPlayer>();
+            }
+        }
+
         private void WindowManager_GameClosing(object sender, EventArgs e) => Save();
 
-        public void Save()
+        private void SaveFriends()
         {
-            Logger.Log("Saving friend and ignore list.");
+            Logger.Log("Saving friend list.");
 
             try
             {
                 File.Delete(ProgramConstants.GamePath + FRIEND_LIST_PATH);
                 File.WriteAllLines(ProgramConstants.GamePath + FRIEND_LIST_PATH,
                     FriendList.ToArray());
+            }
+            catch (Exception ex)
+            {
+                Logger.Log("Saving friends failed! Error message: " + ex.Message);
+            }
+        }
 
+        private void SaveIgnoreList()
+        {
+            Logger.Log("Saving ignore list.");
+
+            try
+            {
                 File.Delete(ProgramConstants.GamePath + IGNORE_LIST_PATH);
                 File.WriteAllLines(ProgramConstants.GamePath + IGNORE_LIST_PATH,
                     IgnoreList.ToArray());
             }
             catch (Exception ex)
             {
-                Logger.Log("Saving User Data failed! Error message: " + ex.Message);
+                Logger.Log("Saving ignore list failed! Error message: " + ex.Message);
             }
+        }
+
+        private void SaveRecentList()
+        {
+            Logger.Log("Saving recent list.");
+
+            try
+            {
+                File.Delete(ProgramConstants.GamePath + RECENT_LIST_PATH);
+                File.WriteAllText(ProgramConstants.GamePath + RECENT_LIST_PATH, JsonConvert.SerializeObject(RecentList));
+            }
+            catch (Exception ex)
+            {
+                Logger.Log("Saving recent players list failed! Error message: " + ex.Message);
+            }
+        }
+
+        public void Save()
+        {
+            SaveFriends();
+            SaveIgnoreList();
+            SaveRecentList();
         }
 
         /// <summary>
@@ -102,6 +178,20 @@ namespace DTAClient.Online
                 IgnoreList.Add(ident);
 
             UserIgnoreToggled?.Invoke(this, new IdentEventArgs(ident));
+        }
+
+        public void AddRecentPlayers(IEnumerable<string> recentPlayerNames, string gameName)
+        {
+            recentPlayerNames = recentPlayerNames.Where(name => name != ProgramConstants.PLAYERNAME);
+            var now = DateTime.UtcNow;
+            RecentList.AddRange(recentPlayerNames.Select(rp => new RecentPlayer()
+            {
+                PlayerName = rp,
+                GameName = gameName,
+                GameTime = now
+            }));
+            int skipCount = Math.Max(0, RecentList.Count - RECENT_LIMIT);
+            RecentList = RecentList.Skip(skipCount).ToList();
         }
 
         /// <summary>

--- a/DXMainClient/Online/RecentPlayer.cs
+++ b/DXMainClient/Online/RecentPlayer.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace DTAClient.Online
+{
+    public class RecentPlayer
+    {
+        public string PlayerName { get; set; }
+        public string GameName { get; set; }
+        public DateTime GameTime { get; set; }
+    }
+}


### PR DESCRIPTION
When a game starts, all players will be logged. In the PM window, there will be a tab for recent players, listing their names, the name of the game you played with them in, and when the game was played. The list will be ordered from newest to oldest. The list will only show the last 50 players. All right-click options for each player in this list should work like any other player list in this window.

The main purpose is to capture recent players so that you can add them to your friends list afterwards, if desired.