### PR TITLE
Fix crash on empty map

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
@@ -438,11 +438,13 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
             string textUpper = tbGameSearch?.Text?.ToUpperInvariant();
 
-            string translatedGameMode = string.IsNullOrEmpty(hg.GameMode) ? "Unknown".L10N("Client:Main:Unknown") :
-                hg.GameMode.L10N($"INI:GameModes:{hg.GameMode}:UIName", notify: false);
+            string translatedGameMode = string.IsNullOrEmpty(hg.GameMode) 
+                ? "Unknown".L10N("Client:Main:Unknown")
+                : hg.GameMode.L10N($"INI:GameModes:{hg.GameMode}:UIName", notify: false);
 
-            string translatedMapName = string.IsNullOrEmpty(hg.Map) ? "Unknown".L10N("Client:Main:Unknown") :
-                mapLoader.TranslatedMapNames.ContainsKey(hg.Map) ? mapLoader.TranslatedMapNames[hg.Map] : null;
+            string translatedMapName = string.IsNullOrEmpty(hg.Map)
+                ? "Unknown".L10N("Client:Main:Unknown") : mapLoader.TranslatedMapNames.ContainsKey(hg.Map)
+                ? mapLoader.TranslatedMapNames[hg.Map] : null;
 
             return
                 string.IsNullOrWhiteSpace(tbGameSearch?.Text) ||

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
@@ -438,11 +438,11 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
             string textUpper = tbGameSearch?.Text?.ToUpperInvariant();
 
-            string translatedGameMode = hg.GameMode.L10N($"INI:GameModes:{hg.GameMode}:UIName", notify: false);
+            string translatedGameMode = string.IsNullOrEmpty(hg.GameMode) ? "Unknown".L10N("Client:Main:Unknown") :
+                hg.GameMode.L10N($"INI:GameModes:{hg.GameMode}:UIName", notify: false);
 
-            string translatedMapName = mapLoader.TranslatedMapNames.ContainsKey(hg.Map)
-                ? mapLoader.TranslatedMapNames[hg.Map]
-                : null;
+            string translatedMapName = string.IsNullOrEmpty(hg.Map) ? "Unknown".L10N("Client:Main:Unknown") :
+                mapLoader.TranslatedMapNames.ContainsKey(hg.Map) ? mapLoader.TranslatedMapNames[hg.Map] : null;
 
             return
                 string.IsNullOrWhiteSpace(tbGameSearch?.Text) ||
@@ -1463,7 +1463,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 return;
 
             string msg = e.Message.Substring(5); // Cut out GAME part
