### PR TITLE
Fix broken PlayerExtraOptionsPanel, adjust its layout to fit TSC better

### DIFF
--- a/DXMainClient/DXGUI/Generic/LoadingScreen.cs
+++ b/DXMainClient/DXGUI/Generic/LoadingScreen.cs
@@ -90,6 +90,7 @@ namespace DTAClient.DXGUI.Generic
             ClientGUICreator.Instance.AddControl(typeof(GameLaunchButton));
             ClientGUICreator.Instance.AddControl(typeof(ChatListBox));
             ClientGUICreator.Instance.AddControl(typeof(XNAChatTextBox));
+            ClientGUICreator.Instance.AddControl(typeof(PlayerExtraOptionsPanel));
 
             var gameCollection = new GameCollection();
             gameCollection.Initialize(GraphicsDevice);

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -52,8 +52,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         public GameLobbyBase(
             WindowManager windowManager,
             string iniName,
-            MapLoader mapLoader, 
-            bool isMultiplayer, 
+            MapLoader mapLoader,
+            bool isMultiplayer,
             DiscordHandler discordHandler
         ) : base(windowManager)
         {
@@ -291,7 +291,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 loadSaveGameOptionsMenu.Items.Add(loadConfigMenuItem);
                 loadSaveGameOptionsMenu.Items.Add(saveConfigMenuItem);
 
-                BtnSaveLoadGameOptions.LeftClick += (sender, args) => 
+                BtnSaveLoadGameOptions.LeftClick += (sender, args) =>
                     loadSaveGameOptionsMenu.Open(new Point(BtnSaveLoadGameOptions.X - 74, BtnSaveLoadGameOptions.Y));
 
                 AddChild(loadSaveGameOptionsMenu);
@@ -315,13 +315,6 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
         private Func<List<GameModeMap>> GetGameModeMaps(GameMode gm) => () =>
             GameModeMaps.Where(gmm => gmm.GameMode == gm).ToList();
-
-        private void InitializePlayerExtraOptionsPanel()
-        {
-            PlayerExtraOptionsPanel = new PlayerExtraOptionsPanel(WindowManager);
-            PlayerExtraOptionsPanel.ClientRectangle = new Rectangle(PlayerOptionsPanel.X, PlayerOptionsPanel.Y, PlayerOptionsPanel.Width, PlayerOptionsPanel.Height);
-            PlayerExtraOptionsPanel.OptionsChanged += PlayerExtraOptions_OptionsChanged;
-        }
 
         private void RefreshBthPlayerExtraOptionsOpenTexture()
         {
@@ -402,7 +395,13 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 ChangeMap(GameModeMap);
         }
 
-        protected void BtnPlayerExtraOptions_LeftClick(object sender, EventArgs e) => PlayerExtraOptionsPanel.Enable();
+        protected void BtnPlayerExtraOptions_LeftClick(object sender, EventArgs e)
+        {
+            if (PlayerExtraOptionsPanel.Enabled)
+                PlayerExtraOptionsPanel.Disable();
+            else
+                PlayerExtraOptionsPanel.Enable();
+        }
 
         protected void ApplyPlayerExtraOptions(string sender, string message)
         {
@@ -784,11 +783,11 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             btnPlayerExtraOptionsOpen = FindChild<XNAClientButton>(nameof(btnPlayerExtraOptionsOpen), true);
             if (btnPlayerExtraOptionsOpen != null)
             {
+                PlayerExtraOptionsPanel = FindChild<PlayerExtraOptionsPanel>(nameof(PlayerExtraOptionsPanel));
+                PlayerExtraOptionsPanel.Disable();
+                PlayerExtraOptionsPanel.OptionsChanged += PlayerExtraOptions_OptionsChanged;
                 btnPlayerExtraOptionsOpen.LeftClick += BtnPlayerExtraOptions_LeftClick;
-                PlayerOptionsPanel.AddChild(btnPlayerExtraOptionsOpen);
-                ReadINIForControl(btnPlayerExtraOptionsOpen);
             }
-
 
             CheckDisallowedSides();
         }

--- a/DXMainClient/DXGUI/Multiplayer/PlayerExtraOptionsPanel.cs
+++ b/DXMainClient/DXGUI/Multiplayer/PlayerExtraOptionsPanel.cs
@@ -14,7 +14,7 @@ namespace DTAClient.DXGUI.Multiplayer
     {
         private const int maxStartCount = 8;
         private const int defaultX = 24;
-        private const int defaultTeamStartMappingX = 200;
+        private const int defaultTeamStartMappingX = UIDesignConstants.EMPTY_SPACE_SIDES;
         private const int teamMappingPanelWidth = 50;
         private const int teamMappingPanelHeight = 22;
         private readonly string customPresetName = "Custom".L10N("UI:Main:CustomPresetName");
@@ -207,7 +207,7 @@ namespace DTAClient.DXGUI.Multiplayer
             chkBoxUseTeamStartMappings = new XNAClientCheckBox(WindowManager);
             chkBoxUseTeamStartMappings.Name = nameof(chkBoxUseTeamStartMappings);
             chkBoxUseTeamStartMappings.Text = "Enable Auto Allying:".L10N("UI:Main:EnableAutoAllying");
-            chkBoxUseTeamStartMappings.ClientRectangle = new Rectangle(defaultTeamStartMappingX, lblHeader.Y, 0, 0);
+            chkBoxUseTeamStartMappings.ClientRectangle = new Rectangle(chkBoxForceRandomSides.X, chkBoxForceRandomStarts.Bottom + 20, 0, 0);
             chkBoxUseTeamStartMappings.CheckedChanged += ChkBoxUseTeamStartMappings_Changed;
             AddChild(chkBoxUseTeamStartMappings);
 
@@ -233,7 +233,7 @@ namespace DTAClient.DXGUI.Multiplayer
             AddChild(ddTeamStartMappingPreset);
 
             teamStartMappingsPanel = new TeamStartMappingsPanel(WindowManager);
-            teamStartMappingsPanel.ClientRectangle = new Rectangle(200, ddTeamStartMappingPreset.Bottom + 8, Width, Height - ddTeamStartMappingPreset.Bottom + 4);
+            teamStartMappingsPanel.ClientRectangle = new Rectangle(lblPreset.X, ddTeamStartMappingPreset.Bottom + 8, Width, Height - ddTeamStartMappingPreset.Bottom + 4);
             AddChild(teamStartMappingsPanel);
 
             AddLocationAssignments();


### PR DESCRIPTION
The massive merge of Tiberian Sun Client v6 changes left the PlayerExtraOptionsPanel broken. My bad.

This should fix it and also adjusts the layout of the panel to fit the layout of the Tiberian Sun Client. As far as I can see, this adjustment shouldn't cause issues for YR.