### PR TITLE
Expose ability to load/save game options in UI

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/LoadOrSaveGameOptionPresetWindow.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/LoadOrSaveGameOptionPresetWindow.cs
@@ -1,0 +1,247 @@
+﻿using System;
+using System.Linq;
+using ClientGUI;
+using DTAClient.Domain.Multiplayer;
+using Microsoft.Xna.Framework;
+using Rampastring.XNAUI;
+using Rampastring.XNAUI.XNAControls;
+
+namespace DTAClient.DXGUI.Multiplayer.CnCNet
+{
+    public class LoadOrSaveGameOptionPresetWindow : XNAWindow
+    {
+        private bool _isLoad;
+
+        private readonly XNALabel lblHeader;
+
+        private readonly XNADropDownItem ddiCreatePresetItem;
+
+        private readonly XNADropDownItem ddiSelectPresetItem;
+
+        private readonly XNAClientButton btnLoadSave;
+
+        private readonly XNAClientDropDown ddPresetSelect;
+
+        private readonly XNALabel lblNewPresetName;
+
+        private readonly XNATextBox tbNewPresetName;
+
+        public EventHandler<string> PresetLoaded;
+
+        public EventHandler<string> PresetSaved;
+
+        public LoadOrSaveGameOptionPresetWindow(WindowManager windowManager) : base(windowManager)
+        {
+            ClientRectangle = new Rectangle(0, 0, 300, 185);
+
+            var margin = 10;
+
+            lblHeader = new XNALabel(WindowManager);
+            lblHeader.FontIndex = 1;
+            lblHeader.ClientRectangle = new Rectangle(
+                margin, margin,
+                150, 22
+            );
+
+            var lblPresetName = new XNALabel(WindowManager);
+            lblPresetName.Text = "Preset Name";
+            lblPresetName.ClientRectangle = new Rectangle(
+                margin, lblHeader.Bottom + margin,
+                150, 18
+            );
+
+            ddiCreatePresetItem = new XNADropDownItem();
+            ddiCreatePresetItem.Text = "[Create New]";
+
+            ddiSelectPresetItem = new XNADropDownItem();
+            ddiSelectPresetItem.Text = "[Select Preset]";
+            ddiSelectPresetItem.Selectable = false;
+
+            ddPresetSelect = new XNAClientDropDown(WindowManager);
+            ddPresetSelect.ClientRectangle = new Rectangle(
+                10, lblPresetName.Bottom + 2,
+                150, 22
+            );
+            ddPresetSelect.SelectedIndexChanged += DropDownPresetSelect_SelectedIndexChanged;
+
+            lblNewPresetName = new XNALabel(WindowManager);
+            lblNewPresetName.Text = "New Preset Name";
+            lblNewPresetName.ClientRectangle = new Rectangle(
+                margin, ddPresetSelect.Bottom + margin,
+                150, 18
+            );
+
+            tbNewPresetName = new XNATextBox(WindowManager);
+            tbNewPresetName.ClientRectangle = new Rectangle(
+                10, lblNewPresetName.Bottom + 2,
+                150, 22
+            );
+            tbNewPresetName.TextChanged += (sender, args) => RefreshLoadSaveBtn();
+
+            btnLoadSave = new XNAClientButton(WindowManager);
+            btnLoadSave.LeftClick += BtnLoadSave_LeftClick;
+            btnLoadSave.ClientRectangle = new Rectangle(
+                margin,
+                Height - UIDesignConstants.BUTTON_HEIGHT - margin,
+                UIDesignConstants.BUTTON_WIDTH_92,
+                UIDesignConstants.BUTTON_HEIGHT
+            );
+
+            var btnCancel = new XNAClientButton(WindowManager);
+            btnCancel.Text = "Cancel";
+            btnCancel.ClientRectangle = new Rectangle(
+                btnLoadSave.Right + margin,
+                btnLoadSave.Y,
+                UIDesignConstants.BUTTON_WIDTH_92,
+                UIDesignConstants.BUTTON_HEIGHT
+            );
+            btnCancel.LeftClick += (sender, args) => Disable();
+
+            AddChild(lblHeader);
+            AddChild(lblPresetName);
+            AddChild(ddPresetSelect);
+            AddChild(lblNewPresetName);
+            AddChild(tbNewPresetName);
+            AddChild(btnLoadSave);
+            AddChild(btnCancel);
+
+            Disable();
+        }
+
+        /// <summary>
+        /// Show the window.
+        /// </summary>
+        /// <param name="isLoad">The "mode" for the window: load vs save.</param>
+        public void Show(bool isLoad)
+        {
+            _isLoad = isLoad;
+            lblHeader.Text = $"{(_isLoad ? "Load" : "Save")} Preset";
+            btnLoadSave.Text = _isLoad ? "Load" : "Save";
+
+            if (_isLoad)
+                ShowLoad();
+            else
+                ShowSave();
+
+            CenterOnParent();
+            Enable();
+        }
+
+        /// <summary>
+        /// Callback when the Preset drop down selection has changed
+        /// </summary>
+        private void DropDownPresetSelect_SelectedIndexChanged(object sender, EventArgs eventArgs)
+        {
+            if (_isLoad)
+                DropDownPresetSelect_SelectedIndexChanged_IsLoad();
+            else
+                DropDownPresetSelect_SelectedIndexChanged_IsSave();
+
+            RefreshLoadSaveBtn();
+        }
+
+        /// <summary>
+        /// Callback when the Preset drop down selection has changed during "load" mode
+        /// </summary>
+        private void DropDownPresetSelect_SelectedIndexChanged_IsLoad()
+        {
+            if (!IsSelectPresetSelected && ddPresetSelect.Items.Contains(ddiSelectPresetItem))
+            {
+                ddPresetSelect.Items.Remove(ddiSelectPresetItem);
+                ddPresetSelect.SelectedIndex--;
+            }
+        }
+
+        /// <summary>
+        /// Callback when the Preset drop down selection has changed during "save" mode
+        /// </summary>
+        private void DropDownPresetSelect_SelectedIndexChanged_IsSave()
+        {
+            if (IsCreatePresetSelected)
+            {
+                // show the field to specify a new name when "create" option is selected in drop down
+                tbNewPresetName.Enable();
+                lblNewPresetName.Enable();
+            }
+            else
+            {
+                // hide the field to specify a new name when an existing preset is selected
+                tbNewPresetName.Disable();
+                lblNewPresetName.Disable();
+            }
+        }
+
+        /// <summary>
+        /// Refresh the state of the load/save button
+        /// </summary>
+        private void RefreshLoadSaveBtn()
+        {
+            if (_isLoad)
+                btnLoadSave.Enabled = !IsSelectPresetSelected;
+            else
+                btnLoadSave.Enabled = !IsCreatePresetSelected || !IsNewPresetNameFieldEmpty;
+        }
+
+        private bool IsCreatePresetSelected => ddPresetSelect.SelectedItem == ddiCreatePresetItem;
+        private bool IsSelectPresetSelected => ddPresetSelect.SelectedItem == ddiSelectPresetItem;
+        private bool IsNewPresetNameFieldEmpty => string.IsNullOrWhiteSpace(tbNewPresetName.Text);
+
+        /// <summary>
+        /// Populate the preset drop down from saved presets
+        /// </summary>
+        private void LoadPresets()
+        {
+            ddPresetSelect.Items.Clear();
+            ddPresetSelect.Items.Add(_isLoad ? ddiSelectPresetItem : ddiCreatePresetItem);
+            ddPresetSelect.SelectedIndex = 0;
+
+            ddPresetSelect.Items.AddRange(GameOptionPresets.Instance
+                .GetPresetNames()
+                .OrderBy(name => name)
+                .Select(name => new XNADropDownItem()
+                {
+                    Text = name
+                }));
+        }
+
+        /// <summary>
+        /// Show the current window in the "load" mode context
+        /// </summary>
+        private void ShowLoad()
+        {
+            LoadPresets();
+
+            // do not show fields to specify a preset name during "load" mode
+            lblNewPresetName.Disable();
+            tbNewPresetName.Disable();
+        }
+
+        /// <summary>
+        /// Show the current window in the "save" mode context
+        /// </summary>
+        private void ShowSave()
+        {
+            LoadPresets();
+
+            // show fields to specify a preset name during "save" mode
+            lblNewPresetName.Enable();
+            tbNewPresetName.Enable();
+        }
+
+        private void BtnLoadSave_LeftClick(object sender, EventArgs e)
+        {
+            var selectedItem = ddPresetSelect.Items[ddPresetSelect.SelectedIndex];
+            if (_isLoad)
+            {
+                PresetLoaded?.Invoke(this, selectedItem.Text);
+            }
+            else
+            {
+                var presetName = IsCreatePresetSelected ? tbNewPresetName.Text : selectedItem.Text;
+                PresetSaved?.Invoke(this, presetName);
+            }
+
+            Disable();
+        }
+    }
+}

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
@@ -593,21 +593,6 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             AddNotice($"{senderName} rolled {results.Length}d{dieSides} and got {string.Join(", ", results)}");
         }
 
