### PR TITLE
#324 User defined auto ally presets

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/TeamStartMappingPresetsWindow.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/TeamStartMappingPresetsWindow.cs
@@ -1,0 +1,312 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using ClientGUI;
+using DTAClient.Domain.Multiplayer;
+using DTAClient.Online.EventArguments;
+using Localization;
+using Microsoft.Xna.Framework;
+using Rampastring.XNAUI;
+using Rampastring.XNAUI.XNAControls;
+
+namespace DTAClient.DXGUI.Multiplayer.CnCNet
+{
+    public class TeamStartMappingPresetsWindow : XNAWindow
+    {
+        private readonly XNALabel lblHeader;
+
+        private readonly XNADropDownItem ddiCreatePresetItem;
+
+        private readonly XNADropDownItem ddiSelectPresetItem;
+
+        private readonly XNAClientButton btnSave;
+
+        private readonly XNAClientButton btnDelete;
+
+        private readonly XNAClientDropDown ddPresetSelect;
+
+        private readonly XNALabel lblNewPresetName;
+
+        private readonly XNATextBox tbNewPresetName;
+
+        private readonly XNAClientCheckBox chkBoxSetDefault;
+
+        public EventHandler<TeamStartMappingPresetEventArgs> PresetSaved;
+
+        public EventHandler<TeamStartMappingPresetEventArgs> PresetDeleted;
+
+        private Map _map;
+
+        public TeamStartMappingPresetsWindow(WindowManager windowManager) : base(windowManager)
+        {
+            ClientRectangle = new Rectangle(0, 0, 325, 185);
+
+            const int margin = 10;
+
+            lblHeader = new XNALabel(WindowManager);
+            lblHeader.Name = nameof(lblHeader);
+            lblHeader.FontIndex = 1;
+            lblHeader.Text = "Edit Preset".L10N("UI:AutoAllyPresetWindow:EditPreset");
+            lblHeader.ClientRectangle = new Rectangle(
+                margin, margin,
+                150, 22
+            );
+
+            var lblPresetName = new XNALabel(WindowManager);
+            lblPresetName.Name = nameof(lblPresetName);
+            lblPresetName.Text = "Preset".L10N("UI:AutoAllyPresetWindow:Preset");
+            lblPresetName.ClientRectangle = new Rectangle(
+                margin, lblHeader.Bottom + margin,
+                150, 18
+            );
+
+            ddiCreatePresetItem = new XNADropDownItem();
+            ddiCreatePresetItem.Text = "[Create New]".L10N("UI:AutoAllyPresetWindow:CreateNewPreset");
+
+            ddiSelectPresetItem = new XNADropDownItem();
+            ddiSelectPresetItem.Text = "[Select Preset]".L10N("UI:AutoAllyPresetWindow:SelectPreset");
+            ddiSelectPresetItem.Selectable = false;
+
+            ddPresetSelect = new XNAClientDropDown(WindowManager);
+            ddPresetSelect.Name = nameof(ddPresetSelect);
+            ddPresetSelect.ClientRectangle = new Rectangle(
+                10, lblPresetName.Bottom + 2,
+                150, 22
+            );
+            ddPresetSelect.SelectedIndexChanged += DropDownPresetSelect_SelectedIndexChanged;
+
+            chkBoxSetDefault = new XNAClientCheckBox(WindowManager);
+            chkBoxSetDefault.Name = nameof(chkBoxSetDefault);
+            chkBoxSetDefault.ClientRectangle = new Rectangle(ddPresetSelect.Right + 12, ddPresetSelect.Y + 2, 100, 22);
+            chkBoxSetDefault.Text = "Default for Map".L10N("UI:AutoAllyPresetWindow:SetDefaultCheckBox");
+
+            lblNewPresetName = new XNALabel(WindowManager);
+            lblNewPresetName.Name = nameof(lblNewPresetName);
+            lblNewPresetName.Text = "New Preset Name".L10N("UI:AutoAllyPresetWindow:NewPresetName");
+            lblNewPresetName.ClientRectangle = new Rectangle(
+                margin, ddPresetSelect.Bottom + margin,
+                150, 18
+            );
+
+            tbNewPresetName = new XNATextBox(WindowManager);
+            tbNewPresetName.Name = nameof(tbNewPresetName);
+            tbNewPresetName.ClientRectangle = new Rectangle(
+                10, lblNewPresetName.Bottom + 2,
+                150, 22
+            );
+            tbNewPresetName.TextChanged += (sender, args) => RefreshUI();
+
+            btnSave = new XNAClientButton(WindowManager);
+            btnSave.Name = nameof(btnSave);
+            btnSave.LeftClick += BtnSave_LeftClick;
+            btnSave.Text = "Save".L10N("UI:AutoAllyPresetWindow:ButtonSave");
+            btnSave.ClientRectangle = new Rectangle(
+                margin,
+                Height - UIDesignConstants.BUTTON_HEIGHT - margin,
+                UIDesignConstants.BUTTON_WIDTH_92,
+                UIDesignConstants.BUTTON_HEIGHT
+            );
+
+            btnDelete = new XNAClientButton(WindowManager);
+            btnDelete.Name = nameof(btnDelete);
+            btnDelete.Text = "Delete".L10N("UI:AutoAllyPresetWindow:ButtonDelete");
+            btnDelete.LeftClick += BtnDelete_LeftClick;
+            btnDelete.ClientRectangle = new Rectangle(
+                btnSave.Right + margin,
+                btnSave.Y,
+                UIDesignConstants.BUTTON_WIDTH_92,
+                UIDesignConstants.BUTTON_HEIGHT
+            );
+
+            var btnCancel = new XNAClientButton(WindowManager);
+            btnCancel.Name = nameof(btnCancel);
+            btnCancel.Text = "Cancel".L10N("UI:AutoAllyPresetWindow:ButtonCancel");
+            btnCancel.ClientRectangle = new Rectangle(
+                btnDelete.Right + margin,
+                btnSave.Y,
+                UIDesignConstants.BUTTON_WIDTH_92,
+                UIDesignConstants.BUTTON_HEIGHT
+            );
+            btnCancel.LeftClick += (sender, args) => Disable();
+
+            AddChild(lblHeader);
+            AddChild(lblPresetName);
+            AddChild(ddPresetSelect);
+            AddChild(chkBoxSetDefault);
+            AddChild(lblNewPresetName);
+            AddChild(tbNewPresetName);
+            AddChild(btnSave);
+            AddChild(btnDelete);
+            AddChild(btnCancel);
+
+            Disable();
+        }
+
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            PanelBackgroundDrawMode = PanelBackgroundImageDrawMode.STRETCHED;
+            BackgroundTexture = AssetLoader.CreateTexture(new Color(0, 0, 0, 255), 1, 1);
+        }
+
+        /// <summary>
+        /// Show the window.
+        /// </summary>
+        public void Show(Map map, TeamStartMappingPreset preset)
+        {
+            _map = map;
+
+            LoadPresets(preset);
+            tbNewPresetName.Text = string.Empty;
+
+            RefreshUI();
+            CenterOnParent();
+            Enable();
+        }
+
+        /// <summary>
+        /// Refresh the state of the load/save button
+        /// </summary>
+        private void RefreshUI()
+        {
+            btnSave.Enabled = !IsCreatePresetSelected || !IsNewPresetNameFieldEmpty;
+            btnDelete.Enabled = !IsCreatePresetSelected && !IsSelectPresetSelected;
+
+            RefreshNewPresetNameTextBox();
+            RefreshDefaultCheckBox();
+        }
+
+        private void RefreshNewPresetNameTextBox()
+        {
+            lblNewPresetName.Disable();
+            tbNewPresetName.Disable();
+
+            if (!IsCreatePresetSelected)
+                return;
+
+            lblNewPresetName.Enable();
+            tbNewPresetName.Enable();
+        }
+
+        private void RefreshDefaultCheckBox()
+        {
+            chkBoxSetDefault.Disable();
+            if (IsCreatePresetSelected && tbNewPresetName.Text.Trim().Length == 0)
+                return;
+
+            chkBoxSetDefault.Enable();
+            chkBoxSetDefault.Checked = SelectedTeamStartMappingPreset?.IsDefaultForMap ?? false;
+        }
+
+        private bool IsCreatePresetSelected => ddPresetSelect.SelectedItem == ddiCreatePresetItem;
+        private bool IsSelectPresetSelected => ddPresetSelect.SelectedItem == ddiSelectPresetItem;
+        private bool IsNewPresetNameFieldEmpty => string.IsNullOrWhiteSpace(tbNewPresetName.Text);
+
+        private TeamStartMappingPreset SelectedTeamStartMappingPreset => ddPresetSelect.SelectedItem?.Tag as TeamStartMappingPreset;
+
+        private List<TeamStartMappingPreset> AllPresets
+            => ddPresetSelect.Items
+                .Select(i => i.Tag as TeamStartMappingPreset)
+                .Where(preset => preset != null)
+                .ToList();
+
+        private XNADropDownItem CreateItem(TeamStartMappingPreset preset)
+            => new XNADropDownItem
+            {
+                Text = preset.Name,
+                Tag = preset
+            };
+
+
+        /// <summary>
+        /// Populate the preset drop down from saved presets
+        /// </summary>
+        private void LoadPresets(TeamStartMappingPreset initialPreset)
+        {
+            ddPresetSelect.Items.Clear();
+            ddPresetSelect.Items.Add(ddiCreatePresetItem);
+
+            ddPresetSelect.Items.AddRange(_map.TeamStartMappingPresets
+                .Select(CreateItem)
+            );
+
+            ddPresetSelect.Items.AddRange(TeamStartMappingUserPresets.Instance
+                .GetPresets(_map)
+                .OrderBy(preset => preset.Name)
+                .Select(CreateItem));
+
+            int initialIndex = ddPresetSelect.Items.FindIndex(i => i.Tag == initialPreset);
+            ddPresetSelect.SelectedIndex = initialIndex == -1 ? 0 : initialIndex;
+        }
+
+        private void BtnSave_LeftClick(object sender, EventArgs e)
+        {
+            var selectedItem = ddPresetSelect.Items[ddPresetSelect.SelectedIndex];
+            var preset = IsCreatePresetSelected
+                ? new TeamStartMappingPreset
+                {
+                    Name = tbNewPresetName.Text
+                }
+                : selectedItem.Tag as TeamStartMappingPreset;
+
+            if (preset == null)
+                return;
+
+            UpdateDefault(preset);
+
+            PresetSaved?.Invoke(this, new TeamStartMappingPresetEventArgs(_map, preset));
+
+            Disable();
+        }
+
+        private void UpdateDefault(TeamStartMappingPreset preset)
+        {
+            preset.IsDefaultForMap = chkBoxSetDefault.Checked;
+            if (!preset.IsDefaultForMap)
+                return;
+
+            // clear the default flag for all others
+            foreach (TeamStartMappingPreset teamStartMappingPreset in AllPresets.Where(p => p != preset))
+                teamStartMappingPreset.IsDefaultForMap = false;
+        }
+
+        private void BtnDelete_LeftClick(object sender, EventArgs e)
+        {
+            if (IsCreatePresetSelected)
+                return;
+
+            var selectedItem = ddPresetSelect.Items[ddPresetSelect.SelectedIndex];
+            var messageBox = XNAMessageBox.ShowYesNoDialog(WindowManager,
+                "Confirm Preset Delete".L10N("UI:AutoAllyPresetWindow:ConfirmPresetDeleteTitle"),
+                "Are you sure you want to delete this preset?".L10N("UI:AutoAllyPresetWindow:ConfirmPresetDeleteText") + "\n\n" + selectedItem.Text);
+            messageBox.YesClickedAction = box =>
+            {
+                PresetDeleted?.Invoke(this, new TeamStartMappingPresetEventArgs(_map, selectedItem.Tag as TeamStartMappingPreset));
+                ddPresetSelect.Items.Remove(selectedItem);
+                ddPresetSelect.SelectedIndex = 0;
+            };
+        }
+
+        /// <summary>
+        /// Callback when the Preset drop down selection has changed
+        /// </summary>
+        private void DropDownPresetSelect_SelectedIndexChanged(object sender, EventArgs eventArgs)
+        {
+            if (IsCreatePresetSelected)
+            {
+                // show the field to specify a new name when "create" option is selected in drop down
+                tbNewPresetName.Enable();
+                lblNewPresetName.Enable();
+            }
+            else
+            {
+                // hide the field to specify a new name when an existing preset is selected
+                tbNewPresetName.Disable();
+                lblNewPresetName.Disable();
+            }
+
+            RefreshUI();
+        }
+    }
+}

