### PR TITLE
Fix a possible LAN game crash on an unexpected player name

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
@@ -89,6 +89,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 AddNotice(string.Format("{0} has modified game files! They could be cheating!".L10N("UI:Main:PlayerModifiedFiles"), sender));
 
             PlayerInfo pInfo = Players.Find(p => p.Name == sender);
+            if (pInfo == null)
+                return;
 
             pInfo.Verified = true;
         }


### PR DESCRIPTION
There was a reported issue in the #support channel of Discord where someone's client was crashing while hosting a lan game as soon as another player joined. It happens when the "file hash" message is received from the joining user. When this happens, it attempts to find that player in their host's Player list. It attempts to set the `verified` property to `true` on that player. However, the client was not able to find the player in the list for some reason and thus a null pointer exception was being thrown.

I provided a temporary new exe to that person and they verified that they were able to play the game with fellow lan members without issue. I don't know if this change will cause any issues though...