-            string[] splitMessage = msg.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            string[] splitMessage = msg.Split(new char[] { ';' });
 
             if (splitMessage.Length != 11)
             {

--- a/DXMainClient/DXGUI/Multiplayer/GameInformationPanel.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameInformationPanel.cs
@@ -94,18 +94,18 @@ namespace DTAClient.DXGUI.Multiplayer
 
         public void SetInfo(GenericHostedGame game)
         {
-            string gameModeName = game.GameMode.L10N($"INI:GameModes:{game.GameMode}:UIName", notify: false);
+            // we don't have the ID of a map here
+            string translatedMapName = string.IsNullOrEmpty(game.Map) ? "Unknown".L10N("Client:Main:Unknown") :
+                mapLoader.TranslatedMapNames.ContainsKey(game.Map) ? mapLoader.TranslatedMapNames[game.Map] : game.Map;
 
-            lblGameMode.Text = Renderer.GetStringWithLimitedWidth("Game mode:".L10N("Client:Main:GameInfoGameMode") + " " + Renderer.GetSafeString(gameModeName, lblGameMode.FontIndex),
+            string translatedGameModeName = string.IsNullOrEmpty(game.GameMode) ? "Unknown".L10N("Client:Main:Unknown") :
+                game.GameMode.L10N($"INI:GameModes:{game.GameMode}:UIName", notify: false);
+
+            lblGameMode.Text = Renderer.GetStringWithLimitedWidth("Game mode:".L10N("Client:Main:GameInfoGameMode") + " " + Renderer.GetSafeString(translatedGameModeName, lblGameMode.FontIndex),
                 lblGameMode.FontIndex, Width - lblGameMode.X * 2);
             lblGameMode.Visible = true;
 
-            // we don't have the ID of a map here
-            string mapName = mapLoader.TranslatedMapNames.ContainsKey(game.Map)
-                ? mapLoader.TranslatedMapNames[game.Map]
-                : game.Map;
-
-            lblMap.Text = Renderer.GetStringWithLimitedWidth("Map:".L10N("Client:Main:GameInfoMap") + " " + Renderer.GetSafeString(mapName, lblMap.FontIndex),
+            lblMap.Text = Renderer.GetStringWithLimitedWidth("Map:".L10N("Client:Main:GameInfoMap") + " " + Renderer.GetSafeString(translatedMapName, lblMap.FontIndex),
                 lblMap.FontIndex, Width - lblMap.X * 2);
             lblMap.Visible = true;
 

--- a/DXMainClient/DXGUI/Multiplayer/GameInformationPanel.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameInformationPanel.cs
@@ -95,11 +95,12 @@ namespace DTAClient.DXGUI.Multiplayer
         public void SetInfo(GenericHostedGame game)
         {
             // we don't have the ID of a map here
-            string translatedMapName = string.IsNullOrEmpty(game.Map) ? "Unknown".L10N("Client:Main:Unknown") :
-                mapLoader.TranslatedMapNames.ContainsKey(game.Map) ? mapLoader.TranslatedMapNames[game.Map] : game.Map;
+            string translatedMapName = string.IsNullOrEmpty(game.Map) 
+                ? "Unknown".L10N("Client:Main:Unknown") : mapLoader.TranslatedMapNames.ContainsKey(game.Map)
+                ? mapLoader.TranslatedMapNames[game.Map] : game.Map;
 
-            string translatedGameModeName = string.IsNullOrEmpty(game.GameMode) ? "Unknown".L10N("Client:Main:Unknown") :
-                game.GameMode.L10N($"INI:GameModes:{game.GameMode}:UIName", notify: false);
+            string translatedGameModeName = string.IsNullOrEmpty(game.GameMode) 
+                ? "Unknown".L10N("Client:Main:Unknown") : game.GameMode.L10N($"INI:GameModes:{game.GameMode}:UIName", notify: false);
 
             lblGameMode.Text = Renderer.GetStringWithLimitedWidth("Game mode:".L10N("Client:Main:GameInfoGameMode") + " " + Renderer.GetSafeString(translatedGameModeName, lblGameMode.FontIndex),
                 lblGameMode.FontIndex, Width - lblGameMode.X * 2);

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -996,15 +996,15 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             foreach (GameLobbyDropDown dd in DropDowns)
                 sb.Append(dd.SelectedIndex);
 
-            sb.Append(Convert.ToInt32(Map.Official));
-            sb.Append(Map.SHA1);
-            sb.Append(GameMode.Name);
+            sb.Append(Convert.ToInt32(Map?.Official ?? false));
+            sb.Append(Map?.SHA1 ?? string.Empty);
+            sb.Append(GameMode?.Name ?? string.Empty);
             sb.Append(FrameSendRate);
             sb.Append(MaxAhead);
             sb.Append(ProtocolVersion);
             sb.Append(RandomSeed);
             sb.Append(Convert.ToInt32(RemoveStartingLocations));
-            sb.Append(Map.UntranslatedName);
+            sb.Append(Map?.UntranslatedName ?? string.Empty);
 
             channel.SendCTCPMessage(sb.ToString(), QueuedMessageType.GAME_SETTINGS_MESSAGE, 11);
         }
@@ -1070,10 +1070,13 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             {
                 ChangeMap(null);
 
-                if (!isMapOfficial)
-                    RequestMap(mapSHA1);
-                else
-                    ShowOfficialMapMissingMessage(mapSHA1);
+                if (!string.IsNullOrEmpty(mapSHA1))
+                {
+                    if (!isMapOfficial)
+                        RequestMap(mapSHA1);
+                    else
+                        ShowOfficialMapMissingMessage(mapSHA1);
+                }
             }
             else if (GameModeMap != currentGameModeMap)
             {
@@ -1890,9 +1893,6 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             if (ProgramConstants.IsInGame && broadcastChannel.Users.Count > 500)
                 return;
 
-            if (GameMode == null || Map == null)
-                return;
-
             StringBuilder sb = new StringBuilder("GAME ");
             sb.Append(ProgramConstants.CNCNET_PROTOCOL_REVISION);
             sb.Append(";");
@@ -1921,9 +1921,9 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             sb.Remove(sb.Length - 1, 1);
             sb.Append(";");
-            sb.Append(Map.UntranslatedName);
+            sb.Append(Map?.UntranslatedName ?? string.Empty);
             sb.Append(";");
-            sb.Append(GameMode.UntranslatedUIName);
+            sb.Append(GameMode?.UntranslatedUIName ?? string.Empty);
             sb.Append(";");
             sb.Append(tunnelHandler.CurrentTunnel.Address + ":" + tunnelHandler.CurrentTunnel.Port);
             sb.Append(";");

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -2081,6 +2081,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
                 MapPreviewBox.GameModeMap = null;
 
+                OnGameOptionChanged();
+
                 return;
             }
 

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
@@ -566,8 +566,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             }
 
             sb.Append(RandomSeed);
-            sb.Append(Map.SHA1);
-            sb.Append(GameMode.Name);
+            sb.Append(Map?.SHA1 ?? string.Empty);
+            sb.Append(GameMode?.Name ?? string.Empty);
             sb.Append(FrameSendRate);
             sb.Append(Convert.ToInt32(RemoveStartingLocations));
 
@@ -743,8 +743,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             sb.Append(ProgramConstants.LAN_PROTOCOL_REVISION);
             sb.Append(ProgramConstants.GAME_VERSION);
             sb.Append(localGame);
-            sb.Append(Map.UntranslatedName);
-            sb.Append(GameMode.UntranslatedUIName);
+            sb.Append(Map?.UntranslatedName ?? string.Empty);
+            sb.Append(GameMode?.UntranslatedUIName ?? string.Empty);
             sb.Append(0); // LoadedGameID
             var sbPlayers = new StringBuilder();
             Players.ForEach(p => sbPlayers.Append(p.Name + ","));
@@ -991,9 +991,11 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             if (gameModeMap == null)
             {
-                AddNotice("The game host has selected a map that doesn't exist on your installation.".L10N("Client:Main:MapNotExist") +
-                    "The host needs to change the map or you won't be able to play.".L10N("Client:Main:HostNeedChangeMapForYou"));
                 ChangeMap(null);
+                if (!string.IsNullOrEmpty(mapSHA1))
+                    AddNotice("The game host has selected a map that doesn't exist on your installation.".L10N("Client:Main:MapNotExist") + " " +
+                        "The host needs to change the map or you won't be able to play.".L10N("Client:Main:HostNeedChangeMapForYou"));
+
                 return;
             }
 

--- a/DXMainClient/DXGUI/Multiplayer/LANLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/LANLobby.cs
@@ -419,8 +419,7 @@ namespace DTAClient.DXGUI.Multiplayer
             string command = commandAndParams[0];
 
             string[] parameters = data.Substring(command.Length + 1).Split(
-                new char[] { ProgramConstants.LAN_DATA_SEPARATOR },
-                StringSplitOptions.RemoveEmptyEntries);
+                new char[] { ProgramConstants.LAN_DATA_SEPARATOR });
 
             LANLobbyUser user = players.Find(p => p.EndPoint.Equals(endPoint));
 


### PR DESCRIPTION
Previously, if a player does not select a map, it will either make the game room invisible (for CnCNet) or causes the client to crash (for LAN). Changing a game option when the map is deselected also causes the client to crash.

Related codes have been reworked, so that:
- A game room whose map is deselected is correctly shown in the list, instead of missing or a crash. 
- The change will be correctly updated to all players when the map is deselected and the host changes a game option, instead of a crash.
- The change will be correctly updated to all players when the host deselect a map, instead of a crash.

![Snipaste_2024-09-23_00-07-47](https://github.com/user-attachments/assets/f74f3b68-2de6-4951-88c1-612003d82e66)
![Snipaste_2024-09-23_00-08-06](https://github.com/user-attachments/assets/85e88690-0476-4b2b-a85c-846c029bff05)
