### PR TITLE
Fix crashes caused by null PlayerExtraOptionsPanel

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
@@ -566,7 +566,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             Locked = false;
 
             UpdateMapPreviewBoxEnabledStatus();
-            PlayerExtraOptionsPanel.SetIsHost(isHost);
+            PlayerExtraOptionsPanel?.SetIsHost(isHost);
             //MapPreviewBox.EnableContextMenu = IsHost;
 
             btnLaunchGame.Text = IsHost ? BTN_LAUNCH_GAME : BTN_LAUNCH_READY;

--- a/DXMainClient/Domain/Multiplayer/PlayerExtraOptions.cs
+++ b/DXMainClient/Domain/Multiplayer/PlayerExtraOptions.cs
@@ -23,7 +23,7 @@ namespace DTAClient.Domain.Multiplayer
         public bool IsForceRandomTeams { get; set; }
         public bool IsForceRandomStarts { get; set; }
         public bool IsUseTeamStartMappings { get; set; }
-        public List<TeamStartMapping> TeamStartMappings { get; set; }
+        public List<TeamStartMapping> TeamStartMappings { get; set; } = new List<TeamStartMapping>();
 
         public string GetTeamMappingsError()
         {


### PR DESCRIPTION
In `GameLobbyBase.cs`:
```cs
protected PlayerExtraOptions GetPlayerExtraOptions() =>
    PlayerExtraOptionsPanel == null ? new PlayerExtraOptions() : PlayerExtraOptionsPanel.GetPlayerExtraOptions();
```

And in `PlayerExtraOptions.cs`:
```cs
public List<TeamStartMapping> TeamStartMappings { get; set; }  // this is by default null
```

Which causes a crash of a null pointer at `PlayerExtraOptions.ToString()`, where:
```cs
TeamStartMapping.ToListString(TeamStartMappings) // TeamStartMappings is null, while ToListString() crash on null
```

-----------------

Also, in `MultiplayerGameLobby.cs`:
```cs
PlayerExtraOptionsPanel.SetIsHost(isHost);
```

`PlayerExtraOptionsPanel` can be null.
