### PR TITLE
Randomized game mode feature

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -1557,7 +1557,11 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             IniFile globalCodeIni = new IniFile(SafePath.CombineFilePath(ProgramConstants.GamePath, "INI", "Map Code", "GlobalCode.ini"));
 
-            MapCodeHelper.ApplyMapCode(mapIni, GameMode.GetMapRulesIniFile());
+            foreach (IniFile iniFile in GameMode.GetMapRulesIniFiles(RandomSeed))
+            {
+                MapCodeHelper.ApplyMapCode(mapIni, iniFile);
+            }
+
             MapCodeHelper.ApplyMapCode(mapIni, globalCodeIni);
 
             if (isMultiplayer)

--- a/DXMainClient/Domain/Multiplayer/GameMode.cs
+++ b/DXMainClient/Domain/Multiplayer/GameMode.cs
@@ -3,6 +3,7 @@ using ClientCore.Extensions;
 using Rampastring.Tools;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace DTAClient.Domain.Multiplayer
 {
@@ -66,6 +67,8 @@ namespace DTAClient.Domain.Multiplayer
         public int MinPlayersOverride { get; private set; } = -1;
 
         private string mapCodeININame;
+        private List<string> randomizedMapCodeININames;
+        private int randomizedMapCodesCount;
 
         private string forcedOptionsSection;
 
@@ -92,6 +95,8 @@ namespace DTAClient.Domain.Multiplayer
             MinPlayersOverride = forcedOptionsIni.GetIntValue(Name, "MinPlayersOverride", -1);
             forcedOptionsSection = forcedOptionsIni.GetStringValue(Name, "ForcedOptions", string.Empty);
             mapCodeININame = forcedOptionsIni.GetStringValue(Name, "MapCodeININame", Name + ".ini");
+            randomizedMapCodeININames = forcedOptionsIni.GetStringValue(Name, "RandomizedMapCodeININames", string.Empty).Split(',', StringSplitOptions.RemoveEmptyEntries).ToList();
+            randomizedMapCodesCount = forcedOptionsIni.GetIntValue(Name, "RandomizedMapCodesCount", 1);
 
             string[] disallowedSides = forcedOptionsIni
                 .GetStringValue(Name, "DisallowedPlayerSides", string.Empty)
@@ -153,9 +158,24 @@ namespace DTAClient.Domain.Multiplayer
                 spawnIni.SetStringValue("Settings", key.Key, key.Value);
         }
 
-        public IniFile GetMapRulesIniFile()
+        public List<IniFile> GetMapRulesIniFiles(int randomSeed)
         {
-            return new IniFile(SafePath.CombineFilePath(ProgramConstants.GamePath, BASE_INI_PATH, mapCodeININame));
+            var mapRules = new List<IniFile>() { new IniFile(SafePath.CombineFilePath(ProgramConstants.GamePath, BASE_INI_PATH, mapCodeININame)) };
+            if (randomizedMapCodeININames.Count == 0)
+                return mapRules;
+
+            Random random = new Random(randomSeed);
+            Dictionary<string, int> randomOrder = new();
+            foreach (string name in randomizedMapCodeININames)
+            {
+                randomOrder[name] = random.Next();
+            }
+
+            mapRules.AddRange(
+                from iniName in randomizedMapCodeININames.OrderBy(x => randomOrder[x]).Take(randomizedMapCodesCount)
+                select new IniFile(SafePath.CombineFilePath(ProgramConstants.GamePath, BASE_INI_PATH, iniName)));
+
+            return mapRules;
         }
 
         protected bool Equals(GameMode other) => string.Equals(Name, other?.Name, StringComparison.InvariantCultureIgnoreCase);


### PR DESCRIPTION
This PR introduces randomness to game modes. Apart from original map code, it can now randomly select and insert some map codes. The following example defines a random game mode, where when game starts, 2 files from `RNG1.ini`, `RNG2.ini`, `RNG3.ini` files will be randomly loaded

```ini
[A Random Game Mode]
UIName=A Random Game Mode
MapCodeININame=A Random Game Mode-Base.ini
RandomizedMapCodeININames=RNG1.ini,RNG2.ini,RNG3.ini
RandomizedMapCodesCount=2
```
