### PR TITLE
RA2/YR Intro Movie Crash Fix 

### DIFF
--- a/ClientCore/Settings/UserINISettings.cs
+++ b/ClientCore/Settings/UserINISettings.cs
@@ -11,6 +11,7 @@ namespace ClientCore
         private static UserINISettings _instance;
 
         public const string VIDEO = "Video";
+        public const string INTRO_SETTINGS = "Intro";
         public const string MULTIPLAYER = "MultiPlayer";
         public const string OPTIONS = "Options";
         public const string AUDIO = "Audio";
@@ -65,6 +66,8 @@ namespace ClientCore
             BorderlessWindowedClient = new BoolSetting(iniFile, VIDEO, "BorderlessWindowedClient", true);
             ClientFPS = new IntSetting(iniFile, VIDEO, "ClientFPS", 60);
             DisplayToggleableExtraTextures = new BoolSetting(iniFile, VIDEO, "DisplayToggleableExtraTextures", true);
+
+            PlayIntroSetting = new BoolSetting(iniFile, INTRO_SETTINGS, "Play", false);
 
             ScoreVolume = new DoubleSetting(iniFile, AUDIO, "ScoreVolume", 0.7);
             SoundVolume = new DoubleSetting(iniFile, AUDIO, "SoundVolume", 0.7);
@@ -156,6 +159,12 @@ namespace ClientCore
         public BoolSetting PlayMainMenuMusic { get; private set; }
         public BoolSetting StopMusicOnMenu { get; private set; }
         public BoolSetting MessageSound { get; private set; }
+
+        /*********/
+        /* INTRO */
+        /*********/
+
+        public BoolSetting PlayIntroSetting { get; private set; }
 
         /********/
         /* GAME */
@@ -294,9 +303,16 @@ namespace ClientCore
 
         public void ApplyDefaults()
         {
+#if YR || ARES
             ForceLowestDetailLevel.SetDefaultIfNonexistent();
             DoubleTapInterval.SetDefaultIfNonexistent();
             ScrollDelay.SetDefaultIfNonexistent();
+            PlayIntroSetting.SetDefaultIfNonexistent();
+#else
+            ForceLowestDetailLevel.SetDefaultIfNonexistent();
+            DoubleTapInterval.SetDefaultIfNonexistent();
+            ScrollDelay.SetDefaultIfNonexistent();
+#endif
         }
 
         public void SaveSettings()


### PR DESCRIPTION
Adds the [Intro] and Play=no section to RA2MD.ini to prevent an error that occurs only when a fresh copy of the client goes on a game install that has yet to play the intro movie, causing the game to never open