### PR TITLE
Fix crashes when translation folder does not exist

### DIFF
--- a/DXMainClient/Online/FileHashCalculator.cs
+++ b/DXMainClient/Online/FileHashCalculator.cs
@@ -136,20 +136,25 @@ namespace DTAClient.Online
             }
 
             // Add the hashes for each checked file from the available translations
-            DirectoryInfo translationsFolderPath = SafePath.GetDirectory(ClientConfiguration.Instance.TranslationsFolderPath);
-            List<TranslationGameFile> translationGameFiles = ClientConfiguration.Instance.TranslationGameFiles
-                .Where(tgf => tgf.Checked).ToList();
 
-            foreach (DirectoryInfo translationFolder in translationsFolderPath.EnumerateDirectories())
+            if (Directory.Exists(ClientConfiguration.Instance.TranslationsFolderPath))
             {
-                foreach (TranslationGameFile tgf in translationGameFiles)
+                DirectoryInfo translationsFolderPath = SafePath.GetDirectory(ClientConfiguration.Instance.TranslationsFolderPath);
+
+                List<TranslationGameFile> translationGameFiles = ClientConfiguration.Instance.TranslationGameFiles
+                    .Where(tgf => tgf.Checked).ToList();
+
+                foreach (DirectoryInfo translationFolder in translationsFolderPath.EnumerateDirectories())
                 {
-                    string filePath = SafePath.CombineFilePath(translationFolder.FullName, tgf.Source);
-                    if (File.Exists(filePath))
+                    foreach (TranslationGameFile tgf in translationGameFiles)
                     {
-                        string sha1 = Utilities.CalculateSHA1ForFile(filePath);
-                        fh.INIHashes += sha1;
-                        Logger.Log("Hash for " + Path.GetRelativePath(ProgramConstants.GamePath, filePath) + ": " + sha1);
+                        string filePath = SafePath.CombineFilePath(translationFolder.FullName, tgf.Source);
+                        if (File.Exists(filePath))
+                        {
+                            string sha1 = Utilities.CalculateSHA1ForFile(filePath);
+                            fh.INIHashes += sha1;
+                            Logger.Log("Hash for " + Path.GetRelativePath(ProgramConstants.GamePath, filePath) + ": " + sha1);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Crashes on New LAN Game.
Fix: check `Directory.Exists(ClientConfiguration.Instance.TranslationsFolderPath)` first.

```txt

02.04. 09:51:41.922    KABOOOOOOM!!! Info:
02.04. 09:51:41.922    Type: System.IO.DirectoryNotFoundException
02.04. 09:51:41.923    Message: Could not find a part of the path 'F:\Mental Omega Dev\Resources\Translations'.
02.04. 09:51:41.923    Source: System.Private.CoreLib
02.04. 09:51:41.923    TargetSite.Name: CreateDirectoryHandle
02.04. 09:51:41.956    Stacktrace:    at System.IO.Enumeration.FileSystemEnumerator`1.CreateDirectoryHandle(String path, Boolean ignoreNotFound)
   at System.IO.Enumeration.FileSystemEnumerator`1.Init()
   at System.IO.Enumeration.FileSystemEnumerable`1..ctor(String directory, FindTransform transform, EnumerationOptions options, Boolean isNormalized)
   at System.IO.Enumeration.FileSystemEnumerableFactory.DirectoryInfos(String directory, String expression, EnumerationOptions options, Boolean isNormalized)
   at System.IO.DirectoryInfo.InternalEnumerateInfos(String path, String searchPattern, SearchTarget searchTarget, EnumerationOptions options)
   at System.IO.DirectoryInfo.EnumerateDirectories()
   at DTAClient.Online.FileHashCalculator.CalculateHashes(List`1 gameModes) in D:\SadPencil\Documents\GitHub\xna-cncnet-client\DXMainClient\Online\FileHashCalculator.cs:line 140
   at DTAClient.DXGUI.Multiplayer.GameLobby.LANGameLobby.SetUp(Boolean isHost, IPEndPoint hostEndPoint, TcpClient client) in D:\SadPencil\Documents\GitHub\xna-cncnet-client\DXMainClient\DXGUI\Multiplayer\GameLobby\LANGameLobby.cs:line 153
   at DTAClient.DXGUI.Multiplayer.LANLobby.GameCreationWindow_NewGame(Object sender, EventArgs e) in D:\SadPencil\Documents\GitHub\xna-cncnet-client\DXMainClient\DXGUI\Multiplayer\LANLobby.cs:line 316
   at DTAClient.DXGUI.Multiplayer.LANGameCreationWindow.BtnNewGame_LeftClick(Object sender, EventArgs e) in D:\SadPencil\Documents\GitHub\xna-cncnet-client\DXMainClient\DXGUI\Multiplayer\LANGameCreationWindow.cs:line 97
   at Rampastring.XNAUI.XNAControls.XNAControl.OnLeftClick()
   at Rampastring.XNAUI.XNAControls.XNAButton.OnLeftClick()
   at Rampastring.XNAUI.XNAControls.XNAControl.Update(GameTime gameTime)
   at Rampastring.XNAUI.XNAControls.XNAButton.Update(GameTime gameTime)
   at Rampastring.XNAUI.XNAControls.XNAControl.Update(GameTime gameTime)
   at Rampastring.XNAUI.XNAControls.XNAPanel.Update(GameTime gameTime)
   at Rampastring.XNAUI.XNAControls.XNAControl.Update(GameTime gameTime)
   at Rampastring.XNAUI.XNAControls.XNAPanel.Update(GameTime gameTime)
   at ClientGUI.DarkeningPanel.Update(GameTime gameTime) in D:\SadPencil\Documents\GitHub\xna-cncnet-client\ClientGUI\DarkeningPanel.cs:line 101
   at Rampastring.XNAUI.XNAControls.XNAControl.Update(GameTime gameTime)
   at Rampastring.XNAUI.XNAControls.XNAPanel.Update(GameTime gameTime)
   at DTAClient.DXGUI.Multiplayer.LANLobby.Update(GameTime gameTime) in D:\SadPencil\Documents\GitHub\xna-cncnet-client\DXMainClient\DXGUI\Multiplayer\LANLobby.cs:line 640
   at Rampastring.XNAUI.XNAControls.XNAControl.Update(GameTime gameTime)
   at Rampastring.XNAUI.XNAControls.XNAPanel.Update(GameTime gameTime)
   at ClientGUI.DarkeningPanel.Update(GameTime gameTime) in D:\SadPencil\Documents\GitHub\xna-cncnet-client\ClientGUI\DarkeningPanel.cs:line 101
   at Rampastring.XNAUI.WindowManager.Update(GameTime gameTime)
   at Microsoft.Xna.Framework.Game.SortingFilteringCollection`1.ForEachFilteredItem[TUserData](Action`2 action, TUserData userData)
   at Microsoft.Xna.Framework.Game.DoUpdate(GameTime gameTime)
   at Microsoft.Xna.Framework.Game.Tick()
   at MonoGame.Framework.WinFormsGameWindow.TickOnIdle(Object sender, EventArgs e)
   at System.Windows.Forms.Application.ThreadContext.Interop.Mso.IMsoComponent.FDoIdle(msoidlef grfidlef)
   at System.Windows.Forms.Application.ComponentManager.Interop.Mso.IMsoComponentManager.FPushMessageLoop(UIntPtr dwComponentID, msoloop uReason, Void* pvLoopData)
   at System.Windows.Forms.Application.ThreadContext.RunMessageLoopInner(msoloop reason, ApplicationContext context)
   at System.Windows.Forms.Application.ThreadContext.RunMessageLoop(msoloop reason, ApplicationContext context)
   at MonoGame.Framework.WinFormsGameWindow.RunLoop()
   at MonoGame.Framework.WinFormsGamePlatform.RunLoop()
   at Microsoft.Xna.Framework.Game.Run(GameRunBehavior runBehavior)
   at Microsoft.Xna.Framework.Game.Run()
   at DTAClient.Startup.Execute() in D:\SadPencil\Documents\GitHub\xna-cncnet-client\DXMainClient\Startup.cs:line 136
   at DTAClient.PreStartup.Initialize(StartupParams parameters) in D:\SadPencil\Documents\GitHub\xna-cncnet-client\DXMainClient\PreStartup.cs:line 193
   at DTAClient.Program.Main(String[] args) in D:\SadPencil\Documents\GitHub\xna-cncnet-client\DXMainClient\Program.cs:line 111
```