### PR TITLE
#301 make player list box reusable and fix list update issues

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
@@ -196,14 +196,9 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             lbGameList.AllowMultiLineItems = false;
             lbGameList.ClientRectangleUpdated += GameList_ClientRectangleUpdated;
 
-            lbPlayerList = new PlayerListBox(WindowManager, gameCollection);
+            lbPlayerList = new PlayerListBox(WindowManager, cncnetUserData, connectionManager, gameCollection);
             lbPlayerList.Name = nameof(lbPlayerList);
-            lbPlayerList.ClientRectangle = new Rectangle(Width - 202,
-                20, 190,
-                btnLogout.Y - 26);
-            lbPlayerList.PanelBackgroundDrawMode = PanelBackgroundImageDrawMode.STRETCHED;
-            lbPlayerList.BackgroundTexture = AssetLoader.CreateTexture(new Color(0, 0, 0, 128), 1, 1);
-            lbPlayerList.LineHeight = 16;
+            lbPlayerList.ClientRectangle = new Rectangle(Width - 202, 20, 190, btnLogout.Y - 26);
             lbPlayerList.DoubleLeftClick += LbPlayerList_DoubleLeftClick;
             lbPlayerList.RightClick += LbPlayerList_RightClick;
 
@@ -649,9 +644,11 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 return;
             }
 
-            var user = (ChannelUser)lbPlayerList.SelectedItem.Tag;
+            var ircUser = lbPlayerList.GetSelectedUser();
+            if (ircUser == null)
+                return;
 
-            globalContextMenu.Show(user, GetCursorPoint());
+            globalContextMenu.Show(ircUser, GetCursorPoint());
         }
 
         private void LbChatMessages_RightClick(object sender, EventArgs e)
@@ -677,9 +674,11 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             if (lbPlayerList.SelectedItem == null)
                 return;
 
-            var channelUser = (ChannelUser)lbPlayerList.SelectedItem.Tag;
+            var ircUser = lbPlayerList.GetSelectedUser();
+            if (ircUser == null)
+                return;
 
-            pmWindow.InitPM(channelUser.IRCUser.Name);
+            pmWindow.InitPM(ircUser.Name);
         }
 
         /// <summary>
@@ -1329,39 +1328,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
         }
 
         private void RefreshPlayerList(object sender, EventArgs e)
