### PR TITLE
Make network servers configurable

### DIFF
--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -27,7 +27,7 @@ namespace ClientCore
         private IniFile gameOptions_ini;
         private IniFile DTACnCNetClient_ini;
         private IniFile clientDefinitionsIni;
-        private IniFile networkDefinitionIni;
+        private IniFile networkDefinitionsIni;
 
         protected ClientConfiguration()
         {
@@ -47,7 +47,7 @@ namespace ClientCore
 
             gameOptions_ini = new IniFile(SafePath.CombineFilePath(baseResourceDirectory.FullName, GAME_OPTIONS));
 
-            networkDefinitionIni = new IniFile(SafePath.CombineFilePath(ProgramConstants.GetResourcePath(), NETWORK_DEFS));
+            networkDefinitionsIni = new IniFile(SafePath.CombineFilePath(ProgramConstants.GetResourcePath(), NETWORK_DEFS));
         }
 
         /// <summary>
@@ -391,15 +391,15 @@ namespace ClientCore
 
         #region Network definitions
 
-        public string CnCNetTunnelListURL => networkDefinitionIni.GetStringValue(SETTINGS, "CnCNetTunnelListURL", "http://cncnet.org/master-list");
+        public string CnCNetTunnelListURL => networkDefinitionsIni.GetStringValue(SETTINGS, "CnCNetTunnelListURL", "http://cncnet.org/master-list");
 
-        public string CnCNetPlayerCountURL => networkDefinitionIni.GetStringValue(SETTINGS, "CnCNetPlayerCountURL", "http://api.cncnet.org/status");
+        public string CnCNetPlayerCountURL => networkDefinitionsIni.GetStringValue(SETTINGS, "CnCNetPlayerCountURL", "http://api.cncnet.org/status");
 
-        public string CnCNetMapDBDownloadURL => networkDefinitionIni.GetStringValue(SETTINGS, "CnCNetMapDBDownloadURL", "http://mapdb.cncnet.org");
+        public string CnCNetMapDBDownloadURL => networkDefinitionsIni.GetStringValue(SETTINGS, "CnCNetMapDBDownloadURL", "http://mapdb.cncnet.org");
 
-        public string CnCNetMapDBUploadURL => networkDefinitionIni.GetStringValue(SETTINGS, "CnCNetMapDBUploadURL", "http://mapdb.cncnet.org/upload");
+        public string CnCNetMapDBUploadURL => networkDefinitionsIni.GetStringValue(SETTINGS, "CnCNetMapDBUploadURL", "http://mapdb.cncnet.org/upload");
 
-        public bool DisableDiscordIntegration => networkDefinitionIni.GetBooleanValue(SETTINGS, "DisableDiscordIntegration", false);
+        public bool DisableDiscordIntegration => networkDefinitionsIni.GetBooleanValue(SETTINGS, "DisableDiscordIntegration", false);
 
         public List<string> IRCServers => GetIRCServers();
 
@@ -409,7 +409,7 @@ namespace ClientCore
         {
             List<string> servers = [];
 
-            IniSection serversSection = networkDefinitionIni.GetSection("IRCServers");
+            IniSection serversSection = networkDefinitionsIni.GetSection("IRCServers");
             if (serversSection != null)
                 foreach ((_, string value) in serversSection.Keys)
                     if (!string.IsNullOrWhiteSpace(value))

--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -418,11 +418,8 @@ namespace ClientCore
             return servers;
         }
 
-        public bool IsDiscordIntegrationGloballyDisabled()
-        {
-            return string.IsNullOrWhiteSpace(DiscordAppId) || DisableDiscordIntegration;
-        }
-
+        public bool DiscordIntegrationGloballyDisabled => string.IsNullOrWhiteSpace(DiscordAppId) || DisableDiscordIntegration;
+        
         public OSVersion GetOperatingSystemVersion()
         {
 #if NETFRAMEWORK

--- a/DTAConfig/OptionPanels/CnCNetOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/CnCNetOptionsPanel.cs
@@ -140,7 +140,7 @@ namespace DTAConfig.OptionPanels
                 chkConnectOnStartup.Bottom + 12, 0, 0);
             chkDiscordIntegration.Text = "Show detailed game info in Discord status".L10N("Client:DTAConfig:DiscordStatus");
 
