### PR TITLE
Allow optional import of game specific build props

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -414,3 +414,6 @@ Icon?
 .directory
 
 .idea/
+
+# Game specific build prop files
+Directory.Build.Game.*.props

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,9 @@
   <Import Project="$(MSBuildThisFileDirectory)build\VSCompatibleLayer.props" Condition="'$(BuildingInsideVisualStudio)' == 'True'" />
   <Import Project="$(MSBuildThisFileDirectory)build\Framework.props" />
 
+  <!-- Allow a game specific build prop file to be imported, if available -->
+  <Import Project="$(MSBuildThisFileDirectory)Directory.Build.Game.$(Game).props" Condition="Exists('$(MSBuildThisFileDirectory)Directory.Build.Game.$(Game).props')"/>
+
   <!-- Visual Studio -->
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == 'True'">
     <OutputPath Condition="'$(_OutputConfiguration)' != ''">$(BaseOutputPath)bin\$(_OutputConfiguration)\$(Game)\$(Engine)\</OutputPath>


### PR DESCRIPTION
With this, I can create YR specific build props file to copy in resources from the YR client repo so that launching the xna client is done in the YR context.