### PR TITLE
Toggleable map preview box ExtraTextures

### DIFF
--- a/ClientCore/Settings/UserINISettings.cs
+++ b/ClientCore/Settings/UserINISettings.cs
@@ -69,6 +69,7 @@ namespace ClientCore
             ClientResolutionY = new IntSetting(iniFile, VIDEO, "ClientResolutionY", Screen.PrimaryScreen.Bounds.Height);
             BorderlessWindowedClient = new BoolSetting(iniFile, VIDEO, "BorderlessWindowedClient", true);
             ClientFPS = new IntSetting(iniFile, VIDEO, "ClientFPS", 60);
+            DisplayToggleableExtraTextures = new BoolSetting(iniFile, VIDEO, "DisplayToggleableExtraTextures", true);
 
             ScoreVolume = new DoubleSetting(iniFile, AUDIO, "ScoreVolume", 0.7);
             SoundVolume = new DoubleSetting(iniFile, AUDIO, "SoundVolume", 0.7);
@@ -146,6 +147,7 @@ namespace ClientCore
         public IntSetting ClientResolutionY { get; private set; }
         public BoolSetting BorderlessWindowedClient { get; private set; }
         public IntSetting ClientFPS { get; private set; }
+        public BoolSetting DisplayToggleableExtraTextures { get; private set; }
 
         /*********/
         /* AUDIO */

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
@@ -501,7 +501,9 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 buttonX = btnToggleExtraTextures.X;
             }
             else
+            {
                 btnToggleExtraTextures.Disable();
+            }
 
             btnToggleFavoriteMap.ClientRectangle = new Rectangle(buttonX - 22, 4, 18, 18);
 

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
@@ -21,11 +21,13 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
     {
         public Texture2D Texture;
         public Point Point;
+        public bool Toggleable;
 
-        public ExtraMapPreviewTexture(Texture2D texture, Point point)
+        public ExtraMapPreviewTexture(Texture2D texture, Point point, bool toggleable)
         {
             Texture = texture;
             Point = point;
+            Toggleable = toggleable;
         }
     }
 
@@ -133,12 +135,15 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         private List<PlayerInfo> players;
         private List<PlayerInfo> aiPlayers;
 
+        private XNAContextMenu mainContextMenu;
         private XNAContextMenu contextMenu;
         private Point lastContextMenuPoint;
 
         private XNAContextMenu mapContextMenu;
         private XNAContextMenuItem toggleFavoriteMapItem;
+        private XNAContextMenuItem toggleExtraTexturesItem;
         private XNAClientButton btnToggleFavoriteMap;
+        private XNAClientButton btnToggleExtraTextures;
 
         private CoopBriefingBox briefingBox;
 
@@ -170,6 +175,12 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             disposeTextures = !UserINISettings.Instance.PreloadMapPreviews;
 #endif
 
+            mainContextMenu = new XNAContextMenu(WindowManager);
+            mainContextMenu.Name = nameof(mainContextMenu);
+            mainContextMenu.ClientRectangle = new Rectangle(0, 0, 150, 2);
+            mainContextMenu.Disable();
+            AddChild(mainContextMenu);
+
             contextMenu = new XNAContextMenu(WindowManager);
             contextMenu.Tag = -1;
             contextMenu.ClientRectangle = new Rectangle(0, 0, 150, 2);
@@ -178,19 +189,34 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             toggleFavoriteMapItem = new XNAContextMenuItem()
             {
-                Text = "Favorite".L10N("UI:Main:Favorite"),
+                Text = "Add Favorite".L10N("UI:Main:AddFavorite"),
                 SelectAction = ToggleFavoriteMap,
                 SelectableChecker = () => GameModeMap != null
             };
+            toggleExtraTexturesItem = new XNAContextMenuItem()
+            {
+                Text = "Hide Extra Icons".L10N("UI:Main:HideExtraIcons"),
+                SelectAction = ToggleExtraTextures,
+                SelectableChecker = () => GameModeMap != null,
+                VisibilityChecker = () => extraTextures.Any(x => x.Toggleable)
+            };
             mapContextMenu = new XNAContextMenu(WindowManager);
-            mapContextMenu.ClientRectangle = new Rectangle(0, 0, 100, 2);
+            mapContextMenu.ClientRectangle = new Rectangle(0, 0, 120, 2);
             mapContextMenu.AddItem(toggleFavoriteMapItem);
