### PR TITLE
Add GameOptionIndex to game lobby CB and DD

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyCheckBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyCheckBox.cs
@@ -60,6 +60,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         public bool AllowChanges { get; set; } = true;
 
         public CheckBoxMapScoringMode MapScoringMode { get; private set; } = CheckBoxMapScoringMode.Irrelevant;
+        
+        public int GameOptionMessageIndex { get; set; }
 
         private string spawnIniOption;
 
@@ -134,6 +136,9 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                     return;
                 case "MapScoringMode":
                     MapScoringMode = (CheckBoxMapScoringMode)Enum.Parse(typeof(CheckBoxMapScoringMode), value);
+                    return;
+                case "GameOptionMessageIndex":
+                    GameOptionMessageIndex = Conversions.IntFromString(value, 0);
                     return;
             }
 

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyDropDown.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyDropDown.cs
@@ -20,6 +20,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         public int HostSelectedIndex { get; set; }
 
         public int UserSelectedIndex { get; set; }
+        
+        public int GameOptionMessageIndex { get; set; }
 
         private DropDownDataWriteMode dataWriteMode = DropDownDataWriteMode.BOOLEAN;
 
@@ -90,6 +92,9 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                     return;
                 case "OptionName":
                     OptionName = value;
+                    return;
+                case "GameOptionMessageIndex":
+                    GameOptionMessageIndex = Conversions.IntFromString(value, 0);
                     return;
             }
 

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
@@ -183,12 +183,19 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 Logger.Log("MultiplayerGameLobby: Saved games are not available!");
         }
 
+        private void ReorderGameOptions()
+        {
+            CheckBoxes = CheckBoxes.OrderBy(cb => cb.GameOptionMessageIndex).ToList();
+            DropDowns = DropDowns.OrderBy(dd => dd.GameOptionMessageIndex).ToList();
+        }
+
         /// <summary>
         /// Performs initialization that is necessary after derived 
         /// classes have performed their own initialization.
         /// </summary>
         protected void PostInitialize()
         {
+            ReorderGameOptions();
             CenterOnParent();
             LoadDefaultGameModeMap();
         }

--- a/Docs/INISystem.md
+++ b/Docs/INISystem.md
@@ -114,6 +114,21 @@ _(inherits XNACheckbox)_
 
 `ToolTip` = {string} tooltip for checkbox. '@' can be used for newlines
 
+#### GameLobbyCheckBox
+_(inherits XNAClientCheckbox)_
+These checkboxes are specific to the game options in a game lobby.
+
+`SpawnIniOption`  
+`EnabledSpawnIniValue`  
+`DisabledSpawnIniValue`  
+`CustomIniPath`  
+`Reversed`  
+`CheckedMP`  
+`Checked`
+`DisallowedSideIndices`  
+`MapScoringMode`  
+`GameOptionMessageIndex` = `{integer}` The order in which this option is sent in an IRC message to other players in the lobby. This can be used for backwards compatibility if reordering game options in the UI.  
+
 #### XNADropDown
 _(inherits XNAControl)_
 
@@ -131,6 +146,17 @@ _(inherits XNAControl)_
 
 #### XNAClientDropDown
 _(inherits XNADropDown)_
+
+#### GameLobbyDropDown
+_(inherits XNAClientDropDown)_
+These drop downs are specific to the game options in a game lobby.
+
+`Items`  
+`DataWriteMode`  
+`SpawnIniOption`  
+`DefaultIndex`  
+`OptionName`  
+`GameOptionMessageIndex` = `{integer}` The order in which this option is sent in an IRC message to other players in the lobby. This can be used for backwards compatibility if reordering game options in the UI.
 
 `ToolTip` = {string} tooltip for checkbox. '@' can be used for newlines  
 


### PR DESCRIPTION
Checkbox and drop down ordering in the Game Options is important in two areas:
- construction of the game options panel
- IRC messages between clients

Previously, the checkbox and drop down ordering for IRC messages was specified separately in a specific INI value for the multiplayer game lobby INI section. That's no longer the case. Now, it's reliant on the order in which they are declared as a $CC key in the INI file. 

Unfortunately, if they not ordered in the UI in the exact same way they are expected to be sent in the IRC message, there is not a backwards incompatibility between clients. Previously, these game option UI elements were mostly statically located by the INI maintainer, when ideally, they should have been located relative to other controls.

Adding a "GameOptionMessageIndex" key to a GameLobbyCheckbox or GameLobbyDropdown allows the INI maintainer to specify the proper order in which the game option should be sent in the IRC message ensuring backwards compatibility.