### PR TITLE
[Feature] Make MPMaps.ini and INItializableWindow can be used translate.

### DIFF
--- a/ClientGUI/INItializableWindow.cs
+++ b/ClientGUI/INItializableWindow.cs
@@ -209,7 +209,7 @@ namespace ClientGUI
                 else if (kvp.Key == "$Text")
                 {
                     control.Text = section.GetStringValue(nameof(control.Text), string.Empty)
-                        .L10N($"UI:ExtraControl:{kvp.Value}");
+                        .L10N($"UI:Control:{kvp.Value}");
                 }
                 else
                 {

--- a/ClientGUI/INItializableWindow.cs
+++ b/ClientGUI/INItializableWindow.cs
@@ -1,4 +1,5 @@
 ﻿using ClientCore;
+using Localization;
 using Microsoft.Xna.Framework;
 using Rampastring.Tools;
 using Rampastring.XNAUI;
@@ -74,7 +75,7 @@ namespace ClientGUI
                 return null; // IniNameOverride must be null, no need to continue
 
             iniFileName = Name;
-            
+
             // get theme specific path
             configIniPath = Path.Combine(ProgramConstants.GetResourcePath(), $"{iniFileName}.ini");
             if (File.Exists(configIniPath))
@@ -204,6 +205,11 @@ namespace ClientGUI
                 {
                     if (kvp.Value == "Disable")
                         control.LeftClick += (s, e) => Disable();
+                }
+                else if (kvp.Key == "$Text")
+                {
+                    control.Text = section.GetStringValue(nameof(control.Text), string.Empty)
+                        .L10N($"UI:ExtraControl:{kvp.Value}");
                 }
                 else
                 {

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -1,22 +1,22 @@
-﻿using ClientCore;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using ClientCore;
+using ClientCore.Enums;
 using ClientCore.Statistics;
 using ClientGUI;
 using DTAClient.Domain;
 using DTAClient.Domain.Multiplayer;
+using DTAClient.DXGUI.Multiplayer.CnCNet;
+using DTAClient.Online;
+using DTAClient.Online.EventArguments;
+using Localization;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Rampastring.Tools;
 using Rampastring.XNAUI;
 using Rampastring.XNAUI.XNAControls;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using ClientCore.Enums;
-using DTAClient.DXGUI.Multiplayer.CnCNet;
-using DTAClient.Online;
-using DTAClient.Online.EventArguments;
-using Localization;
 
 namespace DTAClient.DXGUI.Multiplayer.GameLobby
 {
@@ -255,7 +255,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 ddGameModeMapFilter.AddItem(CreateGameFilterItem(gm.UIName, new GameModeMapFilter(GetGameModeMaps(gm))));
 
             lblGameModeSelect = FindChild<XNALabel>(nameof(lblGameModeSelect));
-            
+
             InitBtnMapSort();
 
             tbMapSearch = FindChild<XNASuggestionTextBox>(nameof(tbMapSearch));
@@ -293,7 +293,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         }
 
         private void InitializeGameOptionPresetUI()
-            {
+        {
             BtnSaveLoadGameOptions = FindChild<XNAClientButton>(nameof(BtnSaveLoadGameOptions), true);
 
             if (BtnSaveLoadGameOptions != null)
@@ -325,7 +325,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
                 AddChild(loadSaveGameOptionsMenu);
                 AddChild(loadOrSaveGameOptionPresetWindow);
-        }
+            }
         }
 
         private void BtnMapSortAlphabetically_LeftClick(object sender, EventArgs e)
@@ -641,7 +641,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             {
                 Logger.Log($"Deleting map {Map.BaseFilePath} failed! Message: {ex.Message}");
                 XNAMessageBox.Show(WindowManager, "Deleting Map Failed".L10N("UI:Main:DeleteMapFailedTitle"),
-                    "Deleting map failed! Reason:".L10N("UI:Main:DeleteMapFailedText")+ " " + ex.Message);
+                    "Deleting map failed! Reason:".L10N("UI:Main:DeleteMapFailedText") + " " + ex.Message);
             }
         }
 
@@ -763,9 +763,9 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                     ddPlayerName.Y, sideWidth, DROP_DOWN_HEIGHT);
                 ddPlayerSide.AddItem("Random", LoadTextureOrNull("randomicon.png"));
                 foreach (string randomSelector in selectorNames)