+            mapContextMenu.AddItem(toggleExtraTexturesItem);
 
             btnToggleFavoriteMap = new XNAClientButton(WindowManager);
             btnToggleFavoriteMap.IdleTexture = AssetLoader.LoadTexture("favInactive.png");
             btnToggleFavoriteMap.HoverTexture = AssetLoader.LoadTexture("favInactive.png");
             btnToggleFavoriteMap.LeftClick += (sender, args) => ToggleFavorite?.Invoke(sender, args);
             btnToggleFavoriteMap.SetToolTipText("Toggle Favorite Map".L10N("UI:Main:ToggleFavoriteMap"));
+
+            btnToggleExtraTextures = new XNAClientButton(WindowManager);
+            btnToggleExtraTextures.IdleTexture = AssetLoader.LoadTexture("pvTexturesActive.png");
+            btnToggleExtraTextures.HoverTexture = AssetLoader.LoadTexture("pvTexturesActive.png");
+            btnToggleExtraTextures.LeftClick += (sender, args) => ToggleExtraTextures();
+            btnToggleExtraTextures.SetToolTipText("Toggle Extra Icons".L10N("UI:Main:ToggleExtraIcons"));
+            btnToggleExtraTextures.Disable();
 
             AddChild(mapContextMenu);
             mapContextMenu.Disable();
@@ -206,6 +232,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             RightClick += MapPreviewBox_RightClick;
 
             AddChild(btnToggleFavoriteMap);
+            AddChild(btnToggleExtraTextures);
         }
 
         private void MapPreviewBox_RightClick(object sender, EventArgs e)
@@ -214,12 +241,23 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 return;
 
             toggleFavoriteMapItem.Text = GameModeMap.IsFavorite ? "Remove Favorite".L10N("UI:Main:RemoveFavorite") : "Add Favorite".L10N("UI:Main:AddFavorite");
+            toggleExtraTexturesItem.Text = UserINISettings.Instance.DisplayToggleableExtraTextures ?
+                "Hide Extra Icons".L10N("UI:Main:HideExtraIcons") : "Show Extra Icons".L10N("UI:Main:ShowExtraIcons");
+
             mapContextMenu.Open(GetCursorPoint());
         }
 
         private void ToggleFavoriteMap()
         {
             ToggleFavorite?.Invoke(null, null);
+        }
+
+        private void ToggleExtraTextures()
+        {
+            UserINISettings.Instance.DisplayToggleableExtraTextures.Value =
+                !UserINISettings.Instance.DisplayToggleableExtraTextures;
+
+            RefreshExtraTexturesBtn();
         }
 
         private void ContextMenu_OptionSelected(int index)
@@ -451,9 +489,23 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                               previewTexture.Height - (extraTexture.Height / 2)), mapExtraTexture.Level),
                               ratio);
 
-                extraTextures.Add(new ExtraMapPreviewTexture(extraTexture, location));
+                extraTextures.Add(new ExtraMapPreviewTexture(extraTexture, location, mapExtraTexture.Toggleable));
             }
-            btnToggleFavoriteMap.ClientRectangle = new Rectangle(Width - 22, 4, 18, 18);
+
+            int buttonX = Width;
+
+            if (extraTextures.Any(x => x.Toggleable))
+            {
+                btnToggleExtraTextures.ClientRectangle = new Rectangle(buttonX - 22, 4, 18, 18);
+                btnToggleExtraTextures.Enable();
+                buttonX = btnToggleExtraTextures.X;
+            }
+            else
+                btnToggleExtraTextures.Disable();
+
+            btnToggleFavoriteMap.ClientRectangle = new Rectangle(buttonX - 22, 4, 18, 18);
+
+            RefreshExtraTexturesBtn();
             RefreshFavoriteBtn();
         }
 
@@ -462,6 +514,14 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             var asset = UserINISettings.Instance.IsFavoriteMap(GameModeMap?.Map.Name, GameModeMap?.GameMode.Name) ? "favActive.png" : "favInactive.png";
             btnToggleFavoriteMap.IdleTexture = AssetLoader.LoadTexture(asset);
             btnToggleFavoriteMap.HoverTexture = AssetLoader.LoadTexture(asset);
