### PR TITLE
Add log and client output for lobby server latency test result

### DIFF
--- a/DXMainClient/Online/CnCNetManager.cs
+++ b/DXMainClient/Online/CnCNetManager.cs
@@ -934,6 +934,19 @@ namespace DTAClient.Online
 
             channels.ForEach(ch => ch.OnUserNameChanged(realOldNickname, newNickname));
         }
+
+        public void OnServerLatencyTested(int candidateCount, int closerCount)
+        {
+            wm.AddCallback(new Action<int, int>(DoServerLatencyTested), candidateCount, closerCount);
+        }
+
+        private void DoServerLatencyTested(int candidateCount, int closerCount)
+        {
+            MainChannel.AddMessage(new ChatMessage(
+                string.Format(
+                    "Lobby servers: {0} available, {1} fast.".L10N("UI:Main:LobbyServerLatencyTestResult"),
+                    candidateCount, closerCount)));
+        }
     }
 
     public class UserEventArgs : EventArgs

--- a/DXMainClient/Online/Connection.cs
+++ b/DXMainClient/Online/Connection.cs
@@ -469,6 +469,15 @@ namespace DTAClient.Online
                 Logger.Log($"Lobby server IP: {serverIPAddress}, latency: {serverLatencyString}.");
             }
 
+            {
+                int candidateCount = sortedServerAndLatencyResults.Count();
+                int closerCount = sortedServerAndLatencyResults.Count(
+                    serverAndLatencyResult => serverAndLatencyResult.Item2 <= MAXIMUM_LATENCY);
+
+                Logger.Log($"Lobby servers: {candidateCount} available, {closerCount} fast.");
+                connectionManager.OnServerLatencyTested(candidateCount, closerCount);
+            }
+
             return sortedServerAndLatencyResults.Select(taskResult => taskResult.Item1).ToList(); // Server
         }
 

--- a/DXMainClient/Online/IConnectionManager.cs
+++ b/DXMainClient/Online/IConnectionManager.cs
@@ -73,6 +73,8 @@ namespace DTAClient.Online
 
         bool GetDisconnectStatus();
 
+        void OnServerLatencyTested(int candidateCount, int closerCount);
+
         //public EventHandler<ServerMessageEventArgs> WelcomeMessageReceived;
         //public EventHandler<ServerMessageEventArgs> GenericServerMessageReceived;
         //public EventHandler<UserAwayEventArgs> AwayMessageReceived;


### PR DESCRIPTION
## Problem

I got the following messages when joining the lobby in Mental Omega 3.3.6 with Chinese language pack:

```
[0:00 AM] 正在与 CnCNet 建立连接...
[0:00 AM] 当前网络质量较好的服务器数量：10

```

The English translation of the above messages is:

```
[0:00 AM] Connecting to CnCNet...
[0:00 AM] At present, the number of servers with better network quality: 10

```

The second message is wrong. Let me explain.

## Explanation

I didn't write the code to display a message about the number of lobby servers. That Chinese message was added by the friends of the translation group. I *guess* that they may have misunderstood the code, thinking that the return value of the "[```GetServerListSortedByLatency()```](https://github.com/CnCNet/xna-cncnet-client/blob/3f24248a251cf0032f7b3fd92080b7980575bf3a/DXMainClient/Online/Connection.cs#L328-L490)" function means the number of closer servers (i.e., servers with better network quality). But actually, it's the total number of candidates.

Here is the disassembly code from [dnSpy/dnSpy](https://github.com/dnSpy/dnSpy):

```csharp
// Token: 0x0600012D RID: 301 RVA: 0x00006FEC File Offset: 0x000051EC
private void ConnectToServer()
{
	IList<Server> serverListSortedByLatency = this.GetServerListSortedByLatency();
	this.connectionManager.OnGenericServerMessageReceived("当前网络质量较好的服务器数量：" + serverListSortedByLatency.Count.ToString());
	foreach (Server server in serverListSortedByLatency)

```

Although the message content is wrong, I think telling the player that how many lobby servers are available is a good idea, so I made this PR.

## What's new

- A message about the test result will be wrote to both the client and log file.
- For the client message, L10N support is applied and the translation should be the value of the "```UI:Main:LobbyServerLatencyTestResult```" key.

## Test

"Translation.ini":

```ini
[General]
LanguageTag=foo
LanguageName=bar
CultureInfo=zh-CN

[Translation]
UI:Main:LobbyServerLatencyTestResult=可用的大厅服务器数量为 {0}，网络质量较好的有 {1}。

```

To make Chinese characters display correctly, I copied the "```SpriteFont(\d).xnb```" font files from MO 3.3.6.

In game:

```
[0:00 AM] Connecting to CnCNet...
[0:00 AM] 可用的大厅服务器数量为 10，网络质量较好的有 1。
[0:00 AM] Attempting connection to ...

```

After removing the translation:

```
[0:00 AM] Connecting to CnCNet...
[0:00 AM] Available lobby servers: 10, closer: 1.
[0:00 AM] Attempting connection to ...

```

It works.

---

See also #212 .

<br>

Hope this patch can be in the next sooooon version of MO ;)

---

/cc @SadPencil 
