### PR TITLE
Use 24-hour time format in TopBar to prevent the string from going beyond the border

### DIFF
--- a/DXMainClient/DXGUI/Generic/TopBar.cs
+++ b/DXMainClient/DXGUI/Generic/TopBar.cs
@@ -441,7 +441,7 @@ namespace DTAClient.DXGUI.Generic
 
             DateTime dtn = DateTime.Now;
 
-            lblTime.Text = Renderer.GetSafeString(dtn.ToLongTimeString(), lblTime.FontIndex);
+            lblTime.Text = Renderer.GetSafeString(dtn.ToString("HH:mm:ss"), lblTime.FontIndex);
             string dateText = Renderer.GetSafeString(dtn.ToShortDateString(), lblDate.FontIndex);
             if (lblDate.Text != dateText)
                 lblDate.Text = dateText;


### PR DESCRIPTION
## Summary

If the time format settings of the OS contains an AM/PM designator, it will go beyond the right border of the window.

## Why

The placeholder of `lblTime` is "`99:99:99`":

https://github.com/CnCNet/xna-cncnet-client/blob/624dfccd23011970ed2ce668888fd71132b0a560/DXMainClient/DXGUI/Generic/TopBar.cs#L161-L167

So I think using 24-hour format (`HH:mm:ss`) is OK.

## Comparison

![20220911-CnCNet-DXClient-TopBar-time-format](https://user-images.githubusercontent.com/29089388/189508773-4ee117a9-f627-4208-ad51-680a7dbcde07.png)

## And...

There is a wrong time format string:

https://github.com/CnCNet/xna-cncnet-client/blob/624dfccd23011970ed2ce668888fd71132b0a560/DXMainClient/Domain/Multiplayer/CnCNet/MapSharer.cs#L418-L422

We should use "`HH:mm:ss`" instead of "`hh:mm:ss`" because "`hh`" is a number from 01 to 12. Since the code is commented out and not relevant to this PR, I didn't modify it.

See also: [The "hh" custom format specifier § Custom date and time format strings | Microsoft Docs](https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings#hhSpecifier)