### PR TITLE
Move parsing of UPDATE and GAME messages to Channel class

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/GameCreationEventArgs.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/GameCreationEventArgs.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace DTAClient.DXGUI.Multiplayer.CnCNet
 {
-    class GameCreationEventArgs : EventArgs
+    public class GameCreationEventArgs : EventArgs
     {
         public GameCreationEventArgs(string roomName, int maxPlayers, 
             string password, CnCNetTunnel tunnel)

--- a/DXMainClient/Online/EventArguments/ChannelCTCPEventArgs.cs
+++ b/DXMainClient/Online/EventArguments/ChannelCTCPEventArgs.cs
@@ -4,13 +4,16 @@ namespace DTAClient.Online.EventArguments
 {
     public class ChannelCTCPEventArgs : EventArgs
     {
-        public ChannelCTCPEventArgs(string userName, string message)
+        public ChannelCTCPEventArgs(string userName, string message, ChannelUser channelUser)
         {
             UserName = userName;
             Message = message;
+            ChannelUser = channelUser;
         }
 
-        public string UserName { get; private set; }
-        public string Message { get; private set; }
+        public string UserName { get; }
+        public string Message { get; }
+        
+        public ChannelUser ChannelUser { get; }
     }
 }

--- a/DXMainClient/Online/EventArguments/ChannelGameEventArgs.cs
+++ b/DXMainClient/Online/EventArguments/ChannelGameEventArgs.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using DTAClient.Domain.Multiplayer.CnCNet;
+
+namespace DTAClient.Online.EventArguments
+{
+    public class ChannelGameEventArgs : ChannelCTCPEventArgs
+    {
+
+        public ChannelGameEventArgs(string userName, string message, ChannelUser channelUser) : base(userName, message, channelUser)
+        {
+        }
+
+        public string MatchID;
+        public bool IsLoadedGame { get; set; }
+        public DateTime LastRefreshTime { get; set; }
+        public bool IsLadder { get; set; }
+        public bool Locked { get; set; }
+        public int TunnelPort { get; set; }
+        public string TunnelAddress { get; set; }
+        public string GameVersion { get; set; }
+        public int MaxPlayers { get; set; }
+        public string GameRoomChannelName { get; set; }
+        public string GameRoomDisplayName { get; set; }
+        public string[] PlayerNames { get; set; }
+        public string MapName { get; set; }
+        public string GameMode { get; set; }
+        public bool IsClosed { get; set; }
+        public bool IsCustomPassword { get; set; }
+        public string Revision { get; set; }
+    }
+}


### PR DESCRIPTION
This is only a first step in an effort to move "logic" out of the UI layer and into a more serviceable one. The UI controls/components do way more than they should in terms of non-UI logic, like in this specific case, message parsing.

This PR moves the UPDATE and GAME command parsing up to the Channel class for cncnet lobby broadcasting where it invokes specific event handlers for those specific messages. Else, it falls back to the base CTCP event handler invoke.