--- a/DXMainClient/DXGUI/Multiplayer/PlayerExtraOptionsPanel.cs
+++ b/DXMainClient/DXGUI/Multiplayer/PlayerExtraOptionsPanel.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using ClientGUI;
 using DTAClient.Domain.Multiplayer;
+using DTAClient.DXGUI.Multiplayer.CnCNet;
+using DTAClient.Online.EventArguments;
 using Localization;
 using Microsoft.Xna.Framework;
 using Rampastring.XNAUI;
@@ -17,7 +19,6 @@ namespace DTAClient.DXGUI.Multiplayer
         private const int defaultTeamStartMappingX = UIDesignConstants.EMPTY_SPACE_SIDES;
         private const int teamMappingPanelWidth = 50;
         private const int teamMappingPanelHeight = 22;
-        private readonly string customPresetName = "Custom".L10N("UI:Main:CustomPresetName");
 
         private XNAClientCheckBox chkBoxForceRandomSides;
         private XNAClientCheckBox chkBoxForceRandomTeams;
@@ -25,7 +26,9 @@ namespace DTAClient.DXGUI.Multiplayer
         private XNAClientCheckBox chkBoxForceRandomStarts;
         private XNAClientCheckBox chkBoxUseTeamStartMappings;
         private XNAClientDropDown ddTeamStartMappingPreset;