-        private void HandleGameOptionPresetSaveCommand(string presetName)
-        {
-            string error = AddGameOptionPreset(presetName);
-            if (!string.IsNullOrEmpty(error))
-                AddNotice(error);
-        }
-
-        private void HandleGameOptionPresetLoadCommand(string presetName)
-        {
-            if (LoadGameOptionPreset(presetName))
-                AddNotice("Game option preset loaded succesfully.");
-            else
-                AddNotice($"Preset {presetName} not found!");
-        }
-
         protected abstract void SendChatMessage(string message);
 
         /// <summary>
@@ -1035,10 +1020,6 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         {
             AddNotice(message, Color.Yellow);
         }
-
-        protected void AddNotice(string message) => AddNotice(message, Color.White);
-
-        protected abstract void AddNotice(string message, Color color);
 
         protected override bool AllowPlayerOptionsChange() => IsHost;
 

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/SkirmishLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/SkirmishLobby.cs
@@ -11,6 +11,7 @@ using Rampastring.Tools;
 using System.IO;
 using DTAClient.Domain;
 using DTAClient.Online;
+using Microsoft.Xna.Framework;
 
 namespace DTAClient.DXGUI.Multiplayer.GameLobby
 {
@@ -58,6 +59,11 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             ProgramConstants.PlayerNameChanged += ProgramConstants_PlayerNameChanged;
             ddPlayerSides[0].SelectedIndexChanged += PlayerSideChanged;
+        }
+
+        protected override void AddNotice(string message, Color color)
+        {
+            XNAMessageBox.Show(WindowManager, "Message", message);
         }
 
         protected override void OnEnabledChanged(object sender, EventArgs args)

