### PR TITLE
Make locale-aware time fully displayed in TopBar to prevent the string from going beyond the border

### DIFF
--- a/DXMainClient/DXGUI/Generic/TopBar.cs
+++ b/DXMainClient/DXGUI/Generic/TopBar.cs
@@ -161,7 +161,7 @@ namespace DTAClient.DXGUI.Generic
             lblTime = new XNALabel(WindowManager);
             lblTime.Name = "lblTime";
             lblTime.FontIndex = 1;
-            lblTime.Text = Renderer.GetSafeString(new DateTime(1, 1, 1, 23, 59, 59).ToLongTimeString(), lblDate.FontIndex);
+            lblTime.Text = Renderer.GetSafeString(new DateTime(1, 1, 1, 23, 59, 59).ToLongTimeString(), lblTime.FontIndex);
             lblTime.ClientRectangle = new Rectangle(Width -
                 (int)Renderer.GetTextDimensions(lblTime.Text, lblTime.FontIndex).X - 12, 4,
                 lblTime.Width, lblTime.Height);

--- a/DXMainClient/DXGUI/Generic/TopBar.cs
+++ b/DXMainClient/DXGUI/Generic/TopBar.cs
@@ -161,7 +161,7 @@ namespace DTAClient.DXGUI.Generic
             lblTime = new XNALabel(WindowManager);
             lblTime.Name = "lblTime";
             lblTime.FontIndex = 1;
-            lblTime.Text = "99:99:99";
+            lblTime.Text = Renderer.GetSafeString(new DateTime(1, 1, 1, 23, 59, 59).ToLongTimeString(), lblDate.FontIndex);
             lblTime.ClientRectangle = new Rectangle(Width -
                 (int)Renderer.GetTextDimensions(lblTime.Text, lblTime.FontIndex).X - 12, 4,
                 lblTime.Width, lblTime.Height);


### PR DESCRIPTION
Hello!

If the time format of the current locale contains an AM/PM designator, it will go beyond the right border of the window.

I tried to remove the AM/PM designator; @Rans4ckeR reviewed my code and said:

> The application should use correct localization, so en-US systems should display AM/PM.
> A proper solution is to update the layout instead. For example by changing the placeholder like this:
> 
> ```C#
> lblTime.Text = new DateTime(1, 1, 1, 23, 59, 59).ToLongTimeString();
> ```
> 
> *source: https://github.com/CnCNet/xna-cncnet-client/pull/366#pullrequestreview-1103272340*

That's better, isn't it? So I make this PR. 

Here is the screenshot:

![20221110-CnCNet-DXClient-TopBar-time-format](https://user-images.githubusercontent.com/29089388/201017342-eadbb769-f2db-49bb-9e15-2a4fefcc574d.png)

This PR will close #366 if gets merged.


      