-                    ddPlayerSide.AddItem(randomSelector, LoadTextureOrNull(randomSelector + "icon.png"));
+                    ddPlayerSide.AddItem(randomSelector.L10N($"UI:Side:{randomSelector}"), LoadTextureOrNull(randomSelector + "icon.png"));
                 foreach (string sideName in sides)
-                    ddPlayerSide.AddItem(sideName, LoadTextureOrNull(sideName + "icon.png"));
+                    ddPlayerSide.AddItem(sideName.L10N($"UI:Side:{sideName}"), LoadTextureOrNull(sideName + "icon.png"));
                 ddPlayerSide.AllowDropDown = false;
                 ddPlayerSide.SelectedIndexChanged += CopyPlayerDataFromUI;
                 ddPlayerSide.Tag = true;
@@ -2075,7 +2075,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         protected string AILevelToName(int aiLevel)
         {
             return ProgramConstants.GetAILevelName(aiLevel);
-            }
+        }
 
         protected GameType GetGameType()
         {

--- a/DXMainClient/Domain/Multiplayer/GameMode.cs
+++ b/DXMainClient/Domain/Multiplayer/GameMode.cs
@@ -1,4 +1,5 @@
 ﻿using ClientCore;
+using Localization;
 using Rampastring.Tools;
 using System;
 using System.Collections.Generic;
@@ -77,7 +78,7 @@ namespace DTAClient.Domain.Multiplayer
             IniFile forcedOptionsIni = new IniFile(ProgramConstants.GamePath + ClientConfiguration.Instance.MPMapsIniPath);
 
             CoopDifficultyLevel = forcedOptionsIni.GetIntValue(Name, "CoopDifficultyLevel", 0);
-            UIName = forcedOptionsIni.GetStringValue(Name, "UIName", Name);
+            UIName = forcedOptionsIni.GetStringValue(Name, "UIName", Name).L10N($"UI:GameMode:{UIName}");
             MultiplayerOnly = forcedOptionsIni.GetBooleanValue(Name, "MultiplayerOnly", false);
             HumanPlayersOnly = forcedOptionsIni.GetBooleanValue(Name, "HumanPlayersOnly", false);
             ForceRandomStartLocations = forcedOptionsIni.GetBooleanValue(Name, "ForceRandomStartLocations", false);

--- a/DXMainClient/Domain/Multiplayer/GameMode.cs
+++ b/DXMainClient/Domain/Multiplayer/GameMode.cs
@@ -78,7 +78,7 @@ namespace DTAClient.Domain.Multiplayer
             IniFile forcedOptionsIni = new IniFile(ProgramConstants.GamePath + ClientConfiguration.Instance.MPMapsIniPath);
 
             CoopDifficultyLevel = forcedOptionsIni.GetIntValue(Name, "CoopDifficultyLevel", 0);
-            UIName = forcedOptionsIni.GetStringValue(Name, "UIName", Name).L10N($"UI:GameMode:{UIName}");
+            UIName = forcedOptionsIni.GetStringValue(Name, "UIName", Name).L10N($"UI:GameMode:{Name}");
             MultiplayerOnly = forcedOptionsIni.GetBooleanValue(Name, "MultiplayerOnly", false);
             HumanPlayersOnly = forcedOptionsIni.GetBooleanValue(Name, "HumanPlayersOnly", false);
             ForceRandomStartLocations = forcedOptionsIni.GetBooleanValue(Name, "ForceRandomStartLocations", false);

--- a/DXMainClient/Domain/Multiplayer/Map.cs
+++ b/DXMainClient/Domain/Multiplayer/Map.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using Newtonsoft.Json;
 using Utilities = Rampastring.Tools.Utilities;
+using Localization;
 
 namespace DTAClient.Domain.Multiplayer
 {
@@ -249,7 +250,8 @@ namespace DTAClient.Domain.Multiplayer
 
                 var section = iniFile.GetSection(BaseFilePath);
 
-                Name = section.GetStringValue("Description", "Unnamed map");
+                Name = section.GetStringValue("Description", "Unnamed map")
+                    .L10N($"UI:Map:{section.GetStringValue("UIName", string.Empty)}");
                 Author = section.GetStringValue("Author", "Unknown author");
                 GameModes = section.GetStringValue("GameModes", "Default").Split(',');
 
@@ -478,7 +480,7 @@ namespace DTAClient.Domain.Multiplayer
                     Logger.Log("Custom map " + customMapFilePath + " has no game modes!");
                     return false;
                 }
-                
+
                 for (int i = 0; i < GameModes.Length; i++)
                 {
                     string gameMode = GameModes[i].Trim();
@@ -542,7 +544,7 @@ namespace DTAClient.Domain.Multiplayer
 
                     waypoints.Add(waypoint);
                 }
-                
+
                 GetTeamStartMappingPresets(basicSection);
 
                 ParseForcedOptions(iniFile, "ForcedOptions");
@@ -589,7 +591,7 @@ namespace DTAClient.Domain.Multiplayer
 
             foreach (string key in spawnIniKeys)
             {
-                ForcedSpawnIniOptions.Add(new KeyValuePair<string, string>(key, 
+                ForcedSpawnIniOptions.Add(new KeyValuePair<string, string>(key,
                     forcedOptionsIni.GetStringValue(spawnIniOptionsSection, key, String.Empty)));
             }
         }
@@ -631,7 +633,7 @@ namespace DTAClient.Domain.Multiplayer
             return mapIni;
         }
 
-        public void ApplySpawnIniCode(IniFile spawnIni, int totalPlayerCount, 
+        public void ApplySpawnIniCode(IniFile spawnIni, int totalPlayerCount,
             int aiPlayerCount, int coopDifficultyLevel)
         {
             foreach (KeyValuePair<string, string> key in ForcedSpawnIniOptions)

--- a/tools/InitializeUIName.ps1
+++ b/tools/InitializeUIName.ps1
@@ -1,0 +1,43 @@
+#!/usr/bin/env pwsh
+#Requires -Version 5.0
+
+using namespace System.IO
+
+[CmdletBinding()]
+param (
+  [Parameter(Mandatory)]
+  [string]
+  $InputFile,
+  # OutputFile
+  [Parameter()]
+  [string]
+  $OutputFile
+)
+if (!$OutputFile) {
+  $OutputFile = [Path]::GetFileNameWithoutExtension($InputFile)
+  $OutputFile += '.out'
+  $OutputFile += '.ini'
+}
+
+Remove-Item $OutputFile -Force
+
+$data = Get-Content $InputFile
+for ($i = 0; $i -lt $data.Length; $i++) {
+  $line = $data[$i]
+  Write-Progress 'Appending "UIName" ...' -PercentComplete ($i / $data.Length * 100)
+  [string]$uiname = [string]::Empty
+  if ($line.StartsWith('[')) {
+    # Section
+    $current = $line.Substring(1, $line.IndexOf(']') - 1)
+    if ($current.Contains('Maps') -and (`
+          $current.Contains('\') -or `
+          $current.Contains('/'))) {
+      $uiname = [Path]::GetFileNameWithoutExtension($current)
+    }
+  }
+
+  $line | Out-File $OutputFile -Append
+  if (![string]::IsNullOrEmpty($uiname)) {
+    "UIName=$uiname" | Out-File $OutputFile -Append
+  }
+}


### PR DESCRIPTION
# Make MPMaps.ini and INItializableWindow can be used translate.

<details>
<summary>

## Translate GameMode

</summary>

### MpMaps.ini
```ini
; ...
[GameModes]
0=Battle
; ...

[Battle]
; ...
```

### Translation.ini
```ini
; ...
[Translation]
; ...
UI:GameMode:Battle=作战
; ...
```

### Failback
UIName

</details>
<details>
<summary>

## Translate Map Name

</summary>

### MpMaps.ini
```ini
; ...
[MultiMaps]
0=Maps/Yuri's Revenge/XMP21S2
; ...

[Maps/Yuri's Revenge/XMP21S2]
UIName=XMP21S2
; ...
```

### Translation.ini
```ini
; ...
[Translation]
; ...
UI:Map:XMP21S2=[2] 阿拉斯加油矿
; ...
```
### Failback
Description
</details>
<details>
<summary>

## Translate INItializableWindow

</summary>

### GameLobbyBase.ini
```ini
; ...
[btnPickRandomMap]
; ...
$Text=PickRandomMapValueText
; ...
```

### Translation.ini
```ini
; ...
[Translation]
; ...
UI:ExtraControl:PickRandomMapValueText=Pick Random Map
; ...
```
### Failback
When $Text is before Text. Failback value is Text.
Else is Empty
</details>