### PR TITLE
Update Rampastring.Tools to fix crashes on empty theme folder

### DIFF
--- a/Localization/Localization.csproj
+++ b/Localization/Localization.csproj
@@ -14,6 +14,6 @@
     <RootNamespace>Localization</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Rampastring.Tools" Version="2.0.2" />
+    <PackageReference Include="Rampastring.Tools" Version="2.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
In file `Startup.cs`:

```cs
            string themePath = ClientConfiguration.Instance.GetThemePath(UserINISettings.Instance.ClientTheme);

            if (themePath == null)
            {
                themePath = ClientConfiguration.Instance.GetThemeInfoFromIndex(0)[1];
            }

            ProgramConstants.RESOURCES_DIR = SafePath.CombineDirectoryPath(ProgramConstants.BASE_RESOURCE_PATH, themePath);
```

`themePath` could be `string.Empty`. (e.g. Mental Omega)
And old version of Rampastring.Tools will mistakenly return `"\\"` as the combined dir path to `ProgramConstants.RESOURCES_DIR`, which has been fixed by https://github.com/Rampastring/Rampastring.Tools/pull/7

And this PR upgrades the dependency to solve this bug.

------------------------------

P.S. I don't know why the dependency of `Rampastring.Tools` only appears in `Localization` project and upgrading it fixes the issue. Why other four projects does not explicitly depends on it while being able to call its methods?
