### PR TITLE
Post v6 updates

### DIFF
--- a/ClientCore/CCIniFile.cs
+++ b/ClientCore/CCIniFile.cs
@@ -36,23 +36,33 @@ namespace ClientCore
 
         protected override void ApplyBaseIni()
         {
-            string basedOn = GetStringValue("INISystem", "BasedOn", string.Empty);
-            if (!string.IsNullOrEmpty(basedOn))
-            {
-                string path;
-                if (basedOn.Contains("$THEME_DIR$"))
-                    path = basedOn.Replace("$THEME_DIR$", ProgramConstants.GetResourcePath().TrimEnd(new char[] { '/', '\\' }));
-                else
-                    path = Path.GetDirectoryName(FileName) + "/" + basedOn;
+            string basedOnSetting = GetStringValue("INISystem", "BasedOn", string.Empty);
+            if (string.IsNullOrEmpty(basedOnSetting))
+                return;
 
-                // Consolidate with the INI file that this INI file is based on
-                if (!File.Exists(path))
-                    Logger.Log(FileName + ": Base INI file not found! " + path);
+            string[] basedOns = basedOnSetting.Split(',');
+            foreach (string basedOn in basedOns)
+                ApplyBasedOnIni(basedOn);
+        }
 
-                CCIniFile baseIni = new CCIniFile(path);
-                ConsolidateIniFiles(baseIni, this);
-                Sections = baseIni.Sections;
-            }
+        private void ApplyBasedOnIni(string basedOn)
+        {
+            if (string.IsNullOrEmpty(basedOn))
+                return;
+            
+            string path;
+            if (basedOn.Contains("$THEME_DIR$"))
+                path = basedOn.Replace("$THEME_DIR$", ProgramConstants.GetResourcePath().TrimEnd(new char[] { '/', '\\' }));
+            else
+                path = Path.GetDirectoryName(FileName) + "/" + basedOn;
+
+            // Consolidate with the INI file that this INI file is based on
+            if (!File.Exists(path))
+                Logger.Log(FileName + ": Base INI file not found! " + path);
+
+            CCIniFile baseIni = new CCIniFile(path);
+            ConsolidateIniFiles(baseIni, this);
+            Sections = baseIni.Sections;
         }
     }
 }

--- a/ClientGUI/INItializableWindow.cs
+++ b/ClientGUI/INItializableWindow.cs
@@ -51,26 +51,51 @@ namespace ClientGUI
             return null;
         }
 
+        /// <summary>
+        /// Attempts to locate the ini config file for the current control.
+        /// Only return a config path if it exists.
+        /// </summary>
+        /// <returns>The ini config file path</returns>
+        protected string GetConfigPath()
+        {
+            string iniFileName = string.IsNullOrWhiteSpace(IniNameOverride) ? Name : IniNameOverride;
+
+            // get theme specific path
+            string configIniPath = Path.Combine(ProgramConstants.GetResourcePath(), $"{iniFileName}.ini");
+            if (File.Exists(configIniPath))
+                return configIniPath;
+
+            // get base path
+            configIniPath = Path.Combine(ProgramConstants.GetBaseResourcePath(), $"{iniFileName}.ini");
+            if (File.Exists(configIniPath))
+                return configIniPath;
+
+            if (iniFileName == Name)
+                return null; // IniNameOverride must be null, no need to continue
+
+            iniFileName = Name;
+            
+            // get theme specific path
+            configIniPath = Path.Combine(ProgramConstants.GetResourcePath(), $"{iniFileName}.ini");
+            if (File.Exists(configIniPath))
+                return configIniPath;
+
+            // get base path
+            configIniPath = Path.Combine(ProgramConstants.GetBaseResourcePath(), $"{iniFileName}.ini");
+            return File.Exists(configIniPath) ? configIniPath : null;
+        }
+
         public override void Initialize()
         {
             if (_initialized)
                 throw new InvalidOperationException("INItializableWindow cannot be initialized twice.");
 
-            string iniFileName = string.IsNullOrWhiteSpace(IniNameOverride) ? Name : IniNameOverride;
+            string configIniPath = GetConfigPath();
 
-            var dsc = Path.DirectorySeparatorChar;
-            string configIniPath = ProgramConstants.GetResourcePath() + iniFileName + ".ini";
-
-            if (!File.Exists(configIniPath))
+            if (string.IsNullOrEmpty(configIniPath))
             {
-                configIniPath = ProgramConstants.GetBaseResourcePath() + iniFileName + ".ini";
-
-                if (!File.Exists(configIniPath))
-                {
-                    base.Initialize();
-                    return;
-                    // throw new FileNotFoundException("Config INI not found: " + configIniPath);
-                }
+                base.Initialize();
+                return;
             }
 
             ConfigIni = new CCIniFile(configIniPath);
@@ -248,5 +273,4 @@ namespace ClientGUI
             return childControl;
         }
     }
-
 }

