### PR TITLE
Add campaign group selector

### DIFF
--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -277,6 +277,8 @@ namespace ClientCore
 
         public string AllowedCustomGameModes => clientDefinitionsIni.GetStringValue(SETTINGS, "AllowedCustomGameModes", "Standard,Custom Map");
 
+        public bool CampaignTagSelectorEnabled => clientDefinitionsIni.GetBooleanValue(SETTINGS, "CampaignTagSelectorEnabled", false);
+
         public string GetGameExecutableName()
         {
             string[] exeNames = clientDefinitionsIni.GetStringValue(SETTINGS, "GameExecutableNames", "Game.exe").Split(',');

--- a/ClientGUI/INItializableWindow.cs
+++ b/ClientGUI/INItializableWindow.cs
@@ -26,29 +26,43 @@ namespace ClientGUI
         /// instead of the window's name.
         /// </summary>
         protected string IniNameOverride { get; set; }
-
-        public T FindChild<T>(string childName, bool optional = false) where T : XNAControl
-        {
-            T child = FindChild<T>(Children, childName);
-            if (child == null && !optional)
-                throw new KeyNotFoundException("Could not find required child control: " + childName);
-
-            return child;
-        }
-
-        private T FindChild<T>(IEnumerable<XNAControl> list, string controlName) where T : XNAControl
+        private bool VisitChild(IEnumerable<XNAControl> list, Func<XNAControl, bool> judge)
         {
             foreach (XNAControl child in list)
             {
-                if (child.Name == controlName)
-                    return (T)child;
-
-                T childOfChild = FindChild<T>(child.Children, controlName);
-                if (childOfChild != null)
-                    return childOfChild;
+                bool stop = judge(child);
+                if (stop) return true;
+                stop = VisitChild(child.Children, judge);
+                if (stop) return true;
             }
+            return false;
+        }
 
-            return null;
+        public T FindChild<T>(string childName, bool optional = false) where T : XNAControl
+        {
+            XNAControl result = null;
+            VisitChild(new List<XNAControl>() { this }, control =>
+            {
+                if (control.Name != childName) return false;
+                result = control;
+                return true;
+            });
+            if (result == null && !optional)
+                throw new KeyNotFoundException("Could not find required child control: " + childName);
+            return (T)result;
+        }
+
+        public List<T> FindChildrenStartWith<T>(string prefix) where T : XNAControl
+        {
+            List<T> result = new List<T>();
+            VisitChild(new List<XNAControl>() { this }, (control) =>
+            {
+                if (string.IsNullOrEmpty(prefix) ||
+                !string.IsNullOrEmpty(control.Name) && control.Name.StartsWith(prefix))
+                    result.Add((T)control);
+                return false;
+            });
+            return result;
         }
 
         /// <summary>

--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -222,6 +222,7 @@ namespace DTAClient.DXGUI
                             .AddSingletonXnaControl<CnCNetGameLoadingLobby>()
                             .AddSingletonXnaControl<CnCNetLobby>()
                             .AddSingletonXnaControl<GameInProgressWindow>()
+                            .AddSingletonXnaControl<CampaignTagSelector>()
                             .AddSingletonXnaControl<SkirmishLobby>()
                             .AddSingletonXnaControl<MainMenu>()
                             .AddSingletonXnaControl<MapPreviewBox>()

--- a/DXMainClient/DXGUI/Generic/CampaignTagSelector.cs
+++ b/DXMainClient/DXGUI/Generic/CampaignTagSelector.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using ClientCore;
+using ClientGUI;
+using DTAClient.Domain;
+using Localization;
+using Microsoft.Xna.Framework;
+using Rampastring.Tools;
+using Rampastring.XNAUI;
+
+namespace DTAClient.DXGUI.Generic
+{
+    public class CampaignTagSelector : INItializableWindow
+    {
+        private const int DEFAULT_WIDTH = 576;
+        private const int DEFAULT_HEIGHT = 475;
+        private string _iniSectionName = nameof(CampaignTagSelector);
+        private DiscordHandler discordHandler;
+
+        public CampaignTagSelector(WindowManager windowManager, DiscordHandler discordHandler)
+            : base(windowManager)
+        {
+            this.discordHandler = discordHandler;
+        }
+
+        protected XNAClientButton btnCancel;
+        protected XNAClientButton btnShowAllMission;
+        public override void Initialize()
+        {
+            CampaignSelector = new CampaignSelector(WindowManager, discordHandler);
+            DarkeningPanel.AddAndInitializeWithControl(WindowManager, CampaignSelector);
+            CampaignSelector.Disable();
+
+            Name = _iniSectionName;
+
+            if (!ClientConfiguration.Instance.CampaignTagSelectorEnabled) return;
+
+            ClientRectangle = new Rectangle(0, 0, DEFAULT_WIDTH, DEFAULT_HEIGHT);
+            BorderColor = UISettings.ActiveSettings.PanelBorderColor;
+
+            base.Initialize();
+
+            WindowManager.CenterControlOnScreen(this);
+
+            btnCancel = FindChild<XNAClientButton>(nameof(btnCancel));
+            btnCancel.LeftClick += BtnCancel_LeftClick;
+            btnShowAllMission = FindChild<XNAClientButton>(nameof(btnShowAllMission));
+            btnShowAllMission.LeftClick += (sender, e) =>
+            {
+                CampaignSelector.LoadMissionsWithFilter(null);
+                CampaignSelector.Enable();
+                Disable();
+            };
+
+            const string TagButtonsPrefix = "ButtonTag_";
+            var tagButtons = FindChildrenStartWith<XNAClientButton>(TagButtonsPrefix);
+            foreach (var tagButton in tagButtons)
+            {
+                string tagName = tagButton.Name.Substring(TagButtonsPrefix.Length);
+                tagButton.LeftClick += (sender, e) =>
+                {
+                    CampaignSelector.LoadMissionsWithFilter(new HashSet<string>() { tagName });
+                    CampaignSelector.Enable();
+                    Disable();
+                };
+            }
+        }
+
+        private void BtnCancel_LeftClick(object sender, EventArgs e)
+        {
+            Disable();
+        }
+
+        public void Open()
+        {
+            if (ClientConfiguration.Instance.CampaignTagSelectorEnabled)
+                Enable();
+            else
+                CampaignSelector.Enable();
+        }
+
+        CampaignSelector CampaignSelector;
+    }
+}

--- a/DXMainClient/DXGUI/Generic/CampaignTagSelector.cs
+++ b/DXMainClient/DXGUI/Generic/CampaignTagSelector.cs
@@ -1,12 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using ClientCore;
 using ClientGUI;
 using DTAClient.Domain;
-using Localization;
 using Microsoft.Xna.Framework;
-using Rampastring.Tools;
 using Rampastring.XNAUI;
 
 namespace DTAClient.DXGUI.Generic
@@ -80,6 +77,6 @@ namespace DTAClient.DXGUI.Generic
                 CampaignSelector.Enable();
         }
 
