### PR TITLE
Fix the inconsistency of the map indicator

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
@@ -492,7 +492,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
                 if (pInfo.TeamId > 0)
                 {
-                    text = teamIds[pInfo.TeamId] + text;
+                    text = teamIds[pInfo.TeamId] + " " + text;
                 }
 
                 int index = i;


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/11227602/152577543-7ab7c097-3803-4bf1-acba-52e29a614521.png)
Now there will always be a space between the team name and the player name.

DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
```cs
text = teamIds[pInfo.TeamId] + text;
```

DXMainClient/DXGUI/Multiplayer/GameLobby/PlayerLocationIndicator.cs
```cs
text = pInfo.TeamId > 0 ? pInfo.Name + " " + teamIds[pInfo.TeamId] : pInfo.Name;
```