-            if (ClientConfiguration.Instance.IsDiscordIntegrationGloballyDisabled())
+            if (ClientConfiguration.Instance.DiscordIntegrationGloballyDisabled)
             {
                 chkDiscordIntegration.AllowChecking = false;
                 chkDiscordIntegration.Checked = false;
@@ -317,7 +317,7 @@ namespace DTAConfig.OptionPanels
             chkSkipLoginWindow.Checked = IniSettings.SkipConnectDialog;
             chkPersistentMode.Checked = IniSettings.PersistentMode;
 
-            chkDiscordIntegration.Checked = !ClientConfiguration.Instance.IsDiscordIntegrationGloballyDisabled()
+            chkDiscordIntegration.Checked = !ClientConfiguration.Instance.DiscordIntegrationGloballyDisabled
                 && IniSettings.DiscordIntegration;
 
             chkAllowGameInvitesFromFriendsOnly.Checked = IniSettings.AllowGameInvitesFromFriendsOnly;
@@ -352,7 +352,7 @@ namespace DTAConfig.OptionPanels
             IniSettings.SkipConnectDialog.Value = chkSkipLoginWindow.Checked;
             IniSettings.PersistentMode.Value = chkPersistentMode.Checked;
 
-            if (!ClientConfiguration.Instance.IsDiscordIntegrationGloballyDisabled())
+            if (!ClientConfiguration.Instance.DiscordIntegrationGloballyDisabled)
             {
                 IniSettings.DiscordIntegration.Value = chkDiscordIntegration.Checked;
             }

--- a/DTAConfig/OptionPanels/CnCNetOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/CnCNetOptionsPanel.cs
@@ -140,7 +140,7 @@ namespace DTAConfig.OptionPanels
                 chkConnectOnStartup.Bottom + 12, 0, 0);
             chkDiscordIntegration.Text = "Show detailed game info in Discord status".L10N("Client:DTAConfig:DiscordStatus");
 