+        private XNAClientButton btnEditCustomPreset;
         private TeamStartMappingsPanel teamStartMappingsPanel;
+        private TeamStartMappingPresetsWindow teamStartMappingPresetsWindow;
         private bool _isHost;
         private bool ignoreMappingChanges;
 
@@ -116,41 +119,85 @@ namespace DTAClient.DXGUI.Multiplayer
                     continue;
 
                 teamStartMappingPanel.EnableControls(_isHost && chkBoxUseTeamStartMappings.Checked && i < _map?.MaxPlayers);
-                RefreshTeamStartMappingPresets(_map?.TeamStartMappingPresets);
+                RefreshTeamStartMappingPresets(_map);
             }
+
+            RefreshSaveTeamStartPresetEditBtn();
         }
 
-        private void RefreshTeamStartMappingPresets(List<TeamStartMappingPreset> teamStartMappingPresets)
+        private void RefreshSaveTeamStartPresetEditBtn()
+        {
+            btnEditCustomPreset.Enabled = CanEditTeamStartMappingPreset();
+            string editBtnTexture = btnEditCustomPreset.Enabled ? "settingsBtnActive.png" : "settingsBtnInactive.png";
+            btnEditCustomPreset.IdleTexture = AssetLoader.LoadTexture(editBtnTexture);
+            btnEditCustomPreset.HoverTexture = AssetLoader.LoadTexture(editBtnTexture);
+        }
+
+        private void RefreshTeamStartMappingPresets(Map map)
         {
             ddTeamStartMappingPreset.Items.Clear();
             ddTeamStartMappingPreset.AddItem(new XNADropDownItem
             {
-                Text = customPresetName,
-                Tag = new List<TeamStartMapping>()
+                Text = "Custom".L10N("UI:Main:CustomPresetName"),
+                Tag = new TeamStartMappingPreset()
+                {
+                    IsCustom = true
+                }
             });
             ddTeamStartMappingPreset.SelectedIndex = 0;
 
-            if (!(teamStartMappingPresets?.Any() ?? false)) return;
+            if (map == null)
+                return;
 
-            teamStartMappingPresets.ForEach(preset => ddTeamStartMappingPreset.AddItem(new XNADropDownItem
+            var mapPresets = map.TeamStartMappingPresets ?? new List<TeamStartMappingPreset>();
+
+            mapPresets.ForEach(preset => ddTeamStartMappingPreset.AddItem(new XNADropDownItem
             {
                 Text = preset.Name,
-                Tag = preset.TeamStartMappings
+                Tag = preset
             }));
-            ddTeamStartMappingPreset.SelectedIndex = 1;
+
+            var userDefinedMapPresets = TeamStartMappingUserPresets.Instance.GetPresets(map);
+            userDefinedMapPresets.ForEach(preset => ddTeamStartMappingPreset.AddItem(new XNADropDownItem
+            {
+                Text = $"{TeamStartMappingPreset.UserDefinedPrefx} {preset.Name}",
+                Tag = preset
+            }));
+
+            if (!mapPresets.Any() && !userDefinedMapPresets.Any())
+            {
+                ddTeamStartMappingPreset.SelectedIndex = 0;
+                return;
+            }
+
+            var defaultPresetItem = ddTeamStartMappingPreset.Items
+                .FirstOrDefault(i => (i.Tag as TeamStartMappingPreset)?.IsDefaultForMap ?? false);
+
+            ddTeamStartMappingPreset.SelectedIndex = defaultPresetItem == null ? 0 : ddTeamStartMappingPreset.Items.IndexOf(defaultPresetItem);
         }
 
         private void DdTeamMappingPreset_SelectedIndexChanged(object sender, EventArgs e)
         {
-            var selectedItem = ddTeamStartMappingPreset.SelectedItem;
-            if (selectedItem?.Text == customPresetName)
+            var selectedPreset = GetSelectedTeamStartMappingPreset();
+            RefreshSaveTeamStartPresetEditBtn();
+            if (selectedPreset?.IsCustom ?? true)
                 return;
 
-            var teamStartMappings = selectedItem?.Tag as List<TeamStartMapping>;
-
             ignoreMappingChanges = true;
-            teamStartMappingsPanel.SetTeamStartMappings(teamStartMappings);
+            teamStartMappingsPanel.SetTeamStartMappings(selectedPreset.TeamStartMappings);
             ignoreMappingChanges = false;
+        }
+
+        private TeamStartMappingPreset GetSelectedTeamStartMappingPreset()
+            => ddTeamStartMappingPreset.SelectedItem?.Tag as TeamStartMappingPreset;
+
+        private bool CanEditTeamStartMappingPreset()
+        {
+            if (_map == null || !_isHost || !chkBoxUseTeamStartMappings.Checked)
+                return false;
+
+            var preset = GetSelectedTeamStartMappingPreset();
+            return preset != null;
         }
 
         private void RefreshPresetDropdown() => ddTeamStartMappingPreset.AllowDropDown = _isHost && chkBoxUseTeamStartMappings.Checked;
@@ -227,14 +274,29 @@ namespace DTAClient.DXGUI.Multiplayer
 
             ddTeamStartMappingPreset = new XNAClientDropDown(WindowManager);
             ddTeamStartMappingPreset.Name = nameof(ddTeamStartMappingPreset);
-            ddTeamStartMappingPreset.ClientRectangle = new Rectangle(lblPreset.X + 50, lblPreset.Y - 2, 160, 0);
+            ddTeamStartMappingPreset.ClientRectangle = new Rectangle(lblPreset.X + 40, lblPreset.Y - 2, 146, 0);
             ddTeamStartMappingPreset.SelectedIndexChanged += DdTeamMappingPreset_SelectedIndexChanged;
             ddTeamStartMappingPreset.AllowDropDown = true;
             AddChild(ddTeamStartMappingPreset);
 
+            btnEditCustomPreset = new XNAClientButton(WindowManager);
+            btnEditCustomPreset.Name = nameof(btnEditCustomPreset);
+            btnEditCustomPreset.ClientRectangle = new Rectangle(ddTeamStartMappingPreset.Right + 2, ddTeamStartMappingPreset.Y, 22, 22);
+            btnEditCustomPreset.SetToolTipText("Edit".L10N("UI:Main:BtnEditAutoAllyPresetTooltip"));
+            btnEditCustomPreset.IdleTexture = AssetLoader.LoadTexture("editActive.png");
+            btnEditCustomPreset.HoverTexture = AssetLoader.LoadTexture("editActive.png");
+            btnEditCustomPreset.LeftClick += EditPresetButton_LeftClick;
+            AddChild(btnEditCustomPreset);
+
             teamStartMappingsPanel = new TeamStartMappingsPanel(WindowManager);
             teamStartMappingsPanel.ClientRectangle = new Rectangle(lblPreset.X, ddTeamStartMappingPreset.Bottom + 8, Width, Height - ddTeamStartMappingPreset.Bottom + 4);
             AddChild(teamStartMappingsPanel);
+
+            teamStartMappingPresetsWindow = new TeamStartMappingPresetsWindow(WindowManager);
+            teamStartMappingPresetsWindow.Name = nameof(teamStartMappingPresetsWindow);
+            teamStartMappingPresetsWindow.PresetSaved += (sender, s) => HandleAutoAllyPresetSaveCommand(s);
+            teamStartMappingPresetsWindow.PresetDeleted += (sender, s) => HandleAutoAllyPresetDeleteCommand(s);
+            AddChild(teamStartMappingPresetsWindow);
 
             AddLocationAssignments();
 
@@ -243,15 +305,64 @@ namespace DTAClient.DXGUI.Multiplayer
             RefreshTeamStartMappingsPanel();
         }
 
+        private void HandleAutoAllyPresetSaveCommand(TeamStartMappingPresetEventArgs teamStartMappingPresetEventArgs)
+        {
+            if (teamStartMappingPresetEventArgs.Preset == null)
+                return;
+
+            var teamStartMappings = GetTeamStartMappings();
+            if (!teamStartMappings.Any())
+            {
+                XNAMessageBox.Show(WindowManager, "Cannot Save Presets", "Cannot save auto ally presets without any locations assigned.");
+                return;
+            }
+
+            var teamStartMappingPreset = teamStartMappingPresetEventArgs.Preset;
+            teamStartMappingPreset.TeamStartMappings = teamStartMappings;
+
+            TeamStartMappingUserPresets.Instance.AddOrUpdate(_map, teamStartMappingPreset);
+
+            RefreshTeamStartMappingPresets(_map);
+            ddTeamStartMappingPreset.SelectedIndex = ddTeamStartMappingPreset.Items.FindIndex(i => i.Tag == teamStartMappingPreset);
+        }
+
+        private void HandleAutoAllyPresetDeleteCommand(TeamStartMappingPresetEventArgs teamStartMappingPresetEventArgs)
+        {
+            if (teamStartMappingPresetEventArgs.Preset == null)
+                return;
+
+            TeamStartMappingUserPresets.Instance.DeletePreset(_map, teamStartMappingPresetEventArgs.Preset);
+
+            if (GetSelectedTeamStartMappingPreset() != teamStartMappingPresetEventArgs.Preset)
+                ddTeamStartMappingPreset.SelectedIndex = 0;
+
+            RefreshTeamStartMappingsPanel();
+        }
+
+        private void EditPresetButton_LeftClick(object sender, EventArgs args)
+        {
+            if (_map == null)
+                return;
+
+            teamStartMappingPresetsWindow.Show(_map, GetSelectedTeamStartMappingPreset());
+        }
+
         private void BtnHelp_LeftClick(object sender, EventArgs args)
         {
             XNAMessageBox.Show(WindowManager, "Auto Allying".L10N("UI:Main:AutoAllyingTitle"),
                 ("Auto allying allows the host to assign starting locations to teams, not players.\n" +
-                "When players are assigned to spawn locations, they will be auto assigned to teams based on these mappings.\n" +
-                "This is best used with random teams and random starts. However, only random teams is required.\n" +
-                "Manually specified starts will take precedence.\n\n").L10N("UI:Main:AutoAllyingText1") +
-                $"{TeamStartMapping.NO_TEAM} : " + "Block this location from being assigned to a player.".L10N("UI:Main:AutoAllyingTextNoTeam") + "\n" +
-                $"{TeamStartMapping.RANDOM_TEAM} : "+"Allow a player here, but don't assign a team.".L10N("UI:Main:AutoAllyingTextRandomTeam")
+                 "When players are assigned to spawn locations, they will be auto assigned to teams based on these mappings.\n" +
+                 "This is best used with random teams and random starts. However, only random teams is required.\n" +
+                 "Manually specified starts will take precedence.\n\n").L10N("UI:Main:AutoAllyingText1") +
+                $"{TeamStartMapping.NO_TEAM} : " +
+                "Block this location from being assigned to a player.".L10N("UI:Main:AutoAllyingTextNoTeam") + "\n" +
+                $"{TeamStartMapping.RANDOM_TEAM} : " +
+                "Allow a player here, but don't assign a team.".L10N("UI:Main:AutoAllyingTextRandomTeam") + "\n\n" +
+                "Custom Auto Ally Presets:".L10N("UI:Main:AutoAllyingTextCustomPresetLabel") + "\n\n" +
+                ("The edit button can be used to create, edit, or delete custom auto ally presets for maps that do not have them predefined.\n" +
+                 $"This button is active when 'Custom' or any preset starting with '{TeamStartMappingPreset.UserDefinedPrefx}' is selected.\n" +
+                 "Custom user presets are map specific.\n" +
+                 $"{TeamStartMappingPreset.UserDefinedPrefx} : User Preset").L10N("UI:Main:AutoAllyingTextCustomPresetText")
             );
         }
 
