### PR TITLE
Fix my mistake in literal string translation

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
@@ -175,7 +175,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             btnLogout.Name = nameof(btnLogout);
             btnLogout.ClientRectangle = new Rectangle(Width - 145, btnNewGame.Y,
                 UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
-            btnLogout.Text = "Log Out".L10N("UI:Main:Log Out");
+            btnLogout.Text = "Log Out".L10N("UI:Main:ButtonLogOut");
             btnLogout.LeftClick += BtnLogout_LeftClick;
 
             var gameListRectangle = new Rectangle(

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/TunnelSelectionWindow.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/TunnelSelectionWindow.cs
@@ -68,7 +68,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             btnCancel.Name = nameof(btnCancel);
             btnCancel.Width = UIDesignConstants.BUTTON_WIDTH_92;
             btnCancel.Height = UIDesignConstants.BUTTON_HEIGHT;
-            btnCancel.Text = "Cancel".L10N("UI:Main:Cancel");
+            btnCancel.Text = "Cancel".L10N("UI:Main:ButtonCancel");
             btnCancel.Y = btnApply.Y;
             AddChild(btnCancel);
             btnCancel.LeftClick += BtnCancel_LeftClick;

--- a/DXMainClient/DXGUI/Multiplayer/GameFiltersPanel.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameFiltersPanel.cs
@@ -92,7 +92,7 @@ namespace DTAClient.DXGUI.Multiplayer
 
             var btnResetDefaults = new XNAClientButton(WindowManager);
             btnResetDefaults.Name = nameof(btnResetDefaults);
-            btnResetDefaults.Text = "Reset Defaults".L10N("UI:Main:Reset Defaults");
+            btnResetDefaults.Text = "Reset Defaults".L10N("UI:Main:ResetDefaults");
             btnResetDefaults.ClientRectangle = new Rectangle(
                 gap, ddMaxPlayerCount.Y + UIDesignConstants.BUTTON_HEIGHT + gap,
                 UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT
@@ -101,7 +101,7 @@ namespace DTAClient.DXGUI.Multiplayer
 
             var btnSave = new XNAClientButton(WindowManager);
             btnSave.Name = nameof(btnSave);
-            btnSave.Text = "Save".L10N("UI:Main:Save");
+            btnSave.Text = "Save".L10N("UI:Main:ButtonSave");
             btnSave.ClientRectangle = new Rectangle(
                 gap, btnResetDefaults.Y + UIDesignConstants.BUTTON_HEIGHT + gap,
                 UIDesignConstants.BUTTON_WIDTH_92, UIDesignConstants.BUTTON_HEIGHT
@@ -110,7 +110,7 @@ namespace DTAClient.DXGUI.Multiplayer
 
             var btnCancel = new XNAClientButton(WindowManager);
             btnCancel.Name = nameof(btnCancel);
-            btnCancel.Text = "Cancel".L10N("UI:Main:Cancel");
+            btnCancel.Text = "Cancel".L10N("UI:Main:ButtonCancel");
             btnCancel.ClientRectangle = new Rectangle(
                 Width - gap - UIDesignConstants.BUTTON_WIDTH_92, btnSave.Y,
                 UIDesignConstants.BUTTON_WIDTH_92, UIDesignConstants.BUTTON_HEIGHT

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -527,7 +527,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             if (Players.Count >= playerLimit)
             {
-                AddNotice("Player limit reached; the game room has been locked.".L10N("UI:Main:GameRoomNumberLimitReached"));
+                AddNotice("Player limit reached. The game room has been locked.".L10N("UI:Main:GameRoomNumberLimitReached"));
                 LockGame();
             }
         }
@@ -560,7 +560,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             if (e.ModeString == "+i")
             {
                 if (Players.Count >= playerLimit)
-                    AddNotice("Player limit reached; the game room has been locked.".L10N("UI:Main:GameRoomNumberLimitReached"));
+                    AddNotice("Player limit reached. The game room has been locked.".L10N("UI:Main:GameRoomNumberLimitReached"));
                 else
                     AddNotice("The game host has locked the game room.".L10N("UI:Main:RoomLockedByHost"));
             }

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
@@ -878,14 +878,14 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         protected virtual void NotVerifiedNotification(int playerIndex)
         {
             if (playerIndex > -1 && playerIndex < Players.Count)
-                AddNotice(string.Format("Unable to launch game; player {0} hasn't been verified.".L10N("UI:Main:NotVerifiedNotification"), Players[playerIndex].Name));
+                AddNotice(string.Format("Unable to launch game. Player {0} hasn't been verified.".L10N("UI:Main:NotVerifiedNotification"), Players[playerIndex].Name));
         }
 
         protected virtual void StillInGameNotification(int playerIndex)
         {
             if (playerIndex > -1 && playerIndex < Players.Count)
             {
-                AddNotice(String.Format("Unable to launch game; player {0} is still playing the game you started previously.".L10N("UI:Main:StillInGameNotification"),
+                AddNotice(String.Format("Unable to launch game. Player {0} is still playing the game you started previously.".L10N("UI:Main:StillInGameNotification"),
                     Players[playerIndex].Name));
             }
         }

--- a/DXMainClient/PreStartup.cs
+++ b/DXMainClient/PreStartup.cs
@@ -170,7 +170,7 @@ namespace DTAClient
                 ex.Message + Environment.NewLine + Environment.NewLine + (crashLogCopied ?
                 "A crash log has been saved to the following file:".L10N("UI:Main:FatalErrorText2") + " " + Environment.NewLine + Environment.NewLine +
                 errorLogPath + Environment.NewLine + Environment.NewLine : "") +
-                (crashLogCopied ? "If the issue is repeatable, contact the {1} staff at {2} and provide the crash log file.".L10N("UI:DXMainClient:FatalErrorText3") :
+                (crashLogCopied ? "If the issue is repeatable, contact the {1} staff at {2} and provide the crash log file.".L10N("UI:Main:FatalErrorText3") :
                 "If the issue is repeatable, contact the {1} staff at {2}.".L10N("UI:Main:FatalErrorText4")),
                 MainClientConstants.GAME_NAME_LONG,
                 MainClientConstants.GAME_NAME_SHORT,
@@ -186,8 +186,8 @@ namespace DTAClient
             DialogResult dr = MessageBox.Show(string.Format(("You seem to be running {0} from a write-protected directory." + Environment.NewLine + Environment.NewLine +
                 "For {1} to function properly when run from a write-protected directory, it needs administrative priveleges." + Environment.NewLine + Environment.NewLine +
                 "Would you like to restart the client with administrative rights?" + Environment.NewLine + Environment.NewLine +
-                "Please also make sure that your security software isn't blocking {1}.").L10N("UI:DXMainClient:AdminRequiredText"), MainClientConstants.GAME_NAME_LONG, MainClientConstants.GAME_NAME_SHORT),
-                "Administrative priveleges required".L10N("UI:DXMainClient:AdminRequiredTitle"), MessageBoxButtons.YesNo);
+                "Please also make sure that your security software isn't blocking {1}.").L10N("UI:Main:AdminRequiredText"), MainClientConstants.GAME_NAME_LONG, MainClientConstants.GAME_NAME_SHORT),
+                "Administrative priveleges required".L10N("UI:Main:AdminRequiredTitle"), MessageBoxButtons.YesNo);
 
             if (dr == DialogResult.No)
                 Environment.Exit(0);

--- a/DXMainClient/PreStartup.cs
+++ b/DXMainClient/PreStartup.cs
@@ -166,16 +166,16 @@ namespace DTAClient
             }
             catch { }
 
-            MessageBox.Show(string.Format("{0} has crashed. Error message:".L10N("UI:DXMainClient:FatalErrorText1") + Environment.NewLine + Environment.NewLine +
+            MessageBox.Show(string.Format("{0} has crashed. Error message:".L10N("UI:Main:FatalErrorText1") + Environment.NewLine + Environment.NewLine +
                 ex.Message + Environment.NewLine + Environment.NewLine + (crashLogCopied ?
-                "A crash log has been saved to the following file:".L10N("UI:DXMainClient:FatalErrorText2") + " " + Environment.NewLine + Environment.NewLine +
+                "A crash log has been saved to the following file:".L10N("UI:Main:FatalErrorText2") + " " + Environment.NewLine + Environment.NewLine +
                 errorLogPath + Environment.NewLine + Environment.NewLine : "") +
                 (crashLogCopied ? "If the issue is repeatable, contact the {1} staff at {2} and provide the crash log file.".L10N("UI:DXMainClient:FatalErrorText3") :
-                "If the issue is repeatable, contact the {1} staff at {2}.".L10N("UI:DXMainClient:FatalErrorText4")),
+                "If the issue is repeatable, contact the {1} staff at {2}.".L10N("UI:Main:FatalErrorText4")),
                 MainClientConstants.GAME_NAME_LONG,
                 MainClientConstants.GAME_NAME_SHORT,
                 MainClientConstants.SUPPORT_URL_SHORT),
-                "KABOOOOOOOM".L10N("UI:DXMainClient:FatalErrorTitle"), MessageBoxButtons.OK);
+                "KABOOOOOOOM".L10N("UI:Main:FatalErrorTitle"), MessageBoxButtons.OK);
         }
 
         private static void CheckPermissions()

--- a/DXMainClient/Program.cs
+++ b/DXMainClient/Program.cs
@@ -95,7 +95,7 @@ namespace DTAClient
                 {
                     case "-NOAUDIO":
                         // TODO fix
-                        throw new NotImplementedException("-NOAUDIO is currently not implemented, please run the client without it.".L10N("UI:DXMainClient:NoAudio"));
+                        throw new NotImplementedException("-NOAUDIO is currently not implemented, please run the client without it.".L10N("UI:Main:NoAudio"));
                     case "-MULTIPLEINSTANCE":
                         multipleInstanceMode = true;
                         break;

--- a/Localization/TranslationTable.cs
+++ b/Localization/TranslationTable.cs
@@ -161,6 +161,9 @@ namespace Localization
             if (raw.Contains(IniNewLinePattern))
                 throw new Exception($"Pattern {IniNewLinePattern} is forbidden as this pattern is used to represent the new line.");
 
+            if (raw.Contains(";"))
+                throw new Exception("The semi-colon(;) is forbidden as this pattern is used to represent a comment line.");
+
             string value = raw.Replace(Environment.NewLine, "\n");
             value = value.Replace("\n", IniNewLinePattern);
             return value;


### PR DESCRIPTION
There are four strings in the source code that contains the semi-colon(`;`) character.
When generating the stub file, this character is written to the .ini file.
But when the .ini file be loaded again, everything behind this character is regarded as a comment, i.e. be ignored.
(P.S. it seems that most C# library that handles .ini file would not throw an exception if some special characters are in the value. It should throws.)

In this PR I replace the `;` with `.` for these four strings.

Besides, some label name contains space or does not have the expected prefix (although it still works). These names are now get corrected.
