### PR TITLE
Reimplement FindChild and add FindChildrenStartWith

### DIFF
--- a/ClientGUI/INItializableWindow.cs
+++ b/ClientGUI/INItializableWindow.cs
@@ -26,29 +26,43 @@ namespace ClientGUI
         /// instead of the window's name.
         /// </summary>
         protected string IniNameOverride { get; set; }
-
-        public T FindChild<T>(string childName, bool optional = false) where T : XNAControl
-        {
-            T child = FindChild<T>(Children, childName);
-            if (child == null && !optional)
-                throw new KeyNotFoundException("Could not find required child control: " + childName);
-
-            return child;
-        }
-
-        private T FindChild<T>(IEnumerable<XNAControl> list, string controlName) where T : XNAControl
+        private bool VisitChild(IEnumerable<XNAControl> list, Func<XNAControl, bool> judge)
         {
             foreach (XNAControl child in list)
             {
-                if (child.Name == controlName)
-                    return (T)child;
-
-                T childOfChild = FindChild<T>(child.Children, controlName);
-                if (childOfChild != null)
-                    return childOfChild;
+                bool stop = judge(child);
+                if (stop) return true;
+                stop = VisitChild(child.Children, judge);
+                if (stop) return true;
             }
+            return false;
+        }
 
-            return null;
+        public T FindChild<T>(string childName, bool optional = false) where T : XNAControl
+        {
+            XNAControl result = null;
+            VisitChild(new List<XNAControl>() { this }, control =>
+            {
+                if (control.Name != childName) return false;
+                result = control;
+                return true;
+            });
+            if (result == null && !optional)
+                throw new KeyNotFoundException("Could not find required child control: " + childName);
+            return (T)result;
+        }
+
+        public List<T> FindChildrenStartWith<T>(string prefix) where T : XNAControl
+        {
+            List<T> result = new List<T>();
+            VisitChild(new List<XNAControl>() { this }, (control) =>
+            {
+                if (string.IsNullOrEmpty(prefix) ||
+                !string.IsNullOrEmpty(control.Name) && control.Name.StartsWith(prefix))
+                    result.Add((T)control);
+                return false;
+            });
+            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
The original `FindChild<T>` is implemented in a less extendable way. It is nicely reimplemented now and a new function named `FindChildrenStartWith` is added.

I am working on a feature that allow mod developpers customize buttons with their own tags, therefore I need to match these buttons with prefix name but the current source code does not provide such a function.