@@ -266,8 +377,7 @@ namespace DTAClient.DXGUI.Multiplayer
         }
 
         public List<TeamStartMapping> GetTeamStartMappings()
-            => chkBoxUseTeamStartMappings.Checked ?
-                teamStartMappingsPanel.GetTeamStartMappings() : new List<TeamStartMapping>();
+            => chkBoxUseTeamStartMappings.Checked ? teamStartMappingsPanel.GetTeamStartMappings() : new List<TeamStartMapping>();
 
         public void EnableControls(bool enable)
         {

--- a/DXMainClient/DXMainClient.csproj
+++ b/DXMainClient/DXMainClient.csproj
@@ -451,6 +451,7 @@
     <Compile Include="Domain\Multiplayer\LAN\LANColor.cs" />
     <Compile Include="Domain\Multiplayer\LAN\HostedLANGame.cs" />
     <Compile Include="Domain\Multiplayer\TeamStartMappingPreset.cs" />
+    <Compile Include="Domain\Multiplayer\TeamStartMappingUserPresets.cs" />
     <Compile Include="Domain\StatisticsSender.cs" />
     <Compile Include="DXGUI\Generic\CheaterWindow.cs" />
     <Compile Include="Domain\Multiplayer\Map.cs" />
@@ -480,6 +481,7 @@
     <Compile Include="DXGUI\Multiplayer\CnCNet\GlobalContextMenuData.cs" />
     <Compile Include="DXGUI\Multiplayer\CnCNet\RecentPlayerTable.cs" />
     <Compile Include="DXGUI\Multiplayer\CnCNet\RecentPlayerTableRightClickEventArgs.cs" />
+    <Compile Include="DXGUI\Multiplayer\CnCNet\TeamStartMappingPresetsWindow.cs" />
     <Compile Include="DXGUI\Multiplayer\CnCNet\TunnelListBox.cs" />
     <Compile Include="DXGUI\Multiplayer\CnCNet\TunnelSelectionWindow.cs" />
     <Compile Include="DXGUI\Multiplayer\GameFiltersPanel.cs" />
@@ -527,6 +529,7 @@
     <Compile Include="Online\ChannelUser.cs" />
     <Compile Include="Online\CnCNetGameCheck.cs" />
     <Compile Include="Online\CnCNetUserData.cs" />
+    <Compile Include="Online\EventArguments\TeamStartMappingPresetEventArgs.cs" />
     <Compile Include="Online\EventArguments\ChannelCTCPEventArgs.cs" />
     <Compile Include="Online\EventArguments\CnCNetPrivateMessageEventArgs.cs" />
     <Compile Include="Online\EventArguments\GameOptionPresetEventArgs.cs" />

--- a/DXMainClient/Domain/Multiplayer/Map.cs
+++ b/DXMainClient/Domain/Multiplayer/Map.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 using Utilities = Rampastring.Tools.Utilities;
 
@@ -46,6 +47,9 @@ namespace DTAClient.Domain.Multiplayer
         /// </summary>
         [JsonProperty]
         public string Name { get; private set; }
+
+        [JsonIgnore]
+        public string IniSafeName => Regex.Replace(Name, "[^a-zA-Z0-9]", string.Empty);
 
         /// <summary>
         /// The maximum amount of players supported by the map.

--- a/DXMainClient/Domain/Multiplayer/TeamStartMappingPreset.cs
+++ b/DXMainClient/Domain/Multiplayer/TeamStartMappingPreset.cs
@@ -5,10 +5,23 @@ namespace DTAClient.Domain.Multiplayer
 {
     public class TeamStartMappingPreset
     {
+        public const string UserDefinedPrefx = "[U]";
+        
         [JsonProperty("n")]
         public string Name { get; set; }
-        
+
         [JsonProperty("m")]
         public List<TeamStartMapping> TeamStartMappings { get; set; }
+
+        public bool IsCustom { get; set; }
+
+        public bool IsUserDefined { get; set; }
+        
+        public bool IsDefaultForMap { get; set; }
+
+        public TeamStartMappingPreset()
+        {
+            TeamStartMappings = new List<TeamStartMapping>();
+        }
     }
 }

--- a/DXMainClient/Domain/Multiplayer/TeamStartMappingUserPresets.cs
+++ b/DXMainClient/Domain/Multiplayer/TeamStartMappingUserPresets.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using ClientCore;
+using Rampastring.Tools;
+
+namespace DTAClient.Domain.Multiplayer
+{
+    public class TeamStartMappingUserPresets
+    {
+        private const string IniFileName = "AutoAllyUserPresets.ini";
+        private static readonly string FullIniPath = ProgramConstants.ClientUserFilesPath + IniFileName;
+        private const string PresetDefinitionsSectionName = "Presets";
+        private const string DefaultPresetKey = "$$Default";
+
+        private IniFile teamStartMappingsPresetsIni;
+        private Dictionary<string, List<TeamStartMappingPreset>> TeamStartMappingPresets;
+
+        private TeamStartMappingUserPresets()
+        {
+        }
+
+        private static TeamStartMappingUserPresets _instance;
+
+        public static TeamStartMappingUserPresets Instance
+        {
+            get
+            {
+                if (_instance == null)
+                    _instance = new TeamStartMappingUserPresets();
+
+                return _instance;
+            }
+        }
+
+        private void LoadIniIfNotInitialized()
+        {
+            if (teamStartMappingsPresetsIni == null)
+                Load();
+        }
+
+        private void Load()
+        {
+            TeamStartMappingPresets = new Dictionary<string, List<TeamStartMappingPreset>>();
+            if (!File.Exists(FullIniPath))
+                return;
+
+            teamStartMappingsPresetsIni = new IniFile(FullIniPath);
+
+            var presetsSection = teamStartMappingsPresetsIni.GetSection(PresetDefinitionsSectionName);
+            var mapNames = presetsSection.Keys.Select(key => key.Value);
+
+            foreach (string mapName in mapNames)
+            {
+                var mapSection = teamStartMappingsPresetsIni.GetSection(mapName);
+                if (mapSection == null)
+                    continue;
+
+                string defaultPresetName = null;
+                if (mapSection.KeyExists(DefaultPresetKey))
+                    defaultPresetName = mapSection.GetStringValue(DefaultPresetKey, null);
+
+                foreach (var mapSectionKey in mapSection.Keys.Where(k => k.Key != DefaultPresetKey))
+                {
+                    try
+                    {
+                        AddOrUpdate(mapName, new TeamStartMappingPreset
+                        {
+                            Name = mapSectionKey.Key,
+                            TeamStartMappings = TeamStartMapping.FromListString(mapSectionKey.Value),
+                            IsDefaultForMap = string.Equals(mapSectionKey.Key, defaultPresetName),
+                            IsUserDefined = true
+                        });
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Log($"Unable to read user defined team/start mapping: {mapName}, {mapSectionKey.Key}, {mapSectionKey.Value}\n{e.Message}");
+                    }
+                }
+            }
+        }
+
+        private void Save()
+        {
+            teamStartMappingsPresetsIni = new IniFile();
+            var presetsSection = new IniSection(PresetDefinitionsSectionName);
+            teamStartMappingsPresetsIni.AddSection(presetsSection);
+            List<string> mapNames = TeamStartMappingPresets.Keys.ToList();
+            for (int i = 0; i < mapNames.Count; i++)
+            {
+                string mapName = mapNames[i];
+                presetsSection.AddKey(i.ToString(), mapName);
+                var mapPresets = TeamStartMappingPresets[mapName];
+                var defaultPreset = mapPresets.FirstOrDefault(p => p.IsDefaultForMap);
+
+                var mapSection = new IniSection(mapName);
+                if (defaultPreset != null)
+                    mapSection.AddKey(DefaultPresetKey, defaultPreset.Name);
+                
+                foreach (var teamStartMappingPreset in mapPresets)
+                    mapSection.AddKey(teamStartMappingPreset.Name, TeamStartMapping.ToListString(teamStartMappingPreset.TeamStartMappings));
+
+                teamStartMappingsPresetsIni.AddSection(mapSection);
+            }
+
+            teamStartMappingsPresetsIni.WriteIniFile(FullIniPath);
+        }
+
+        public void AddOrUpdate(Map map, TeamStartMappingPreset preset)
+        {
+            LoadIniIfNotInitialized();
+            AddOrUpdate(map.IniSafeName, preset);
+            Save();
+        }
+
+        private void AddOrUpdate(string mapName, TeamStartMappingPreset preset)
+        {
+            preset.IsUserDefined = true;
+            if (!TeamStartMappingPresets.ContainsKey(mapName))
+                TeamStartMappingPresets.Add(mapName, new List<TeamStartMappingPreset>());
+
+            var existingPreset = TeamStartMappingPresets[mapName].FirstOrDefault(p => p.Name == preset.Name);
+
+            if (existingPreset == null)
+                TeamStartMappingPresets[mapName].Add(preset);
+            else
+                existingPreset.TeamStartMappings = preset.TeamStartMappings;
+        }
+
+        public void DeletePreset(Map map, TeamStartMappingPreset preset)
+        {
+            LoadIniIfNotInitialized();
+            if (preset == null)
+                return;
+
+            string iniSafeName = map.IniSafeName;
+            if (!TeamStartMappingPresets.ContainsKey(iniSafeName))
+                return;
+
+            TeamStartMappingPresets[iniSafeName].Remove(preset);
+
+            Save();
+        }
+
+        public List<TeamStartMappingPreset> GetPresets(Map map)
+        {
+            LoadIniIfNotInitialized();
+            string iniSafeName = map.IniSafeName;
+
+            return TeamStartMappingPresets.ContainsKey(iniSafeName) ? TeamStartMappingPresets[iniSafeName] : new List<TeamStartMappingPreset>();
+        }
+    }
+}

--- a/DXMainClient/Online/EventArguments/TeamStartMappingPresetEventArgs.cs
+++ b/DXMainClient/Online/EventArguments/TeamStartMappingPresetEventArgs.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using DTAClient.Domain.Multiplayer;
+
+namespace DTAClient.Online.EventArguments
+{
+    public class TeamStartMappingPresetEventArgs : EventArgs
+    {
+        public Map Map { get; set; }
+
+        public TeamStartMappingPreset Preset { get; }
+
+        public TeamStartMappingPresetEventArgs(Map map, TeamStartMappingPreset preset)
+        {
+            Map = map;
+            Preset = preset;
+        }
+    }
+}


### PR DESCRIPTION
Drop down with custom preset and edit button
![image](https://user-images.githubusercontent.com/2062360/164119282-bb7551d8-5cba-4c20-864c-efa16b5e327e.png)

This allows the user to save custom auto ally presets for any map. Currently, presets are only available if they exist in a map file. 

Custom user auto ally presets are stored at `Client/AutoAllyUserPresets.ini`

Example `AutoAllyUserPresets.ini` contents:
```
[Presets]
0=8WalledWorld112v2v2v2
1=4DesertIslandLE
2=4ColdestPeak
3=8MayflowerFreezesOver

[8WalledWorld112v2v2v2]
2v2v2v2=A,A,B,B,C,C,D,D

[4DesertIslandLE]
my custom=A,B,x,A
test=A,B,x,A

[4ColdestPeak]
test=A,B,B,A

[8MayflowerFreezesOver]
4v4 Corners=A,A,B,B,A,A,B,B
```

Drop down opened with differing preset options
![image](https://user-images.githubusercontent.com/2062360/164119296-a0678de6-ae60-4f57-b245-5ce8b1446526.png)

Edit preset with "create" option selected
![image](https://user-images.githubusercontent.com/2062360/164119374-a38eacfe-1daa-44ec-aedf-a9d7e3eec478.png)

Edit preset with existing option selected
![image](https://user-images.githubusercontent.com/2062360/164119402-2ca224d6-b115-464f-a70f-3ef3d3dbf828.png)


Edit preset window drop down options (only user defined are listed)
![image](https://user-images.githubusercontent.com/2062360/164119437-820f284b-f824-496e-81ad-90632cd54140.png)

Edit button is disabled when auto allying is disabled
![image](https://user-images.githubusercontent.com/2062360/164119501-8f54b57c-0a56-4295-86bc-c1fd1e0c8e7e.png)

Edit button is disabled when map preset is selected
![image](https://user-images.githubusercontent.com/2062360/164119543-420651d5-d359-4c57-ac0c-a195ab7a0554.png)

Edit button is enabled when Custom option is selected (aka save new)
![image](https://user-images.githubusercontent.com/2062360/164119635-97a8544d-1529-41d4-8acb-4626b6547248.png)