+        }
+
+
+        public void RefreshExtraTexturesBtn()
+        {
+            var asset = UserINISettings.Instance.DisplayToggleableExtraTextures ? "pvTexturesActive.png" : "pvTexturesInactive.png";
+            btnToggleExtraTextures.IdleTexture = AssetLoader.LoadTexture(asset);
+            btnToggleExtraTextures.HoverTexture = AssetLoader.LoadTexture(asset);
         }
 
         private Point PreviewTexturePointToControlAreaPoint(Point previewTexturePoint, double scaleRatio)
@@ -589,10 +649,13 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
                 foreach (var extraTexture in extraTextures)
                 {
-                    Renderer.DrawTexture(extraTexture.Texture,
-                        new Rectangle(renderPoint.X + extraTexture.Point.X,
-                        renderPoint.Y + extraTexture.Point.Y,
-                        extraTexture.Texture.Width, extraTexture.Texture.Height), Color.White);
+                    if (!extraTexture.Toggleable || UserINISettings.Instance.DisplayToggleableExtraTextures)
+                    {
+                        Renderer.DrawTexture(extraTexture.Texture,
+                            new Rectangle(renderPoint.X + extraTexture.Point.X,
+                            renderPoint.Y + extraTexture.Point.Y,
+                            extraTexture.Texture.Width, extraTexture.Texture.Height), Color.White);
+                    }
                 }
             }
             else if (DrawBorders)

--- a/DXMainClient/Domain/Multiplayer/Map.cs
+++ b/DXMainClient/Domain/Multiplayer/Map.cs
@@ -18,12 +18,14 @@ namespace DTAClient.Domain.Multiplayer
         public string TextureName;
         public Point Point;
         public int Level;
+        public bool Toggleable;
 
-        public ExtraMapPreviewTexture(string textureName, Point point, int level)
+        public ExtraMapPreviewTexture(string textureName, Point point, int level, bool toggleable)
         {
             TextureName = textureName;
             Point = point;
             Level = level;
+            Toggleable = toggleable;
         }
     }
 
@@ -280,9 +282,9 @@ namespace DTAClient.Domain.Multiplayer
                 while (true)
                 {
                     // Format example:
-                    // ExtraTexture0=oilderrick.png,200,150,1
-                    // Last value is map cell level and is optional, defaults to 0 if unspecified.
-
+                    // ExtraTexture0=oilderrick.png,200,150,1,false
+                    // Third value is optional map cell level, defaults to 0 if unspecified.
+                    // Fourth value is optional boolean value that determines if the texture can be toggled on / off.
                     string value = section.GetStringValue("ExtraTexture" + i, null);
 
                     if (string.IsNullOrWhiteSpace(value))
@@ -290,7 +292,7 @@ namespace DTAClient.Domain.Multiplayer
 
                     string[] parts = value.Split(',');
 
-                    if (parts.Length < 3 || parts.Length > 4)
+                    if (parts.Length < 3 || parts.Length > 5)
                     {
                         Logger.Log($"Invalid format for ExtraTexture{i} in map " + BaseFilePath);
                         continue;
@@ -300,11 +302,15 @@ namespace DTAClient.Domain.Multiplayer
                     success &= int.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out int y);
 
                     int level = 0;
+                    bool toggleable = false;
 
                     if (parts.Length > 3)
                         int.TryParse(parts[3], NumberStyles.Integer, CultureInfo.InvariantCulture, out level);
 
-                    extraTextures.Add(new ExtraMapPreviewTexture(parts[0], new Point(x, y), level));
+                    if (parts.Length > 4)
+                        toggleable = Conversions.BooleanFromString(parts[4], false);
+
+                    extraTextures.Add(new ExtraMapPreviewTexture(parts[0], new Point(x, y), level, toggleable));
 
                     i++;
                 }


### PR DESCRIPTION
Client now reads an additional optional boolean value from maps INI for extra textures which tells if it is toggleable or not.

f.ex
`ExtraTexture0=tech-oil.png,59,86,4,true`

If currently selected map has any toggleable textures on it, an additional context menu option and button is shown for toggling these textures on / off - this state is saved in options INI and retained throughout the game lobbies / sessions.
![extraTexturesShown](https://user-images.githubusercontent.com/1392346/154482391-cfd975fe-d374-4bf9-b84c-c470c807801b.png)
![extraTexturesHidden](https://user-images.githubusercontent.com/1392346/154482407-11601d7c-923a-490c-aeb7-55342d26611a.png)

I initially wanted to condense the favourite button and this into something like the Load / Save one for game options but decided against this as I figured some people probably like seeing the favourite status at a glance.
