### PR TITLE
Implement support for parsing and displaying starting positions of Red Alert 1 and Tiberian Dawn maps, with non-isometric cells

### DIFF
--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -213,6 +213,10 @@ namespace ClientCore
 
         public int MaxNameLength => clientDefinitionsIni.GetIntValue(SETTINGS, "MaxNameLength", 16);
 
+        public bool UseIsometricCells => clientDefinitionsIni.GetBooleanValue(SETTINGS, "UseIsometricCells", true);
+
+        public int WaypointCoefficient => clientDefinitionsIni.GetIntValue(SETTINGS, "WaypointCoefficient", 128);
+
         public int MapCellSizeX => clientDefinitionsIni.GetIntValue(SETTINGS, "MapCellSizeX", 48);
 
         public int MapCellSizeY => clientDefinitionsIni.GetIntValue(SETTINGS, "MapCellSizeY", 24);

--- a/DXMainClient/Domain/MainClientConstants.cs
+++ b/DXMainClient/Domain/MainClientConstants.cs
@@ -13,6 +13,8 @@ namespace DTAClient.Domain
 
         public static string SUPPORT_URL_SHORT = "www.cncnet.org";
 
+        public static bool USE_ISOMETRIC_CELLS = true;
+        public static int TDRA_WAYPOINT_COEFFICIENT = 128;
         public static int MAP_CELL_SIZE_X = 48;
         public static int MAP_CELL_SIZE_Y = 24;
 
@@ -31,6 +33,8 @@ namespace DTAClient.Domain
 
             CREDITS_URL = clientConfiguration.CreditsURL;
 
+            USE_ISOMETRIC_CELLS = clientConfiguration.UseIsometricCells;
+            TDRA_WAYPOINT_COEFFICIENT = clientConfiguration.WaypointCoefficient;
             MAP_CELL_SIZE_X = clientConfiguration.MapCellSizeX;
             MAP_CELL_SIZE_Y = clientConfiguration.MapCellSizeY;
 

--- a/DXMainClient/Domain/Multiplayer/Map.cs
+++ b/DXMainClient/Domain/Multiplayer/Map.cs
@@ -808,11 +808,8 @@ namespace DTAClient.Domain.Multiplayer
             int rx = cellX - x;
             int ry = cellY - y;
 
-            int mapPixelPosX = rx * MainClientConstants.MAP_CELL_SIZE_X;
-            int mapPixelPosY = ry * MainClientConstants.MAP_CELL_SIZE_Y;
-
-            double ratioX = mapPixelPosX / (width * MainClientConstants.MAP_CELL_SIZE_X);
-            double ratioY = mapPixelPosY / (height * MainClientConstants.MAP_CELL_SIZE_Y);
+            double ratioX = rx / (double)width;
+            double ratioY = ry / (double)height;
 
             int pixelX = (int)(ratioX * previewSizePoint.X);
             int pixelY = (int)(ratioY * previewSizePoint.Y);

--- a/DXMainClient/Domain/Multiplayer/Map.cs
+++ b/DXMainClient/Domain/Multiplayer/Map.cs
@@ -784,9 +784,17 @@ namespace DTAClient.Domain.Multiplayer
 
         public string GetSizeString()
         {
-            if (actualSize == null || actualSize.Length < 4)
-                return "Not available";
-            return actualSize[2] + "x" + actualSize[3];
+            if (MainClientConstants.USE_ISOMETRIC_CELLS)
+            {
+                if (actualSize == null || actualSize.Length < 4)
+                    return "Not available";
+
+                return actualSize[2] + "x" + actualSize[3];
+            }
+            else
+            {
+                return width + "x" + height;
+            }
         }
 
         private static Point GetTDRAWaypointCoords(string waypoint, int x, int y, int width, int height, Point previewSizePoint)

--- a/DXMainClient/Domain/Multiplayer/Map.cs
+++ b/DXMainClient/Domain/Multiplayer/Map.cs
@@ -805,8 +805,8 @@ namespace DTAClient.Domain.Multiplayer
 
         private static Point GetTDRACellPixelCoord(int cellX, int cellY, int x, int y, int width, int height, Point previewSizePoint)
         {
-            int rx = x - cellX;
-            int ry = y - cellY;
+            int rx = cellX - x;
+            int ry = cellY - y;
 
             int mapPixelPosX = rx * MainClientConstants.MAP_CELL_SIZE_X;
             int mapPixelPosY = ry * MainClientConstants.MAP_CELL_SIZE_Y;


### PR DESCRIPTION
This PR adds optional, configurable support for displaying starting locations of players in Red Alert 1 and Tiberian Dawn maps correctly.

These games use non-isometric cells, which requires some changes to the cell math for figuring out the pixel coordinates of starting locations.

They also have a slightly different map format when it comes to specifying the size of the map, which required changes to the map size parsing code.

To support these features without making TS/YR support more complicated, two new keys were introduced to `ClientDefinitions.ini`:

```cs
[Settings]
UseIsometricCells=
WaypointCoefficient=
```

`WaypointCoefficient` is only used when calculating waypoint positions for RA and TD. `UseIsometricCells` defines whether the use TS/YR or RA1 logic for parsing the map size and for cell math. It defaults to `true` to keep compatibility with existing TS/YR implementations of the client.

As a bonus, this PR fixes some outdated syntax from `Map.cs`.