-        CampaignSelector CampaignSelector;
+        private CampaignSelector CampaignSelector;
     }
 }

--- a/DXMainClient/DXGUI/Generic/MainMenu.cs
+++ b/DXMainClient/DXGUI/Generic/MainMenu.cs
@@ -43,7 +43,8 @@ namespace DTAClient.DXGUI.Generic
             TopBar topBar, 
             OptionsWindow optionsWindow,
             CnCNetLobby cncnetLobby,
-            CnCNetManager connectionManager, 
+            CampaignTagSelector campaignTagSelector,
+            CnCNetManager connectionManager,
             DiscordHandler discordHandler,
             CnCNetGameLoadingLobby cnCNetGameLoadingLobby,
             CnCNetGameLobby cnCNetGameLobby,
@@ -57,6 +58,7 @@ namespace DTAClient.DXGUI.Generic
             this.connectionManager = connectionManager;
             this.optionsWindow = optionsWindow;
             this.cncnetLobby = cncnetLobby;
+            this.campaignTagSelector = campaignTagSelector;
             this.discordHandler = discordHandler;
             this.skirmishLobby = skirmishLobby;
             this.cnCNetGameLoadingLobby = cnCNetGameLoadingLobby;
@@ -77,6 +79,8 @@ namespace DTAClient.DXGUI.Generic
         private CnCNetLobby cncnetLobby;
 
         private SkirmishLobby skirmishLobby;
+
+        private CampaignTagSelector campaignTagSelector;
 
         private LANLobby lanLobby;
 
