### PR TITLE
Team/start fix and rebranding

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -554,7 +554,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 AddPlayerExtraOptionForcedNotice(playerExtraOptions.IsForceRandomTeams, "team selection");
 
             if (playerExtraOptions.IsUseTeamStartMappings != PlayerExtraOptionsPanel.IsUseTeamStartMappings())
-                AddPlayerExtraOptionForcedNotice(!playerExtraOptions.IsUseTeamStartMappings, "team/start mappings");
+                AddPlayerExtraOptionForcedNotice(!playerExtraOptions.IsUseTeamStartMappings, "auto ally");
 
             SetPlayerExtraOptions(playerExtraOptions);
             UpdateMapPreviewBoxEnabledStatus();

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -414,6 +414,13 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             PlayerExtraOptionsPanel.OptionsChanged += PlayerExtraOptions_OptionsChanged;
         }
 
+        private void RefreshBthPlayerExtraOptionsOpenTexture()
+        {
+            var texture = GetPlayerExtraOptions().IsDefault() ? "comboBoxArrow.png" : "comboBoxArrow-highlight.png";
+            btnPlayerExtraOptionsOpen.IdleTexture = AssetLoader.LoadTexture(texture);
+            btnPlayerExtraOptionsOpen.HoverTexture = AssetLoader.LoadTexture(texture);
+        }
+
         private void InitializeGameOptionsPanel()
         {
             GameOptionsPanel = new XNAPanel(WindowManager);
@@ -956,6 +963,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 EnablePlayerOptionDropDown(ddPlayerStarts[i], i, !playerExtraOptions.IsForceRandomStarts);
 
             UpdateMapPreviewBoxEnabledStatus();
+            RefreshBthPlayerExtraOptionsOpenTexture();
         }
 
         private void EnablePlayerOptionDropDown(XNAClientDropDown clientDropDown, int playerIndex, bool enable)

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -961,7 +961,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         private void EnablePlayerOptionDropDown(XNAClientDropDown clientDropDown, int playerIndex, bool enable)
         {
             var pInfo = GetPlayerInfoForIndex(playerIndex);
-            clientDropDown.AllowDropDown = enable && pInfo?.Name == ProgramConstants.PLAYERNAME;
+            var allowOtherPlayerOptionsChange = AllowPlayerOptionsChange() && pInfo != null;
+            clientDropDown.AllowDropDown = enable && (allowOtherPlayerOptionsChange || pInfo?.Name == ProgramConstants.PLAYERNAME);
             if (!clientDropDown.AllowDropDown)
                 clientDropDown.SelectedIndex = clientDropDown.SelectedIndex > 0 ? 0 : clientDropDown.SelectedIndex;
         }

--- a/DXMainClient/DXGUI/Multiplayer/PlayerExtraOptionsPanel.cs
+++ b/DXMainClient/DXGUI/Multiplayer/PlayerExtraOptionsPanel.cs
@@ -205,7 +205,7 @@ namespace DTAClient.DXGUI.Multiplayer
 
             chkBoxUseTeamStartMappings = new XNAClientCheckBox(WindowManager);
             chkBoxUseTeamStartMappings.Name = nameof(chkBoxUseTeamStartMappings);
-            chkBoxUseTeamStartMappings.Text = "Use Team/Start Mappings:";
+            chkBoxUseTeamStartMappings.Text = "Enable Auto Allying:";
             chkBoxUseTeamStartMappings.ClientRectangle = new Rectangle(defaultTeamStartMappingX, lblHeader.Y, 0, 0);
             chkBoxUseTeamStartMappings.CheckedChanged += ChkBoxUseTeamStartMappings_Changed;
             AddChild(chkBoxUseTeamStartMappings);
@@ -244,10 +244,10 @@ namespace DTAClient.DXGUI.Multiplayer
 
         private void BtnHelp_LeftClick(object sender, EventArgs args)
         {
-            XNAMessageBox.Show(WindowManager, "Team/Start Mappings",
-                "Team/start mappings allow the host to assign starting locations to teams, not players.\n" +
+            XNAMessageBox.Show(WindowManager, "Auto Allying", 
+                "Auto allying allows the host to assign starting locations to teams, not players.\n" +
                 "When players are assigned to spawn locations, they will be auto assigned to teams based on these mappings.\n" +
-                "This is best used with random teams/starts. However, only random teams is required.\n" +
+                "This is best used with random teams and random starts. However, only random teams is required.\n" +
                 "Manually specified starts will take precedence.\n\n" +
                 $"{TeamStartMapping.NO_TEAM} : Block this location from being assigned to a player.\n" +
                 $"{TeamStartMapping.RANDOM_TEAM} : Allow a player here, but don't assign a team."

--- a/DXMainClient/Domain/Multiplayer/PlayerExtraOptions.cs
+++ b/DXMainClient/Domain/Multiplayer/PlayerExtraOptions.cs
@@ -78,5 +78,15 @@ namespace DTAClient.Domain.Multiplayer
                 TeamStartMappings = TeamStartMapping.FromListString(parts[1])
             };
         }
+
+        public bool IsDefault()
+        {
+            var defaultPLayerExtraOptions = new PlayerExtraOptions();
+            return IsForceRandomColors == defaultPLayerExtraOptions.IsForceRandomColors &&
+                   IsForceRandomStarts == defaultPLayerExtraOptions.IsForceRandomStarts &&
+                   IsForceRandomTeams == defaultPLayerExtraOptions.IsForceRandomTeams &&
+                   IsForceRandomSides == defaultPLayerExtraOptions.IsForceRandomSides &&
+                   IsUseTeamStartMappings == defaultPLayerExtraOptions.IsUseTeamStartMappings;
+        }
     }
 }

--- a/DXMainClient/Domain/Multiplayer/PlayerExtraOptions.cs
+++ b/DXMainClient/Domain/Multiplayer/PlayerExtraOptions.cs
@@ -8,7 +8,7 @@ namespace DTAClient.Domain.Multiplayer
     public class PlayerExtraOptions
     {
         private const string INVALID_OPTIONS_MESSAGE = "Invalid player extra options message";
-        private const string MAPPING_ERROR_PREFIX = "Team/Start Mappings:";
+        private const string MAPPING_ERROR_PREFIX = "Auto Allying:";
         protected static readonly string NOT_ALL_MAPPINGS_ASSIGNED = $"{MAPPING_ERROR_PREFIX} You must have all mappings assigned.";
         protected static readonly string MULTIPLE_MAPPINGS_ASSIGNED_TO_SAME_START = $"{MAPPING_ERROR_PREFIX} Multiple mappings assigned to the same start location.";
         protected static readonly string ONLY_ONE_TEAM = $"{MAPPING_ERROR_PREFIX} You must have more than one team assigned.";


### PR DESCRIPTION
- Fixes an issue where some player drop downs were incorrectly being disabled for the host when they enabled the auto allying. As a result, it was also then triggering all other players to have random teams. 
- "Rebrands" the labels of "team/start mappings" to "auto allying" for a better user understanding.
- Highlights the button to show the player extra options panel if there are options applied that are not the default. This highlighting occurs for both the host and guests.

New label:
![image](https://user-images.githubusercontent.com/2062360/150520356-73cc42f0-a825-4ad2-9663-f04a14fbe03b.png)

Highlighted - non-default options are currently set:
![image](https://user-images.githubusercontent.com/2062360/150520441-2e0f92f2-3cf3-423b-b294-43d8d6bbf733.png)

Not highlighted - default options are currently set:
![image](https://user-images.githubusercontent.com/2062360/150520500-4225ff97-4a71-48ee-bdf9-d4e75239d241.png)


