### PR TITLE
399-the-main-menu-music-track-can-be-heard-after-the-client-closes

### DIFF
--- a/DXMainClient/DXGUI/Generic/MainMenu.cs
+++ b/DXMainClient/DXGUI/Generic/MainMenu.cs
@@ -997,6 +997,7 @@ namespace DTAClient.DXGUI.Generic
         {
             Logger.Log("Exiting.");
             WindowManager.CloseGame();
+            themeSong?.Dispose();
 #if !XNA
             Thread.Sleep(1000);
             Environment.Exit(0);


### PR DESCRIPTION
Fixes #399
Also fixes the 2nd stage updater unable to update the music file on linux as it complains about the file still being in use even after the client has exited.