@@ -548,6 +552,7 @@ namespace DTAClient.DXGUI.Generic
         /// </summary>
         public void PostInit()
         {
+            DarkeningPanel.AddAndInitializeWithControl(WindowManager, campaignTagSelector);
             DarkeningPanel.AddAndInitializeWithControl(WindowManager, skirmishLobby);
             DarkeningPanel.AddAndInitializeWithControl(WindowManager, cnCNetGameLoadingLobby);
             DarkeningPanel.AddAndInitializeWithControl(WindowManager, cnCNetGameLobby);
@@ -561,6 +566,7 @@ namespace DTAClient.DXGUI.Generic
             topBar.SetOptionsWindow(optionsWindow);
             WindowManager.AddAndInitializeControl(gameInProgressWindow);
 
+            campaignTagSelector.Disable();
             skirmishLobby.Disable();
             cncnetLobby.Disable();
             cnCNetGameLobby.Disable();
@@ -829,7 +835,7 @@ namespace DTAClient.DXGUI.Generic
             => optionsWindow.Open();
 
         private void BtnNewCampaign_LeftClick(object sender, EventArgs e)
-            => innerPanel.Show(innerPanel.CampaignSelector);
+            => campaignTagSelector.Open();
 
         private void BtnLoadGame_LeftClick(object sender, EventArgs e)
             => innerPanel.Show(innerPanel.GameLoadingWindow);

--- a/DXMainClient/DXGUI/Generic/MainMenuDarkeningPanel.cs
+++ b/DXMainClient/DXGUI/Generic/MainMenuDarkeningPanel.cs
@@ -22,7 +22,6 @@ namespace DTAClient.DXGUI.Generic
 
         private DiscordHandler discordHandler;
 
-        public CampaignSelector CampaignSelector;
         public GameLoadingWindow GameLoadingWindow;
         public StatisticsWindow StatisticsWindow;
         public UpdateQueryWindow UpdateQueryWindow;
@@ -39,9 +38,6 @@ namespace DTAClient.DXGUI.Generic
             BackgroundTexture = AssetLoader.CreateTexture(new Color(0, 0, 0, 128), 1, 1);
             PanelBackgroundDrawMode = PanelBackgroundImageDrawMode.STRETCHED;
             Alpha = 1.0f;
-
-            CampaignSelector = new CampaignSelector(WindowManager, discordHandler);
-            AddChild(CampaignSelector);
 
             GameLoadingWindow = new GameLoadingWindow(WindowManager, discordHandler);
             AddChild(GameLoadingWindow);

--- a/DXMainClient/Domain/Mission.cs
+++ b/DXMainClient/Domain/Mission.cs
@@ -1,5 +1,6 @@
 ﻿using Rampastring.Tools;
 using System;
+using System.Collections.Generic;
 
 namespace DTAClient.Domain
 {
@@ -22,7 +23,7 @@ namespace DTAClient.Domain
             Enabled = iniFile.GetBooleanValue(sectionName, nameof(Enabled), true);
             BuildOffAlly = iniFile.GetBooleanValue(sectionName, nameof(BuildOffAlly), false);
             PlayerAlwaysOnNormalDifficulty = iniFile.GetBooleanValue(sectionName, nameof(PlayerAlwaysOnNormalDifficulty), false);
-
+            Tags = iniFile.GetStringValue(sectionName, nameof(Tags), string.Empty).Split(',');
             GUIDescription = GUIDescription.Replace("@", Environment.NewLine);
         }
 
@@ -38,5 +39,6 @@ namespace DTAClient.Domain
         public bool Enabled { get; }
         public bool BuildOffAlly { get; }
         public bool PlayerAlwaysOnNormalDifficulty { get; }
+        public string[] Tags { get; }
     }
 }


### PR DESCRIPTION
This PR is backward compatible as by default the option is off. Modders can enable the `CampaignTagSelectorEnabled` option to use this feature.

This feature enables modders to make a "choose your side" interface before the campaign selector. Choosing among "Act 1/Act 2/..." or any other tags is also possible.

The screenshot below shows the feature. (I am not an expert in beautifying user interfaces so it is only a working example. Fully configurable through ini files.)

![img1](https://user-images.githubusercontent.com/11227602/190046449-22361b5f-03aa-4745-8bdf-e658cbec65ce.png)
![img2](https://user-images.githubusercontent.com/11227602/190046453-0b470a43-cbf0-41e1-9b01-42e9920ab3f1.png)
![img3](https://user-images.githubusercontent.com/11227602/190046457-3d22c30c-aeab-4abf-835d-c6b2d77a5f5a.png)

The modders define tags for missions in `battle.ini` and customize the selector window in `CampaignTagSelector.ini` using the new INItializableWindow ini format.

I use TSC v6 client as an example. The corresponding files are attached here.

[TSC.v6.example.zip](https://github.com/CnCNet/xna-cncnet-client/files/9687387/TSC.v6.example.zip)

-----------------------------------------------------
Prerequisite of this PR: #364 (merged now) and #367 (requesting merge).