### PR TITLE
CnCNetLobby message right click context menu

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
@@ -52,17 +52,26 @@ namespace DTAClient.DXGUI.Multiplayer
 
         public void AddMessage(ChatMessage message)
         {
+            var listBoxItem = new XNAListBoxItem
+            {
+                TextColor = message.Color,
+                Selectable = true,
+                Tag = message
+            };
+            
             if (message.SenderName == null)
-                AddItem(Renderer.GetSafeString(string.Format("[{0}] {1}",
+            {
+                listBoxItem.Text = Renderer.GetSafeString(string.Format("[{0}] {1}",
                     message.DateTime.ToShortTimeString(),
-                    message.Message), FontIndex),
-                    message.Color, true);
+                    message.Message), FontIndex);
+            }
             else
             {
-                AddItem(Renderer.GetSafeString(string.Format("[{0}] {1}: {2}",
-                    message.DateTime.ToShortTimeString(), message.SenderName, message.Message), FontIndex),
-                    message.Color, true);
+                listBoxItem.Text = Renderer.GetSafeString(string.Format("[{0}] {1}: {2}",
+                    message.DateTime.ToShortTimeString(), message.SenderName, message.Message), FontIndex);
             }
+            
+            AddItem(listBoxItem);
 
             if (LastIndex >= Items.Count - 2)
             {

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
@@ -64,6 +64,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
         private ChatListBox lbChatMessages;
         private GameListBox lbGameList;
         private PlayerContextMenu playerContextMenu;
+        private PlayerMessageContextMenu playerMessageContextMenu;
 
         private XNAClientButton btnLogout;
         private XNAClientButton btnNewGame;
@@ -209,6 +210,9 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             playerContextMenu = new PlayerContextMenu(WindowManager, connectionManager, cncnetUserData, pmWindow);
             playerContextMenu.JoinEvent += (sender, args) => JoinUser(args.IrcUser, connectionManager.MainChannel);
 
+            playerMessageContextMenu = new PlayerMessageContextMenu(WindowManager, connectionManager, cncnetUserData, pmWindow);
+            playerMessageContextMenu.JoinEvent += (sender, args) => JoinUser(args.IrcUser, connectionManager.MainChannel);
+
             lbChatMessages = new ChatListBox(WindowManager);
             lbChatMessages.Name = nameof(lbChatMessages);
             lbChatMessages.ClientRectangle = new Rectangle(lbGameList.Right + 12, lbGameList.Y,
@@ -217,6 +221,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             lbChatMessages.BackgroundTexture = AssetLoader.CreateTexture(new Color(0, 0, 0, 128), 1, 1);
             lbChatMessages.LineHeight = 16;
             lbChatMessages.LeftClick += (sender, args) => lbGameList.SelectedIndex = -1;
+            lbChatMessages.RightClick += LbChatMessages_RightClick;
 
             tbChatInput = new XNAChatTextBox(WindowManager);
             tbChatInput.Name = nameof(tbChatInput);
@@ -342,6 +347,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             AddChild(lblCurrentChannel);
             AddChild(ddCurrentChannel);
             AddChild(playerContextMenu);
+            AddChild(playerMessageContextMenu);
             AddChild(lblOnline);
             AddChild(lblOnlineCount);
             AddChild(tbGameSearch);
@@ -649,6 +655,27 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             var user = (ChannelUser)lbPlayerList.SelectedItem.Tag;
 
             playerContextMenu.Show(user, GetCursorPoint());
+        }
+
+        private void LbChatMessages_RightClick(object sender, EventArgs e)
+        {
+            var item = lbChatMessages.HoveredItem;
+            var chatMessage = item?.Tag as ChatMessage;
+            if (!(chatMessage?.IsUser ?? false))
+                return;
+
+            ShowPlayerMessageContextMenu(chatMessage);
+        }
+
+        private void ShowPlayerMessageContextMenu(ChatMessage chatMessage)
+        {
+            lbChatMessages.SelectedIndex = lbChatMessages.HoveredIndex;
+
+            var user = connectionManager.UserList.Find(u => string.Equals(u.Ident, chatMessage.SenderIdent));
+            if (user == null)
+                return;
+
+            playerMessageContextMenu.Show(user, GetCursorPoint());
         }
 
         /// <summary>

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/PlayerContextMenu.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/PlayerContextMenu.cs
@@ -11,7 +11,7 @@ using Microsoft.Xna.Framework;
 
 namespace DTAClient.DXGUI.Multiplayer.CnCNet
 {
-    class PlayerContextMenu : XNAContextMenu
+    public class PlayerContextMenu : XNAContextMenu
     {
         private const string PRIVATE_MESSAGE = "Private Message";
         private const string ADD_FRIEND = "Add Friend";

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/PlayerMessageContextMenu.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/PlayerMessageContextMenu.cs
@@ -1,0 +1,17 @@
+﻿using DTAClient.Online;
+using Rampastring.XNAUI;
+
+namespace DTAClient.DXGUI.Multiplayer.CnCNet
+{
+    public class PlayerMessageContextMenu : PlayerContextMenu
+    {
+        public PlayerMessageContextMenu(
+            WindowManager windowManager,
+            CnCNetManager connectionManager,
+            CnCNetUserData cncnetUserData,
+            PrivateMessagingWindow pmWindow
+        ) : base(windowManager, connectionManager, cncnetUserData, pmWindow)
+        {
+        }
+    }
+}

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/RecentPlayerTable.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/RecentPlayerTable.cs
@@ -47,7 +47,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                     Tag = iu
                 },
                 new XNAListBoxItem(recentPlayer.GameName, textColor),
-                new XNAListBoxItem(recentPlayer.GameTime.ToString("ddd, MMM d, yyyy @ h:mm tt"), textColor)
+                new XNAListBoxItem(recentPlayer.GameTime.ToLocalTime().ToString("ddd, MMM d, yyyy @ h:mm tt"), textColor)
             });
         }
 

--- a/DXMainClient/DXMainClient.csproj
+++ b/DXMainClient/DXMainClient.csproj
@@ -473,6 +473,7 @@
     <Compile Include="DXGUI\Multiplayer\CnCNet\PlayerContextMenu.cs" />
     <Compile Include="DXGUI\Multiplayer\CnCNet\PlayerContextMenuData.cs" />
     <Compile Include="DXGUI\Multiplayer\CnCNet\RecentPlayerTable.cs" />
+    <Compile Include="DXGUI\Multiplayer\CnCNet\PlayerMessageContextMenu.cs" />
     <Compile Include="DXGUI\Multiplayer\CnCNet\TunnelListBox.cs" />
     <Compile Include="DXGUI\Multiplayer\CnCNet\TunnelSelectionWindow.cs" />
     <Compile Include="DXGUI\Multiplayer\GameFiltersPanel.cs" />

--- a/DXMainClient/Online/ChatMessage.cs
+++ b/DXMainClient/Online/ChatMessage.cs
@@ -64,5 +64,7 @@ namespace DTAClient.Online
         public DateTime DateTime { get; private set; }
         public string Message { get; private set; }
         public bool SenderIsAdmin { get; private set; }
+
+        public bool IsUser => SenderIdent != null;
     }
 }


### PR DESCRIPTION
Right click context menu for player-sent messages in the cncnet main lobby.

For now, this uses the existing functionality of the current player right-click context menu. However, it is a derived class leaving it open to other future menu options.