### PR TITLE
Fix issue with deleting custom map

### DIFF
--- a/DXMainClient/DXGUI/Generic/LoadingScreen.cs
+++ b/DXMainClient/DXGUI/Generic/LoadingScreen.cs
@@ -111,7 +111,7 @@ namespace DTAClient.DXGUI.Generic
                 gameCollection, cncnetUserData, optionsWindow);
             var gipw = new GameInProgressWindow(WindowManager);
 
-            var skirmishLobby = new SkirmishLobby(WindowManager, topBar, mapLoader.GameModeMaps, discordHandler);
+            var skirmishLobby = new SkirmishLobby(WindowManager, topBar, mapLoader, discordHandler);
 
             topBar.SetSecondarySwitch(cncnetLobby);
 

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -43,19 +43,19 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         /// </summary>
         /// <param name="windowManager"></param>
         /// <param name="iniName">The name of the lobby in GameOptions.ini.</param>
-        /// <param name="gameModeMaps"></param>
+        /// <param name="mapLoader"></param>
         /// <param name="isMultiplayer"></param>
         /// <param name="discordHandler"></param>
         public GameLobbyBase(
             WindowManager windowManager, 
             string iniName,
-            GameModeMapCollection gameModeMaps, 
+            MapLoader mapLoader, 
             bool isMultiplayer, 
             DiscordHandler discordHandler
         ) : base(windowManager)
         {
             _iniSectionName = iniName;
-            GameModeMaps = gameModeMaps;
+            MapLoader = mapLoader;
             this.isMultiplayer = isMultiplayer;
             this.discordHandler = discordHandler;
         }
@@ -73,10 +73,12 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
         protected DiscordHandler discordHandler;
 
+        protected MapLoader MapLoader;
         /// <summary>
-        /// The list of multiplayer game modes.
+        /// The list of multiplayer game mode maps.
+        /// Each is an instance of a map for a specific game mode.
         /// </summary>
-        protected GameModeMapCollection GameModeMaps;
+        protected GameModeMapCollection GameModeMaps => MapLoader.GameModeMaps;
 
         protected GameModeMapFilter gameModeMapFilter;
 
@@ -687,16 +689,19 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         {
             try
             {
-                Logger.Log("Deleting map " + Map.BaseFilePath);
-                File.Delete(Map.CompleteFilePath);
-                foreach (GameMode gameMode in GameModeMaps.GameModes)
-                {
-                    gameMode.Maps.Remove(Map);
-                }
+                MapLoader.DeleteCustomMap(GameModeMap);
 
                 tbMapSearch.Text = string.Empty;
                 if (GameMode.Maps.Count == 0)
+                {
+                    // this will trigger another GameMode to be selected
                     GameModeMap = GameModeMaps.Find(gm => gm.GameMode.Maps.Count > 0);
+                }
+                else
+                {
+                    // this will trigger another Map to be selected
+                    lbGameModeMapList.SelectedIndex = lbGameModeMapList.SelectedIndex == 0 ? 1 : lbGameModeMapList.SelectedIndex - 1;
+                }
 
                 ListMaps();
                 ChangeMap(GameModeMap);

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
@@ -27,7 +27,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
         public MultiplayerGameLobby(WindowManager windowManager, string iniName, 
             TopBar topBar, MapLoader mapLoader, DiscordHandler discordHandler)
-            : base(windowManager, iniName, mapLoader.GameModeMaps, true, discordHandler)
+            : base(windowManager, iniName, mapLoader, true, discordHandler)
         {
             TopBar = topBar;
             MapLoader = mapLoader;

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/SkirmishLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/SkirmishLobby.cs
@@ -19,8 +19,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
     {
         private const string SETTINGS_PATH = "Client/SkirmishSettings.ini";
 
-        public SkirmishLobby(WindowManager windowManager, TopBar topBar, GameModeMapCollection gameModeMaps, DiscordHandler discordHandler)
-            : base(windowManager, "SkirmishLobby", gameModeMaps, false, discordHandler)
+        public SkirmishLobby(WindowManager windowManager, TopBar topBar, MapLoader mapLoader, DiscordHandler discordHandler)
+            : base(windowManager, "SkirmishLobby", mapLoader, false, discordHandler)
         {
             this.topBar = topBar;
         }

--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -149,7 +149,7 @@ namespace DTAClient.Domain.Multiplayer
                 Logger.Log("Custom maps directory does not exist!");
                 return;
             }
-            
+
             string[] mapFiles = Directory.GetFiles(ProgramConstants.GamePath + CUSTOM_MAPS_DIRECTORY, "*.map");
             ConcurrentDictionary<string, Map> customMapCache = LoadCustomMapCache();
             var localMapSHAs = new List<string>();
@@ -188,7 +188,7 @@ namespace DTAClient.Domain.Multiplayer
                 AddMapToGameModes(map, false);
             }
         }
-        
+
         /// <summary>
         /// Save cache of custom maps.
         /// </summary>
@@ -201,7 +201,7 @@ namespace DTAClient.Domain.Multiplayer
                 Version = CurrentCustomMapCacheVersion
             };
             var jsonData = JsonConvert.SerializeObject(customMapCache);
-            
+
             File.WriteAllText(CUSTOM_MAPS_CACHE, jsonData);
         }
 
@@ -279,6 +279,18 @@ namespace DTAClient.Domain.Multiplayer
             resultMessage = $"Loading map {mapPath} failed!";
 
             return null;
+        }
+
+        public void DeleteCustomMap(GameModeMap gameModeMap)
+        {
+            Logger.Log("Deleting map " + gameModeMap.Map.Name);
+            File.Delete(gameModeMap.Map.CompleteFilePath);
+            foreach (GameMode gameMode in GameModeMaps.GameModes)
+            {
+                gameMode.Maps.Remove(gameModeMap.Map);
+            }
+
+            GameModeMaps.Remove(gameModeMap);
         }
 
         /// <summary>


### PR DESCRIPTION
Maps were being deleted properly, but the UI wasn't being updated to show it. If the user restarted their client, the map would no longer be there. 