--- a/ClientGUI/XNAClientButton.cs
+++ b/ClientGUI/XNAClientButton.cs
@@ -40,7 +40,7 @@ namespace ClientGUI
 
         public override void ParseAttributeFromINI(IniFile iniFile, string key, string value)
         {
-            if (key == "MatchTextureSize" && Conversions.BooleanFromString(key, false))
+            if (key == "MatchTextureSize" && Conversions.BooleanFromString(value, false))
             {
                 Width = IdleTexture.Width;
                 Height = IdleTexture.Height;

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -293,7 +293,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 loadSaveGameOptionsMenu.Items.Add(saveConfigMenuItem);
 
                 BtnSaveLoadGameOptions.LeftClick += (sender, args) =>
-                    loadSaveGameOptionsMenu.Open(new Point(BtnSaveLoadGameOptions.X - 74, BtnSaveLoadGameOptions.Y));
+                    loadSaveGameOptionsMenu.Open(GetCursorPoint());
 
                 AddChild(loadSaveGameOptionsMenu);
                 AddChild(loadOrSaveGameOptionPresetWindow);
@@ -1000,7 +1000,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                     foreach (XNADropDown dd in ddPlayerSides)
                         dd.Items[i + RandomSelectorCount].Selectable = false;
 
-                    // Change the sides of players that use the disabled 
+                    // Change the sides of players that use the disabled
                     // side to the default side
                     foreach (PlayerInfo pInfo in playerInfos)
                     {
@@ -1487,7 +1487,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             // As an additional restriction, players can only start from waypoints 0 to 7.
             // That means that if the map already has too many starting waypoints,
-            // we need to move existing (but un-occupied) starting waypoints to point 
+            // we need to move existing (but un-occupied) starting waypoints to point
             // to the stacked locations so we can spawn the players there.
 
 
@@ -1500,7 +1500,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 {
                     startingLocationUsed[houseInfo.RealStartingWaypoint] = true;
 
-                    // If assigned starting waypoint is unknown while the real 
+                    // If assigned starting waypoint is unknown while the real
                     // starting location is known, it means that
                     // the location is shared with another player
                     if (houseInfo.StartingWaypoint == -1)
@@ -1527,7 +1527,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             // For each player, check if they're sharing the starting location
             // with someone else
-            // If they are, find an unused waypoint and assign their 
+            // If they are, find an unused waypoint and assign their
             // starting location to match that
             for (int pId = 0; pId < houseInfos.Length; pId++)
             {
@@ -2119,7 +2119,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
                 if (lowestEnemyAILevel < highestAllyAILevel)
                 {
-                    // Check that the player's AI allies aren't stronger 
+                    // Check that the player's AI allies aren't stronger
                     return RANK_NONE;
                 }
 
@@ -2153,7 +2153,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             if (lowestEnemyAILevel < highestAllyAILevel)
             {
-                // Check that the player's AI allies aren't stronger 
+                // Check that the player's AI allies aren't stronger
                 return RANK_NONE;
             }
 

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -209,6 +209,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             MapPreviewBox = FindChild<MapPreviewBox>("MapPreviewBox");
             MapPreviewBox.SetFields(Players, AIPlayers, MPColors, GameOptionsIni.GetStringValue("General", "Sides", String.Empty).Split(','), GameOptionsIni);
+            MapPreviewBox.ToggleFavorite += MapPreviewBox_ToggleFavorite;
 
             lblMapName = FindChild<XNALabel>(nameof(lblMapName));
             lblMapAuthor = FindChild<XNALabel>(nameof(lblMapAuthor));

--- a/DXMainClient/Resources/DTA/GlobalThemeSettings.ini
+++ b/DXMainClient/Resources/DTA/GlobalThemeSettings.ini
@@ -6,6 +6,7 @@
 
 ;Use DTACnCNetClient.ini to configure theme-specific settings.
 
+
 [General]
 ; The color of most strings in the UI.
 UILabelColor=0,185,0

--- a/Docs/INISystem.md
+++ b/Docs/INISystem.md
@@ -1,0 +1,189 @@
+﻿# Instructions on how to construct the UI using INI files.
+*TODO work in progress*
+
+## Constants
+
+The `[ParserConstants]` section of the `GlobalThemeSettings.ini` file contains constants that can be used in other INI files.
+
+### Predefined System Constants
+
+`RESOLUTION_WIDTH`: the width of the window when it is initialized  
+`RESOLUTION_HEIGHT`: the height of the window when it is initialized  
+
+### User Defined Constants
+
+```
+MY_EXAMPLE_CONSTANT=15
+```
+The above user-defined or system constants can be used elsewhere as:
+```
+[MyExampleControl]
+$X=MY_EXAMPLE_CONSTANT
+```
+_NOTE: Constants can only be used in [dynamic control properties](#dynamic-control-properties)_
+
+## Control properties: 
+Below lists basic and dynamic control properties. Ordering of properties is important. If there is a property that relies on the size of a control, the properties must set the size of that control first.
+
+
+### Basic Control Properties
+Basic control properties cannot use constants
+
+#### XNAControl
+
+`X` = `{integer}` the X location of the control  
+`Y` = `{integer}` the Y location of the control  
+`Location` = `{comma separated integers}` the X and Y location of the control.  
+`Width` = `{integer}` the Width of the control  
+`Height` = `{integer}` the Height of the control  
+`Size` = `{comma separated integers}` the Width and Height of the control.  
+`Text` = `{string}` the text to display for the control (ex: buttons, labels, etc...)  
+`Visible` = `{true/false or yes/no}` whether or not the control should be visible by default  
+`Enabled` = `{true/false or yes/no}` whether or not the control should be enabled by default  
+`DistanceFromRightBorder` = `{integer}` the distance of the right edge of this control from the right edge of its parent. This control MUST have a parent.  
+`DistanceFromBottomBorder` = `{integer}` the distance of the bottom edge of this control from the bottom edge of its parent. This control MUST have a parent.  
+`FillWidth` = `{integer}` this will set the width of this control to fill the parent/window MINUS this value, starting from the its X position  
+`FillHeight` = `{integer}` this will set the height of this control to fill the parent/window MINUS this value, starting from the its Y position  
+`DrawOrder`  
+`UpdateOrder`  
+`RemapColor`  
+
+#### XNAPanel
+_(inherits XNAControl)_
+
+`BorderColor`  
+`DrawMode`  
+`AlphaRate`  
+`BackgroundTexture`  
+`SolidColorBackgroundTexture`  
+`DrawBorders`  
+`Padding`  
+
+#### XNAExtraPanel
+_(inherits XNAPanel)_
+
+`BackgroundTexture`  
+
+#### XNALabel
+_(inherits XNAControl)_
+
+`RemapColor`  
+`TextColor`  
+`FontIndex`  
+`AnchorPoint`  
+`TextAnchor`  
+`TextShadowDistance`  
+
+#### XNAButton
+_(inherits XNAControl)_
+
+`TextColorIdle`  
+`TextColorHover`  
+`HoverSoundEffect`   
+`ClickSoundEffect`  
+`AdaptiveText`  
+`AlphaRate`  
+`FontIndex`  
+`IdleTexture`  
+`HoverTexture`  
+`TextShadowDistance`  
+
+#### XNAClientButton
+_(inherits XNAButton)_
+
+`MatchTextureSize`  
+
+#### XNALinkButton
+_(inherits XNAClientButton)_
+
+`URL`  
+`ToolTip` = {string} tooltip for checkbox. '@' can be used for newlines  
+
+#### XNACheckbox
+_(inherits XNAControl)_
+
+`FontIndex`  
+`IdleColor`  
+`HighlightColor`  
+`AlphaRate`  
+`AllowChecking`  
+`Checked`  
+
+#### XNAClientCheckbox
+_(inherits XNACheckbox)_
+
+`ToolTip` = {string} tooltip for checkbox. '@' can be used for newlines
+
+#### XNADropDown
+_(inherits XNAControl)_
+
+`OpenUp`  
+`DropDownTexture`  
+`DropDownOpenTexture`  
+`ItemHeight`  
+`ClickSoundEffect`  
+`FontIndex`   
+`BorderColor`  
+`FocusColor`  
+`BackColor`  
+`~~DisabledItemColor~~`  
+`OptionN`  
+
+#### XNAClientDropDown
+_(inherits XNADropDown)_
+
+`ToolTip` = {string} tooltip for checkbox. '@' can be used for newlines  
+
+#### XNATabControl
+_(inherits XNAControl)_
+
+`RemapColor`  
+`TextColor`  
+`TextColorDisabled`  
+`RemoveTabIndexN`  
+
+#### XNATextBox
+_(inherits XNAControl)_
+
+`MaximumTextLength`  
+
+### Basic Control Property Examples
+```
+X=100
+Y=100
+Location=100,100
+Width=100
+Height=100
+Size=100,100
+Visible=true
+Visible=yes
+Enabled=true
+Enabled=yes
+DistanceFromRightBorder=10
+DistanceFromLeftBorder=10
+FillWidth=10
+FillHeight=10
+```
+
+### Dynamic Control Properties
+Dynamic Control Properties CAN use constants
+
+These can ONLY be used in parent controls that inherit the `INItializableWindow` class
+
+`$X` = ``{integer}`` the X location of the control  
+`$Y` = ``{integer}`` the Y location of the control  
+`$Width` = ``{integer}`` the Width of the control  
+`$Height` = ``{integer}`` the Height of the control  
+`$TextAnchor`  
+
+### Dynamic Control Property Examples
+```
+$X=100
+$X=MY_X_CONSTANT
+$Y=100
+$Y=MY_Y_CONSTANT
+$Width=100
+$Width=MY_WIDTH_CONSTANT
+$Height=100
+$Height=MY_HEIGHT_CONSTANT
+```


### PR DESCRIPTION
- Improve ini config file locating
  - This slightly improves the backwards compatibility of the new INItializableWindow implementation.
  - With the initial INItializableWindow updates, there seemed to be no inheritance of which ini config file to load for a given class implementing INItializableWindow. If it has an override ini name, it would attempt to use it, but not fall back to the name of the control itself, which could be the parent class' name.
- Make BasedOn a list for multi inheritance
- Fix missing toggle fav map event
- Add starting documentation for INI system
- Fix bug in XNAClientButton