### PR TITLE
Bugs/custom map download

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -1597,7 +1597,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 AddNotice(returnMessage);
                 if (lastMapSHA1 == e.SHA1)
                 {
-                    GameModeMap = GameModeMaps.Find(gmm => gmm.GameMode.UIName == lastGameMode);
+                    GameModeMap = GameModeMaps.Find(gmm => gmm.Map.SHA1 == lastMapSHA1);
                     ChangeMap(GameModeMap);
                 }
             }

--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -267,6 +267,8 @@ namespace DTAClient.Domain.Multiplayer
                 Logger.Log("LoadCustomMap: Map " + mapPath + " added succesfully.");
 
                 AddMapToGameModes(map, true);
+                var gameModes = GameModes.Where(gm => gm.Maps.Contains(map));
+                GameModeMaps.AddRange(gameModes.Select(gm => new GameModeMap(gm, map, false)));
 
                 resultMessage = $"Map {mapPath} loaded succesfully.";
 


### PR DESCRIPTION
The map loader maintains a list of GameModeMaps. This list is used by the game lobbies to determine if a player has the map selected by the host. If it does not, the player is prompted to download the map. 

The problem was that after the map downloaded successfully, the player's local list of GameModeMaps was not updated to now contain this map. As a result, if the host ever reselected that map, the player that downloaded the map the first time will now be prompted to download it again. When the download happens the second time, the client will attempt to move the file on the file system, resulting in an exception.