### PR TITLE
Fix incorrect hash code implementation

### DIFF
--- a/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
@@ -882,7 +882,7 @@ namespace DTAConfig.OptionPanels
 
             public override int GetHashCode()
             {
-                return Width - Height;
+                return new { Width, Height }.GetHashCode();
             }
         }
     }


### PR DESCRIPTION
```cs
            public override int GetHashCode()
            {
                return new { Width, Height }.GetHashCode();
                // return Width - Height;
            }
```

It follows the best practice at: https://stackoverflow.com/a/4630550.