--- a/DXMainClient/DXMainClient.csproj
+++ b/DXMainClient/DXMainClient.csproj
@@ -468,6 +468,7 @@
     <Compile Include="DXGUI\Multiplayer\CnCNet\CnCNetLoginWindow.cs" />
     <Compile Include="DXGUI\Multiplayer\CnCNet\GameCreationEventArgs.cs" />
     <Compile Include="DXGUI\Multiplayer\CnCNet\GameCreationWindow.cs" />
+    <Compile Include="DXGUI\Multiplayer\CnCNet\LoadOrSaveGameOptionPresetWindow.cs" />
     <Compile Include="DXGUI\Multiplayer\CnCNet\MapSharingConfirmationPanel.cs" />
     <Compile Include="DXGUI\Multiplayer\CnCNet\PasswordRequestWindow.cs" />
     <Compile Include="DXGUI\Multiplayer\CnCNet\PlayerContextMenu.cs" />

--- a/DXMainClient/Domain/Multiplayer/GameOptionPresets.cs
+++ b/DXMainClient/Domain/Multiplayer/GameOptionPresets.cs
@@ -115,8 +115,7 @@ namespace DTAClient.Domain.Multiplayer
 
         public GameOptionPreset GetPreset(string name)
         {
-            if (gameOptionPresetsIni == null)
-                LoadIni();
+            LoadIniIfNotInitialized();
 
             if (presets.TryGetValue(name, out GameOptionPreset value))
             {
@@ -127,13 +126,27 @@ namespace DTAClient.Domain.Multiplayer
             return null;
         }
 
+        public List<string> GetPresetNames()
+        {
+            LoadIniIfNotInitialized();
+
+            return presets.Keys
+                .Where(key  => !string.IsNullOrWhiteSpace(key))
+                .ToList();
+        }
+
         public void AddPreset(GameOptionPreset preset)
         {
-            if (gameOptionPresetsIni == null)
-                LoadIni();
+            LoadIniIfNotInitialized();
 
             presets[preset.ProfileName] = preset;
             WriteIni();
+        }
+
+        private void LoadIniIfNotInitialized()
+        {
+            if (gameOptionPresetsIni == null)
+                LoadIni();
         }
 
         private void LoadIni()


### PR DESCRIPTION
The ability to save and load game options already exists via a "slash" command in the game chat. This simply exposes them to the UI. This menu exists in the GameLobbyBase thus also enables them for skirmish.

![image](https://user-images.githubusercontent.com/2062360/143720031-b6c27e3c-e85a-4890-bdfb-7051cf7ff5b8.png)
![image](https://user-images.githubusercontent.com/2062360/143719882-261c4087-e79d-40d7-b018-cd33d554d57b.png)
![image](https://user-images.githubusercontent.com/2062360/143719950-e5788576-82a3-47d4-8f6f-94e44764e58d.png)
![image](https://user-images.githubusercontent.com/2062360/143719955-bff7506f-98f3-4338-9297-8d187eeed980.png)
![image](https://user-images.githubusercontent.com/2062360/143719957-a7839c67-d085-4388-9fef-d2fc80a8ec01.png)
![image](https://user-images.githubusercontent.com/2062360/143719959-48e6c80f-c46b-4eb6-a7be-626067524d57.png)
