### PR TITLE
#350: Add a command to download a map via lobby chat

### DIFF
--- a/DXMainClient/Domain/Multiplayer/CnCNet/MapSharer.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/MapSharer.cs
@@ -386,9 +386,14 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
 
             string destinationFilePath = customMapsDirectory + mapFileName + ".zip";
 
+            // This string is up here so we can check that there isn't already a .map file for this download.
+            // This prevents the client from crashing when trying to rename the unzipped file to a duplicate filename.
+            string newFilename = customMapsDirectory + mapFileName + ".map";
+
             try
             {
                 if (File.Exists(destinationFilePath)) File.Delete(destinationFilePath);
+                if (File.Exists(newFilename)) File.Delete(newFilename);
             }
             catch
             {
@@ -428,14 +433,15 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
 
             string extractedFile = ExtractZipFile(destinationFilePath, customMapsDirectory);
 
-            string newFilename = customMapsDirectory + mapFileName + ".map";
-            File.Move(customMapsDirectory + extractedFile, newFilename);
-
             if (String.IsNullOrEmpty(extractedFile))
             {
                 success = false;
                 return null;
             }
+
+            // We can safely assume that there will not be a duplicate file due to deleting it
+            // earlier if one already existed.
+            File.Move(customMapsDirectory + extractedFile, newFilename);
 
             try
             {


### PR DESCRIPTION
- Add a command to download a map by hash: `/downloadmap HASH`
- Allow users to specify a filename after the hash, e.g. `/downloadmap HASH [2] My Battle Map`
- Fix a bug where renaming unzipped map files would cause a crash if the `.map` filename already exists.
- Relocate the file renaming to occur after we check that the file was successfully unzipped.

Users and devs can find map IDs using this URL template `http://mapdb.cncnet.org/search.php?game=GAME_ID&search=MAP_NAME_SEARCH_STRING`

Issue: https://github.com/CnCNet/xna-cncnet-client/issues/350