-        {
-            string selectedUserName = lbPlayerList.SelectedItem == null ?
-                string.Empty : lbPlayerList.SelectedItem.Text;
-
-            lbPlayerList.Clear();
-
-            var current = currentChatChannel.Users.GetFirst();
-            while (current != null)
-            {
-                var user = current.Value;
-                user.IRCUser.IsFriend = cncnetUserData.IsFriend(user.IRCUser.Name);
-                user.IRCUser.IsIgnored = cncnetUserData.IsIgnored(user.IRCUser.Ident);
-                lbPlayerList.AddUser(user);
-                current = current.Next;
-            }
-
-            if (selectedUserName != string.Empty)
-            {
-                lbPlayerList.SelectedIndex = lbPlayerList.Items.FindIndex(
-                    i => i.Text == selectedUserName);
-            }
-        }
-
-        /// <summary>
-        /// Refreshes a single user's info on the player list.
-        /// </summary>
-        /// <param name="user">User on the current chat channel.</param>
-        private void RefreshPlayerListUser(ChannelUser user)
-        {
-            user.IRCUser.IsFriend = cncnetUserData.IsFriend(user.IRCUser.Name);
-            user.IRCUser.IsIgnored = cncnetUserData.IsIgnored(user.IRCUser.Ident);
-            lbPlayerList.UpdateUserInfo(user);
-        }
+            => lbPlayerList.UpdatePlayers(new PlayerListBoxOptions(currentChatChannel.Users.ToList().Select(u => u.IRCUser).ToList()));
 
         private void CurrentChatChannel_UserGameIndexUpdated(object sender, ChannelUserEventArgs e)
         {

--- a/DXMainClient/DXGUI/Multiplayer/PlayerListBoxOptions.cs
+++ b/DXMainClient/DXGUI/Multiplayer/PlayerListBoxOptions.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using DTAClient.Online;
+
+namespace DTAClient.DXGUI.Multiplayer
+{
+    public class PlayerListBoxOptions
+    {
+        public List<IRCUser> Users { get; set; }
+        public bool HighlightOnline { get; set; }
+        public bool HideFriendIcon { get; set; }
+
+        public PlayerListBoxOptions() : this(null)
+        {
+        }
+
+        public PlayerListBoxOptions(
+            List<IRCUser> users
+        )
+        {
+            Users = users;
+        }
+    }
+}

--- a/DXMainClient/DXMainClient.csproj
+++ b/DXMainClient/DXMainClient.csproj
@@ -520,6 +520,7 @@
     <Compile Include="DXGUI\Multiplayer\CnCNet\PrivateMessageNotificationBox.cs" />
     <Compile Include="DXGUI\Multiplayer\CnCNet\PrivateMessagingPanel.cs" />
     <Compile Include="DXGUI\Multiplayer\CnCNet\PrivateMessagingWindow.cs" />
+    <Compile Include="DXGUI\Multiplayer\PlayerListBoxOptions.cs" />
     <Compile Include="DXGUI\Multiplayer\TeamStartMappingPanel.cs" />
     <Compile Include="DXGUI\Multiplayer\PlayerExtraOptionsPanel.cs" />
     <Compile Include="DXGUI\Multiplayer\PlayerListBox.cs" />

--- a/DXMainClient/Online/CnCNetManager.cs
+++ b/DXMainClient/Online/CnCNetManager.cs
@@ -22,7 +22,7 @@ namespace DTAClient.Online
         // When implementing IConnectionManager functions, pay special attention
         // to thread-safety.
         // The functions in IConnectionManager are usually called from the networking
-        // thread, so if they affect anything in the UI or affect data that the 
+        // thread, so if they affect anything in the UI or affect data that the
         // UI thread might be reading, use WindowManager.AddCallback to execute a function
         // on the UI thread instead of modifying the data or raising events directly.
 
@@ -83,7 +83,7 @@ namespace DTAClient.Online
         private bool connected = false;
 
         /// <summary>
-        /// Gets a value that determines whether the client is 
+        /// Gets a value that determines whether the client is
         /// currently connected to CnCNet.
         /// </summary>
         public bool IsConnected
@@ -120,12 +120,18 @@ namespace DTAClient.Online
             return Connection.IsIdSet();
         }
 
+        public ChannelUser GetChannelUser(IRCUser ircUser) => MainChannel?.Users?.ToList().FirstOrDefault(u => u.IRCUser == ircUser);
+
+        public bool IsAdmin(IRCUser ircUser) => GetChannelUser(ircUser)?.IsAdmin ?? false;
+
+        public bool IsOnline(IRCUser ircUser) => GetChannelUser(ircUser) != null;
+
         /// <summary>
         /// Factory method for creating a new channel.
         /// </summary>
         /// <param name="uiName">The user-interface name of the channel.</param>
         /// <param name="channelName">The name of the channel.</param>
-        /// <param name="persistent">Determines whether the channel's information 
+        /// <param name="persistent">Determines whether the channel's information
         /// should remain in memory even after a disconnect.</param>
         /// <param name="password">The password for the channel. Use null for none.</param>
         /// <returns>A channel.</returns>

--- a/DXMainClient/Online/IUserCollection.cs
+++ b/DXMainClient/Online/IUserCollection.cs
@@ -14,5 +14,6 @@ namespace DTAClient.Online
         LinkedListNode<T> GetFirst();
         void Reinsert(string username);
         bool Remove(string username);
+        List<T> ToList();
     }
 }

--- a/DXMainClient/Online/SortedUserCollection.cs
+++ b/DXMainClient/Online/SortedUserCollection.cs
@@ -57,6 +57,8 @@ namespace DTAClient.Online
             }
         }
 
+        public List<T> ToList() => linkedList.ToList();
+
         public bool Remove(string username)
         {
             if (dictionary.TryGetValue(username.ToLower(), out var node))

--- a/DXMainClient/Online/UnsortedUserCollection.cs
+++ b/DXMainClient/Online/UnsortedUserCollection.cs
@@ -59,5 +59,7 @@ namespace DTAClient.Online
         {
             return dictionary.Remove(username.ToLower());
         }
+
+        public List<T> ToList() => dictionary.Values.ToList();
     }
 }


### PR DESCRIPTION
This makes the PlayerListBox that is used in the CncnetLobby reusable so that it can then be reused in the Private Messaging Window.

It also resolves some issues in "updating" the lists for various actions including: user added, removed, friended, ignored, etc... When these actions occur, this list is updated accordingly where ever it is used and in the same way in all locations.