-            if (String.IsNullOrEmpty(ClientConfiguration.Instance.DiscordAppId))
+            if (ClientConfiguration.Instance.IsDiscordIntegrationGloballyDisabled())
             {
                 chkDiscordIntegration.AllowChecking = false;
                 chkDiscordIntegration.Checked = false;
@@ -317,7 +317,7 @@ namespace DTAConfig.OptionPanels
             chkSkipLoginWindow.Checked = IniSettings.SkipConnectDialog;
             chkPersistentMode.Checked = IniSettings.PersistentMode;
 
-            chkDiscordIntegration.Checked = !String.IsNullOrEmpty(ClientConfiguration.Instance.DiscordAppId)
+            chkDiscordIntegration.Checked = !ClientConfiguration.Instance.IsDiscordIntegrationGloballyDisabled()
                 && IniSettings.DiscordIntegration;
 
             chkAllowGameInvitesFromFriendsOnly.Checked = IniSettings.AllowGameInvitesFromFriendsOnly;
@@ -352,7 +352,7 @@ namespace DTAConfig.OptionPanels
             IniSettings.SkipConnectDialog.Value = chkSkipLoginWindow.Checked;
             IniSettings.PersistentMode.Value = chkPersistentMode.Checked;
 
-            if (!String.IsNullOrEmpty(ClientConfiguration.Instance.DiscordAppId))
+            if (!ClientConfiguration.Instance.IsDiscordIntegrationGloballyDisabled())
             {
                 IniSettings.DiscordIntegration.Value = chkDiscordIntegration.Checked;
             }

--- a/DXMainClient/DXGUI/Generic/MainMenu.cs
+++ b/DXMainClient/DXGUI/Generic/MainMenu.cs
@@ -410,7 +410,7 @@ namespace DTAClient.DXGUI.Generic
             if (!connectionManager.IsConnected)
                 ProgramConstants.PLAYERNAME = UserINISettings.Instance.PlayerName;
 
-            if (UserINISettings.Instance.DiscordIntegration && !ClientConfiguration.Instance.IsDiscordIntegrationGloballyDisabled())
+            if (UserINISettings.Instance.DiscordIntegration && !ClientConfiguration.Instance.DiscordIntegrationGloballyDisabled)
                 discordHandler.Connect();
             else
                 discordHandler.Disconnect();

--- a/DXMainClient/DXGUI/Generic/MainMenu.cs
+++ b/DXMainClient/DXGUI/Generic/MainMenu.cs
@@ -410,7 +410,7 @@ namespace DTAClient.DXGUI.Generic
             if (!connectionManager.IsConnected)
                 ProgramConstants.PLAYERNAME = UserINISettings.Instance.PlayerName;
 
-            if (UserINISettings.Instance.DiscordIntegration)
+            if (UserINISettings.Instance.DiscordIntegration && !ClientConfiguration.Instance.IsDiscordIntegrationGloballyDisabled())
                 discordHandler.Connect();
             else
                 discordHandler.Disconnect();

--- a/DXMainClient/Domain/DiscordHandler.cs
+++ b/DXMainClient/Domain/DiscordHandler.cs
@@ -48,7 +48,7 @@ namespace DTAClient.Domain
         /// </summary>
         public DiscordHandler()
         {
-            if (!UserINISettings.Instance.DiscordIntegration || ClientConfiguration.Instance.IsDiscordIntegrationGloballyDisabled())
+            if (!UserINISettings.Instance.DiscordIntegration || ClientConfiguration.Instance.DiscordIntegrationGloballyDisabled)
                 return;
 
             InitializeClient();

--- a/DXMainClient/Domain/DiscordHandler.cs
+++ b/DXMainClient/Domain/DiscordHandler.cs
@@ -48,7 +48,7 @@ namespace DTAClient.Domain
         /// </summary>
         public DiscordHandler()
         {
-            if (!UserINISettings.Instance.DiscordIntegration || string.IsNullOrEmpty(ClientConfiguration.Instance.DiscordAppId))
+            if (!UserINISettings.Instance.DiscordIntegration || ClientConfiguration.Instance.IsDiscordIntegrationGloballyDisabled())
                 return;
 
             InitializeClient();

--- a/DXMainClient/Domain/MainClientConstants.cs
+++ b/DXMainClient/Domain/MainClientConstants.cs
@@ -12,7 +12,7 @@ namespace DTAClient.Domain
 {
     public static class MainClientConstants
     {
-        public const string CNCNET_TUNNEL_LIST_URL = "http://cncnet.org/master-list";
+        public static string CNCNET_TUNNEL_LIST_URL = "http://cncnet.org/master-list";
 
         public static string GAME_NAME_LONG = "CnCNet Client";
         public static string GAME_NAME_SHORT = "CnCNet";
@@ -91,6 +91,8 @@ namespace DTAClient.Domain
             SUPPORT_URL_SHORT = clientConfiguration.ShortSupportURL;
 
             CREDITS_URL = clientConfiguration.CreditsURL;
+
+            CNCNET_TUNNEL_LIST_URL = clientConfiguration.CnCNetTunnelListURL;
 
             USE_ISOMETRIC_CELLS = clientConfiguration.UseIsometricCells;
             TDRA_WAYPOINT_COEFFICIENT = clientConfiguration.WaypointCoefficient;

--- a/DXMainClient/Domain/Multiplayer/CnCNet/CnCNetPlayerCountTask.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/CnCNetPlayerCountTask.cs
@@ -50,10 +50,15 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
         {
             try
             {
-                WebClient client = new WebClient();
+                // Don't fetch the player count if it is explicitly disabled
+                // For example, the official CnCNet server might be unavailable/unstable in a country with Internet censorship,
+                // which causes lags in the splash screen. In the worst case, say if packets are dropped, it waits until timeouts --- 30 seconds
+                if (string.IsNullOrWhiteSpace(ClientConfiguration.Instance.CnCNetPlayerCountURL))
+                    return -1;
 
-                Stream data = client.OpenRead("http://api.cncnet.org/status");
-                
+                WebClient client = new WebClient();
+                Stream data = client.OpenRead(ClientConfiguration.Instance.CnCNetPlayerCountURL);
+
                 string info = string.Empty;
 
                 using (StreamReader reader = new StreamReader(data))

--- a/DXMainClient/Domain/Multiplayer/CnCNet/MapSharer.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/MapSharer.cs
@@ -390,7 +390,8 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
                 if (string.IsNullOrWhiteSpace(ClientConfiguration.Instance.CnCNetMapDBDownloadURL))
                 {
                     success = false;
-                    return "MapSharer: Download URL is not set.";
+                    Logger.Log("MapSharer: Download URL is not configured.");
+                    return null;
                 }
 
                 string url = string.Format(CultureInfo.InvariantCulture, "{0}/{1}/{2}.zip", ClientConfiguration.Instance.CnCNetMapDBDownloadURL, myGame, sha1);

--- a/DXMainClient/Domain/Multiplayer/CnCNet/MapSharer.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/MapSharer.cs
@@ -36,8 +36,6 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
 
         private static readonly object locker = new object();
 
-        private const string MAPDB_URL = "http://mapdb.cncnet.org/upload";
-
         /// <summary>
         /// Adds a map into the CnCNet map upload queue.
         /// </summary>
@@ -78,8 +76,14 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
 
             Logger.Log("MapSharer: Starting upload of " + map.BaseFilePath);
 
-            bool success = false;
-            string message = MapUpload(MAPDB_URL, map, myGameId, out success);
+            if (string.IsNullOrWhiteSpace(ClientConfiguration.Instance.CnCNetMapDBUploadURL))
+            {
+                Logger.Log("MapSharer: Upload URL is not set.");
+                MapUploadFailed?.Invoke(null, new MapEventArgs(map));
+                return;
+            }
+
+            string message = MapUpload(ClientConfiguration.Instance.CnCNetMapDBUploadURL, map, myGameId, out bool success);
 
             if (success)
             {
@@ -380,12 +384,21 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
 
             using (TWebClient webClient = new TWebClient())
             {
+                // TODO enable proxy support for some users
                 webClient.Proxy = null;
+
+                if (string.IsNullOrWhiteSpace(ClientConfiguration.Instance.CnCNetMapDBDownloadURL))
+                {
+                    success = false;
+                    return "MapSharer: Download URL is not set.";
+                }
+
+                string url = string.Format(CultureInfo.InvariantCulture, "{0}/{1}/{2}.zip", ClientConfiguration.Instance.CnCNetMapDBDownloadURL, myGame, sha1);
 
                 try
                 {
-                    Logger.Log("MapSharer: Downloading URL: " + "http://mapdb.cncnet.org/" + myGame + "/" + sha1 + ".zip");
-                    webClient.DownloadFile("http://mapdb.cncnet.org/" + myGame + "/" + sha1 + ".zip", destinationFile.FullName);
+                    Logger.Log($"MapSharer: Downloading URL: {url}");
+                    webClient.DownloadFile(url, destinationFile.FullName);
                 }
                 catch (Exception ex)
                 {
@@ -449,6 +462,7 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
 
             public TWebClient()
             {
+                // TODO enable proxy support for some users
                 this.Proxy = null;
             }
 

--- a/DXMainClient/Domain/Multiplayer/CnCNet/TunnelHandler.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/TunnelHandler.cs
@@ -143,48 +143,78 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
             });
         }
 
+        private bool IsOnlineTunnelDataAvailable() => !string.IsNullOrWhiteSpace(MainClientConstants.CNCNET_TUNNEL_LIST_URL);
+        private bool IsOfflineTunnelDataAvailable() => SafePath.GetFile(ProgramConstants.ClientUserFilesPath, "tunnel_cache").Exists;
+
+        private byte[] GetRawTunnelDataOnline()
+        {
+            WebClient client = new WebClient();
+            return client.DownloadData(MainClientConstants.CNCNET_TUNNEL_LIST_URL);
+        }
+
+        private byte[] GetRawTunnelDataOffline()
+        {
+            FileInfo tunnelCacheFile = SafePath.GetFile(ProgramConstants.ClientUserFilesPath, "tunnel_cache");
+            return File.ReadAllBytes(tunnelCacheFile.FullName);
+        }
+
+        private byte[] GetRawTunnelData(int retryCount = 2)
+        {
+            Logger.Log("Fetching tunnel server info.");
+
+            if (IsOnlineTunnelDataAvailable())
+            {
+                for (int i = 0; i < retryCount; i++)
+                {
+                    try
+                    {
+                        byte[] data = GetRawTunnelDataOnline();
+                        return data;
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Log("Error when downloading tunnel server info: " + ex.Message);
+                        if (i < retryCount - 1)
+                            Logger.Log("Retrying.");
+                        else
+                            Logger.Log("Fetching tunnel server list failed.");
+                    }
+                }
+            }
+            else
+            {
+                // Don't fetch the latest tunnel list if it is explicitly disabled
+                // For example, the official CnCNet server might be unavailable/unstable in a country with Internet censorship,
+                // where players might either establish a substitute server or manually distribute the tunnel cache file
+                Logger.Log("Fetching tunnel server list online is disabled.");
+            }
+
+            if (IsOfflineTunnelDataAvailable())
+            {
+                Logger.Log("Using cached tunnel data.");
+                byte[] data = GetRawTunnelDataOffline();
+                return data;
+            }
+            else
+                Logger.Log("Tunnel cache file doesn't exist!");
+
+            return null;
+        }
+
+
         /// <summary>
         /// Downloads and parses the list of CnCNet tunnels.
         /// </summary>
         /// <returns>A list of tunnel servers.</returns>
         private List<CnCNetTunnel> RefreshTunnels()
         {
-            FileInfo tunnelCacheFile = SafePath.GetFile(ProgramConstants.ClientUserFilesPath, "tunnel_cache");
-
             List<CnCNetTunnel> returnValue = new List<CnCNetTunnel>();
 
-            WebClient client = new WebClient();
+            FileInfo tunnelCacheFile = SafePath.GetFile(ProgramConstants.ClientUserFilesPath, "tunnel_cache");
 
-            byte[] data;
-
-            Logger.Log("Fetching tunnel server info.");
-
-            try
-            {
-                data = client.DownloadData(MainClientConstants.CNCNET_TUNNEL_LIST_URL);
-            }
-            catch (Exception ex)
-            {
-                Logger.Log("Error when downloading tunnel server info: " + ex.ToString());
-                Logger.Log("Retrying.");
-                try
-                {
-                    data = client.DownloadData(MainClientConstants.CNCNET_TUNNEL_LIST_URL);
-                }
-                catch
-                {
-                    if (!tunnelCacheFile.Exists)
-                    {
-                        Logger.Log("Tunnel cache file doesn't exist!");
-                        return returnValue;
-                    }
-                    else
-                    {
-                        Logger.Log("Fetching tunnel server list failed. Using cached tunnel data.");
-                        data = File.ReadAllBytes(tunnelCacheFile.FullName);
-                    }
-                }
-            }
+            byte[] data = GetRawTunnelData();
+            if (data is null)
+                return returnValue;
 
             string convertedData = Encoding.Default.GetString(data);
 
@@ -234,6 +264,7 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
                 }
             }
 
+            Logger.Log($"Successfully refreshed tunnel cache with {returnValue.Count} servers.");
             return returnValue;
         }
 

--- a/DXMainClient/Domain/Multiplayer/CnCNet/TunnelHandler.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/TunnelHandler.cs
@@ -143,8 +143,8 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
             });
         }
 
-        private bool IsOnlineTunnelDataAvailable() => !string.IsNullOrWhiteSpace(MainClientConstants.CNCNET_TUNNEL_LIST_URL);
-        private bool IsOfflineTunnelDataAvailable() => SafePath.GetFile(ProgramConstants.ClientUserFilesPath, "tunnel_cache").Exists;
+        private bool OnlineTunnelDataAvailable => !string.IsNullOrWhiteSpace(MainClientConstants.CNCNET_TUNNEL_LIST_URL);
+        private bool OfflineTunnelDataAvailable => SafePath.GetFile(ProgramConstants.ClientUserFilesPath, "tunnel_cache").Exists;
 
         private byte[] GetRawTunnelDataOnline()
         {
@@ -162,7 +162,7 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
         {
             Logger.Log("Fetching tunnel server info.");
 
-            if (IsOnlineTunnelDataAvailable())
+            if (OnlineTunnelDataAvailable)
             {
                 for (int i = 0; i < retryCount; i++)
                 {
@@ -189,7 +189,7 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
                 Logger.Log("Fetching tunnel server list online is disabled.");
             }
 
-            if (IsOfflineTunnelDataAvailable())
+            if (OfflineTunnelDataAvailable)
             {
                 Logger.Log("Using cached tunnel data.");
                 byte[] data = GetRawTunnelDataOffline();

--- a/DXMainClient/Online/Connection.cs
+++ b/DXMainClient/Online/Connection.cs
@@ -47,24 +47,9 @@ namespace DTAClient.Online
                     serversList = ClientConfiguration.Instance.IRCServers;
                 else
                 {
-                    // fallback to the hardcoded server list
+                    // fallback to the hardcoded servers list
                     serversList = [
-                        "Burstfire.UK.EU.GameSurge.net|GameSurge London, UK|6667,6668,7000",
-                        "ColoCrossing.IL.US.GameSurge.net|GameSurge Chicago, IL|6660,6666,6667,6668,6669",
-                        "Gameservers.NJ.US.GameSurge.net|GameSurge Newark, NJ|6665,6666,6667,6668,6669,7000,8080",
-                        "Krypt.CA.US.GameSurge.net|GameSurge Santa Ana, CA|6666,6667,6668,6669",
-                        "NuclearFallout.WA.US.GameSurge.net|GameSurge Seattle, WA|6667,5960",
-                        "Portlane.SE.EU.GameSurge.net|GameSurge Stockholm, Sweden|6660,6666,6667,6668,6669",
-                        "Prothid.NY.US.GameSurge.Net|GameSurge NYC, NY|5960,6660,6666,6667,6668,6669,6697",
-                        "TAL.DE.EU.GameSurge.net|GameSurge Wuppertal, Germany|6660,6666,6667,6668,6669",
-                        "208.167.237.120|GameSurge IP 208.167.237.120|6660,6666,6667,6668,6669,7000,8080",
-                        "192.223.27.109|GameSurge IP 192.223.27.109|6660,6666,6667,6668,6669,7000,8080",
-                        "108.174.48.100|GameSurge IP 108.174.48.100|6660,6666,6667,6668,6669,7000,8080",
-                        "208.146.35.105|GameSurge IP 208.146.35.105|6660,6666,6667,6668,6669,7000,8080",
-                        "195.8.250.180|GameSurge IP 195.8.250.180|6660,6666,6667,6668,6669,7000,8080",
-                        "91.217.189.76|GameSurge IP 91.217.189.76|6660,6666,6667,6668,6669,7000,8080",
-                        "195.68.206.250|GameSurge IP 195.68.206.250|6660,6666,6667,6668,6669,7000,8080",
-                        "irc.gamesurge.net|GameSurge|6667",
+                        "irc.gamesurge.net|GameSurge|6667,6660,6666,6668,6669",
                     ];
                 }
 

--- a/DXMainClient/Online/Connection.cs
+++ b/DXMainClient/Online/Connection.cs
@@ -31,28 +31,47 @@ namespace DTAClient.Online
 
         IConnectionManager connectionManager;
 
+        private static IList<Server> _servers = null;
         /// <summary>
         /// The list of CnCNet / GameSurge IRC servers to connect to.
         /// </summary>
-        private static readonly IList<Server> Servers = new List<Server>
+        private static IList<Server> Servers
         {
-            new Server("Burstfire.UK.EU.GameSurge.net", "GameSurge London, UK", new int[3] { 6667, 6668, 7000 }),
-            new Server("ColoCrossing.IL.US.GameSurge.net", "GameSurge Chicago, IL", new int[5] { 6660, 6666, 6667, 6668, 6669 }),
-            new Server("Gameservers.NJ.US.GameSurge.net", "GameSurge Newark, NJ", new int[7] { 6665, 6666, 6667, 6668, 6669, 7000, 8080 }),
-            new Server("Krypt.CA.US.GameSurge.net", "GameSurge Santa Ana, CA", new int[4] { 6666, 6667, 6668, 6669 }),
-            new Server("NuclearFallout.WA.US.GameSurge.net", "GameSurge Seattle, WA", new int[2] { 6667, 5960 }),
-            new Server("Portlane.SE.EU.GameSurge.net", "GameSurge Stockholm, Sweden", new int[5] { 6660, 6666, 6667, 6668, 6669 }),
-            new Server("Prothid.NY.US.GameSurge.Net", "GameSurge NYC, NY", new int[7] { 5960, 6660, 6666, 6667, 6668, 6669, 6697 }),
-            new Server("TAL.DE.EU.GameSurge.net", "GameSurge Wuppertal, Germany", new int[5] { 6660, 6666, 6667, 6668, 6669 }),
-            new Server("208.167.237.120", "GameSurge IP 208.167.237.120", new int[7] {  6660, 6666, 6667, 6668, 6669, 7000, 8080 }),
-            new Server("192.223.27.109", "GameSurge IP 192.223.27.109", new int[7] {  6660, 6666, 6667, 6668, 6669, 7000, 8080 }),
-            new Server("108.174.48.100", "GameSurge IP 108.174.48.100", new int[7] { 6660, 6666, 6667, 6668, 6669, 7000, 8080 }),
-            new Server("208.146.35.105", "GameSurge IP 208.146.35.105", new int[7] { 6660, 6666, 6667, 6668, 6669, 7000, 8080 }),
-            new Server("195.8.250.180", "GameSurge IP 195.8.250.180", new int[7] { 6660, 6666, 6667, 6668, 6669, 7000, 8080 }),
-            new Server("91.217.189.76", "GameSurge IP 91.217.189.76", new int[7] { 6660, 6666, 6667, 6668, 6669, 7000, 8080 }),
-            new Server("195.68.206.250", "GameSurge IP 195.68.206.250", new int[7] { 6660, 6666, 6667, 6668, 6669, 7000, 8080 }),
-            new Server("irc.gamesurge.net", "GameSurge", new int[1] { 6667 }),
-        }.AsReadOnly();
+            get
+            {
+                if (_servers is not null)
+                    return _servers;
+
+                IEnumerable<string> serversList;
+                if (ClientConfiguration.Instance.IRCServers.Count > 0)
+                    serversList = ClientConfiguration.Instance.IRCServers;
+                else
+                {
+                    // fallback to the hardcoded server list
+                    serversList = [
+                        "Burstfire.UK.EU.GameSurge.net|GameSurge London, UK|6667,6668,7000",
+                        "ColoCrossing.IL.US.GameSurge.net|GameSurge Chicago, IL|6660,6666,6667,6668,6669",
+                        "Gameservers.NJ.US.GameSurge.net|GameSurge Newark, NJ|6665,6666,6667,6668,6669,7000,8080",
+                        "Krypt.CA.US.GameSurge.net|GameSurge Santa Ana, CA|6666,6667,6668,6669",
+                        "NuclearFallout.WA.US.GameSurge.net|GameSurge Seattle, WA|6667,5960",
+                        "Portlane.SE.EU.GameSurge.net|GameSurge Stockholm, Sweden|6660,6666,6667,6668,6669",
+                        "Prothid.NY.US.GameSurge.Net|GameSurge NYC, NY|5960,6660,6666,6667,6668,6669,6697",
+                        "TAL.DE.EU.GameSurge.net|GameSurge Wuppertal, Germany|6660,6666,6667,6668,6669",
+                        "208.167.237.120|GameSurge IP 208.167.237.120|6660,6666,6667,6668,6669,7000,8080",
+                        "192.223.27.109|GameSurge IP 192.223.27.109|6660,6666,6667,6668,6669,7000,8080",
+                        "108.174.48.100|GameSurge IP 108.174.48.100|6660,6666,6667,6668,6669,7000,8080",
+                        "208.146.35.105|GameSurge IP 208.146.35.105|6660,6666,6667,6668,6669,7000,8080",
+                        "195.8.250.180|GameSurge IP 195.8.250.180|6660,6666,6667,6668,6669,7000,8080",
+                        "91.217.189.76|GameSurge IP 91.217.189.76|6660,6666,6667,6668,6669,7000,8080",
+                        "195.68.206.250|GameSurge IP 195.68.206.250|6660,6666,6667,6668,6669,7000,8080",
+                        "irc.gamesurge.net|GameSurge|6667",
+                    ];
+                }
+
+                _servers = serversList.Select(Server.Deserialize).ToList();
+                return _servers;
+            }
+        }
 
         bool _isConnected = false;
         public bool IsConnected

--- a/DXMainClient/Online/Server.cs
+++ b/DXMainClient/Online/Server.cs
@@ -1,4 +1,6 @@
-﻿namespace DTAClient.Online
+﻿using System;
+
+namespace DTAClient.Online
 {
     /// <summary>
     /// A struct containing information on an IRC server.
@@ -16,7 +18,7 @@
         public string Name;
         public int[] Ports;
 
-        public string Serialize() => $"{Host}|{Name}|{string.Join(",", Ports)}";
+        public string Serialize() => FormattableString.Invariant($"{Host}|{Name}|{string.Join(",", Ports)}");
 
         public static Server Deserialize(string serialized)
         {

--- a/DXMainClient/Online/Server.cs
+++ b/DXMainClient/Online/Server.cs
@@ -15,5 +15,26 @@
         public string Host;
         public string Name;
         public int[] Ports;
+
+        public string Serialize()
+        {
+            return $"{Host}|{Name}|{string.Join(",", Ports)}";
+        }
+
+        public static Server Deserialize(string serialized)
+        {
+            string[] parts = serialized.Split('|');
+            string host = parts[0];
+            string name = parts[1];
+            string[] portStrings = parts[2].Split(',');
+            int[] ports = new int[portStrings.Length];
+
+            for (int i = 0; i < portStrings.Length; i++)
+            {
+                ports[i] = int.Parse(portStrings[i]);
+            }
+
+            return new Server(host, name, ports);
+        }
     }
 }

--- a/DXMainClient/Resources/DTA/NetworkDefinitions.ini
+++ b/DXMainClient/Resources/DTA/NetworkDefinitions.ini
@@ -1,0 +1,24 @@
+[Settings]
+CnCNetTunnelListURL=http://cncnet.org/master-list
+CnCNetPlayerCountURL=http://api.cncnet.org/status
+CnCNetMapDBDownloadURL=http://mapdb.cncnet.org
+CnCNetMapDBUploadURL=http://mapdb.cncnet.org/upload
+DisableDiscordIntegration=False
+
+[IRCServers]
+1=Burstfire.UK.EU.GameSurge.net|GameSurge London, UK|6667,6668,7000
+2=ColoCrossing.IL.US.GameSurge.net|GameSurge Chicago, IL|6660,6666,6667,6668,6669
+3=Gameservers.NJ.US.GameSurge.net|GameSurge Newark, NJ|6665,6666,6667,6668,6669,7000,8080
+4=Krypt.CA.US.GameSurge.net|GameSurge Santa Ana, CA|6666,6667,6668,6669
+5=NuclearFallout.WA.US.GameSurge.net|GameSurge Seattle, WA|6667,5960
+6=Portlane.SE.EU.GameSurge.net|GameSurge Stockholm, Sweden|6660,6666,6667,6668,6669
+7=Prothid.NY.US.GameSurge.Net|GameSurge NYC, NY|5960,6660,6666,6667,6668,6669,6697
+8=TAL.DE.EU.GameSurge.net|GameSurge Wuppertal, Germany|6660,6666,6667,6668,6669
+9=208.167.237.120|GameSurge IP 208.167.237.120|6660,6666,6667,6668,6669,7000,8080
+10=192.223.27.109|GameSurge IP 192.223.27.109|6660,6666,6667,6668,6669,7000,8080
+11=108.174.48.100|GameSurge IP 108.174.48.100|6660,6666,6667,6668,6669,7000,8080
+12=208.146.35.105|GameSurge IP 208.146.35.105|6660,6666,6667,6668,6669,7000,8080
+13=195.8.250.180|GameSurge IP 195.8.250.180|6660,6666,6667,6668,6669,7000,8080
+14=91.217.189.76|GameSurge IP 91.217.189.76|6660,6666,6667,6668,6669,7000,8080
+15=195.68.206.250|GameSurge IP 195.68.206.250|6660,6666,6667,6668,6669,7000,8080
+16=irc.gamesurge.net|GameSurge|6667

--- a/DXMainClient/Resources/DTA/NetworkDefinitions.ini
+++ b/DXMainClient/Resources/DTA/NetworkDefinitions.ini
@@ -6,19 +6,4 @@ CnCNetMapDBUploadURL=http://mapdb.cncnet.org/upload
 DisableDiscordIntegration=False
 
 [IRCServers]
-1=Burstfire.UK.EU.GameSurge.net|GameSurge London, UK|6667,6668,7000
-2=ColoCrossing.IL.US.GameSurge.net|GameSurge Chicago, IL|6660,6666,6667,6668,6669
-3=Gameservers.NJ.US.GameSurge.net|GameSurge Newark, NJ|6665,6666,6667,6668,6669,7000,8080
-4=Krypt.CA.US.GameSurge.net|GameSurge Santa Ana, CA|6666,6667,6668,6669
-5=NuclearFallout.WA.US.GameSurge.net|GameSurge Seattle, WA|6667,5960
-6=Portlane.SE.EU.GameSurge.net|GameSurge Stockholm, Sweden|6660,6666,6667,6668,6669
-7=Prothid.NY.US.GameSurge.Net|GameSurge NYC, NY|5960,6660,6666,6667,6668,6669,6697
-8=TAL.DE.EU.GameSurge.net|GameSurge Wuppertal, Germany|6660,6666,6667,6668,6669
-9=208.167.237.120|GameSurge IP 208.167.237.120|6660,6666,6667,6668,6669,7000,8080
-10=192.223.27.109|GameSurge IP 192.223.27.109|6660,6666,6667,6668,6669,7000,8080
-11=108.174.48.100|GameSurge IP 108.174.48.100|6660,6666,6667,6668,6669,7000,8080
-12=208.146.35.105|GameSurge IP 208.146.35.105|6660,6666,6667,6668,6669,7000,8080
-13=195.8.250.180|GameSurge IP 195.8.250.180|6660,6666,6667,6668,6669,7000,8080
-14=91.217.189.76|GameSurge IP 91.217.189.76|6660,6666,6667,6668,6669,7000,8080
-15=195.68.206.250|GameSurge IP 195.68.206.250|6660,6666,6667,6668,6669,7000,8080
-16=irc.gamesurge.net|GameSurge|6667
+1=irc.gamesurge.net|GameSurge|6667,6660,6666,6668,6669


### PR DESCRIPTION
Fixes #479 and #489

This PR removes all servers but `irc.gamesurge.net` --- the rest domains are (almost) duplicated. See #489 for more details.

This PR defines a new configuration file `NetworkDefinitions.ini`. This file is optional, so if it is missing everything goes well as if this PR were not merged -- except removing all servers but `irc.gamesurge.net`

----

The following urls are configurable:
- http://cncnet.org/master-list
- http://api.cncnet.org/status
- http://mapdb.cncnet.org
- http://mapdb.cncnet.org/upload

Also, setting a url to empty means do not fetch these resources online. This is meaningful if either:
- someone publishes a mod only focusing on solo mission
- a user's Internet connection is partially unstable

Add an option `DisableDiscordIntegration` to enable Chinese players disabling discord integration even before the first client launch. (`DiscordIntegration` in `UserINISettings` defaults to true!)

Allow specifying IRC servers in `[IRCServers]` section.

----

Example `NetworkDefinitions.ini` file:

```ini
[Settings]
CnCNetTunnelListURL=http://cncnet.org/master-list
CnCNetPlayerCountURL=http://api.cncnet.org/status
CnCNetMapDBDownloadURL=http://mapdb.cncnet.org
CnCNetMapDBUploadURL=http://mapdb.cncnet.org/upload
DisableDiscordIntegration=False

[IRCServers]
1=irc.gamesurge.net|GameSurge|6667,6660,6666,6668,6669
2=Krypt.CA.US.GameSurge.net|GameSurge Santa Ana, CA|6667,6660,6666,6668,6669
```