### PR TITLE
Allow option to sort map list

### DIFF
--- a/ClientCore/Settings/UserINISettings.cs
+++ b/ClientCore/Settings/UserINISettings.cs
@@ -108,6 +108,7 @@ namespace ClientCore
             AllowPrivateMessagesFromState = new IntSetting(iniFile, MULTIPLAYER, "AllowPrivateMessagesFromState", (int)AllowPrivateMessagesFromEnum.All);
             EnableMapSharing = new BoolSetting(iniFile, MULTIPLAYER, "EnableMapSharing", true);
             AlwaysDisplayTunnelList = new BoolSetting(iniFile, MULTIPLAYER, "AlwaysDisplayTunnelList", false);
+            MapSortState = new IntSetting(iniFile, MULTIPLAYER, "MapSortState", (int)SortDirection.None);
 
             CheckForUpdates = new BoolSetting(iniFile, OPTIONS, "CheckforUpdates", true);
 
@@ -208,6 +209,8 @@ namespace ClientCore
         public BoolSetting EnableMapSharing { get; private set; }
 
         public BoolSetting AlwaysDisplayTunnelList { get; private set; }
+
+        public IntSetting MapSortState { get; private set; }
         
         /*********************/
         /* GAME LIST FILTERS */


### PR DESCRIPTION
This removes the default sorting of maps alphabetically and instead adds a sort button to the left of the game mode drop down list.

The list is not sorted by default. The setting for the sort selection is stored in user ini settings.

![image](https://user-images.githubusercontent.com/2062360/156757512-e5296966-ec4a-4748-972d-9f3126a78685.png)
