### PR TITLE
Write detailed exception message to log

### DIFF
--- a/ClientCore/SavedGameManager.cs
+++ b/ClientCore/SavedGameManager.cs
@@ -83,7 +83,7 @@ namespace ClientCore
             }
             catch (Exception ex)
             {
-                Logger.Log("Writing spawn.ini for saved game failed! Exception message: " + ex.Message);
+                Logger.Log("Writing spawn.ini for saved game failed! Exception message: " + ex.ToString());
                 return false;
             }
 
@@ -140,7 +140,7 @@ namespace ClientCore
                 }
                 catch (Exception ex)
                 {
-                    Logger.Log("Renaming saved game failed! Exception message: " + ex.Message);
+                    Logger.Log("Renaming saved game failed! Exception message: " + ex.ToString());
                 }
 
                 tryCount++;
@@ -172,7 +172,7 @@ namespace ClientCore
             }
             catch (Exception ex)
             {
-                Logger.Log("Erasing previous MP saved games failed! Exception message: " + ex.Message);
+                Logger.Log("Erasing previous MP saved games failed! Exception message: " + ex.ToString());
                 return false;
             }
 

--- a/ClientCore/Statistics/GameParsers/LogFileStatisticsParser.cs
+++ b/ClientCore/Statistics/GameParsers/LogFileStatisticsParser.cs
@@ -150,7 +150,7 @@ namespace ClientCore.Statistics.GameParsers
             }
             catch (Exception ex)
             {
-                Logger.Log("DTAStatisticsParser: Error parsing statistics from match! Message: " + ex.Message);
+                Logger.Log("DTAStatisticsParser: Error parsing statistics from match! Message: " + ex.ToString());
             }
         }
     }

--- a/ClientCore/Statistics/StatisticsManager.cs
+++ b/ClientCore/Statistics/StatisticsManager.cs
@@ -107,7 +107,7 @@ namespace ClientCore.Statistics
             }
             catch (Exception ex)
             {
-                Logger.Log("Error reading statistics: " + ex.Message);
+                Logger.Log("Error reading statistics: " + ex.ToString());
             }
 
             return returnValue;
@@ -259,7 +259,7 @@ namespace ClientCore.Statistics
             }
             catch (Exception ex)
             {
-                Logger.Log("Reading the statistics file failed! Message: " + ex.Message);
+                Logger.Log("Reading the statistics file failed! Message: " + ex.ToString());
             }
         }
 

--- a/ClientGUI/GameProcessLogic.cs
+++ b/ClientGUI/GameProcessLogic.cs
@@ -7,6 +7,7 @@ using Rampastring.Tools;
 using ClientCore.INIProcessing;
 using System.Threading;
 using Rampastring.XNAUI;
+using ClientCore.Extensions;
 
 namespace ClientGUI
 {
@@ -95,10 +96,12 @@ namespace ClientGUI
                 }
                 catch (Exception ex)
                 {
-                    Logger.Log("Error launching QRes: " + ex.Message);
-                    XNAMessageBox.Show(windowManager, "Error launching game", "Error launching " + ProgramConstants.QRES_EXECUTABLE + ". Please check that your anti-virus isn't blocking the CnCNet Client. " +
-                        "You can also try running the client as an administrator." + Environment.NewLine + Environment.NewLine + "You are unable to participate in this match." +
-                        Environment.NewLine + Environment.NewLine + "Returned error: " + ex.Message);
+                    Logger.Log("Error launching QRes: " + ex.ToString());
+                    XNAMessageBox.Show(windowManager,
+                        "Error launching game".L10N("Client:ClientGUI:ErrorLaunchQresTitle"),
+                        string.Format("Error launching {0}. Please check that your anti-virus isn't blocking the CnCNet Client. " +
+                        "You can also try running the client as an administrator.\n\nYou are unable to participate in this match. \n\n" +
+                        "Returned error: {1}".L10N("Client:ClientGUI:ErrorLaunchQresText"), ProgramConstants.QRES_EXECUTABLE, ex.Message));
                     Process_Exited(QResProcess, EventArgs.Empty);
                     return;
                 }
@@ -135,7 +138,7 @@ namespace ClientGUI
                 }
                 catch (Exception ex)
                 {
-                    Logger.Log("Error launching " + gameFileInfo.Name + ": " + ex.Message);
+                    Logger.Log("Error launching " + gameFileInfo.Name + ": " + ex.ToString());
                     XNAMessageBox.Show(windowManager, "Error launching game", "Error launching " + gameFileInfo.Name + ". Please check that your anti-virus isn't blocking the CnCNet Client. " +
                         "You can also try running the client as an administrator." + Environment.NewLine + Environment.NewLine + "You are unable to participate in this match." +
                         Environment.NewLine + Environment.NewLine + "Returned error: " + ex.Message);

--- a/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
@@ -441,7 +441,7 @@ namespace DTAConfig.OptionPanels
                 }
                 catch (Exception ex)
                 {
-                    Logger.Log("Setting TSCompatFixDeclined failed! Returned error: " + ex.Message);
+                    Logger.Log("Setting TSCompatFixDeclined failed! Returned error: " + ex.ToString());
                 }
             }
             catch { }
@@ -478,7 +478,7 @@ namespace DTAConfig.OptionPanels
                 }
                 catch (Exception ex)
                 {
-                    Logger.Log("Uninstalling DTA/TI/TS Compatibility Fix failed. Error message: " + ex.Message);
+                    Logger.Log("Uninstalling DTA/TI/TS Compatibility Fix failed. Error message: " + ex.ToString());
                     XNAMessageBox.Show(WindowManager, "Uninstalling Compatibility Fix Failed".L10N("Client:DTAConfig:TSFixUninstallFailTitle"),
                         "Uninstalling DTA/TI/TS Compatibility Fix failed. Returned error:".L10N("Client:DTAConfig:TSFixUninstallFailText") + " " + ex.Message);
                 }
@@ -506,7 +506,7 @@ namespace DTAConfig.OptionPanels
             }
             catch (Exception ex)
             {
-                Logger.Log("Installing DTA/TI/TS Compatibility Fix failed. Error message: " + ex.Message);
+                Logger.Log("Installing DTA/TI/TS Compatibility Fix failed. Error message: " + ex.ToString());
                 XNAMessageBox.Show(WindowManager, "Installing Compatibility Fix Failed".L10N("Client:DTAConfig:TSFixInstallFailTitle"),
                     "Installing DTA/TI/TS Compatibility Fix failed. Error message:".L10N("Client:DTAConfig:TSFixInstallFailText") + " " + ex.Message);
             }
@@ -537,7 +537,7 @@ namespace DTAConfig.OptionPanels
                 }
                 catch (Exception ex)
                 {
-                    Logger.Log("Uninstalling FinalSun Compatibility Fix failed. Error message: " + ex.Message);
+                    Logger.Log("Uninstalling FinalSun Compatibility Fix failed. Error message: " + ex.ToString());
                     XNAMessageBox.Show(WindowManager, "Uninstalling Compatibility Fix Failed".L10N("Client:DTAConfig:TSFinalSunFixUninstallFailedTitle"),
                         "Uninstalling FinalSun Compatibility Fix failed. Error message:".L10N("Client:DTAConfig:TSFinalSunFixUninstallFailedText") + " " + ex.Message);
                 }
@@ -565,7 +565,7 @@ namespace DTAConfig.OptionPanels
             }
             catch (Exception ex)
             {
-                Logger.Log("Installing FinalSun Compatibility Fix failed. Error message: " + ex.Message);
+                Logger.Log("Installing FinalSun Compatibility Fix failed. Error message: " + ex.ToString());
                 XNAMessageBox.Show(WindowManager, "Installing Compatibility Fix Failed".L10N("Client:DTAConfig:TSFinalSunCompatibilityFixInstalledFailedTitle"),
                     "Installing FinalSun Compatibility Fix failed. Error message:".L10N("Client:DTAConfig:TSFinalSunCompatibilityFixInstalledFailedText") + " " + ex.Message);
             }

--- a/DTAConfig/OptionsWindow.cs
+++ b/DTAConfig/OptionsWindow.cs
@@ -191,7 +191,7 @@ namespace DTAConfig
             }
             catch (Exception ex)
             {
-                Logger.Log("Saving settings failed! Error message: " + ex.Message);
+                Logger.Log("Saving settings failed! Error message: " + ex.ToString());
                 XNAMessageBox.Show(WindowManager, "Saving Settings Failed".L10N("Client:DTAConfig:SaveSettingFailTitle"),
                     "Saving settings failed! Error message:".L10N("Client:DTAConfig:SaveSettingFailText") + " " + ex.Message);
             }

--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -88,6 +88,7 @@ namespace DTAClient.DXGUI
             }
             catch (Exception ex)
             {
+                // TODO Get English exception message
                 if (ex.Message.Contains("DeviceRemoved"))
                 {
                     Logger.Log($"Creating texture on startup failed! Creating {startupFailureFile} file and re-launching client launcher.");

--- a/DXMainClient/DXGUI/Generic/GameInProgressWindow.cs
+++ b/DXMainClient/DXGUI/Generic/GameInProgressWindow.cs
@@ -108,7 +108,7 @@ namespace DTAClient.DXGUI
             }
             catch (Exception ex)
             {
-                Logger.Log("Exception when deleting error log files! Message: " + ex.Message);
+                Logger.Log("Exception when deleting error log files! Message: " + ex.ToString());
                 deletingLogFilesFailed = true;
             }
 #endif
@@ -246,7 +246,7 @@ namespace DTAClient.DXGUI
             }
             catch (Exception ex)
             {
-                Logger.Log("An error occured while checking for " + filename + " file. Message: " + ex.Message);
+                Logger.Log("An error occured while checking for " + filename + " file. Message: " + ex.ToString());
             }
             return copied;
         }
@@ -290,7 +290,7 @@ namespace DTAClient.DXGUI
             }
             catch (Exception ex)
             {
-                Logger.Log("An error occured while checking for SYNCX.TXT files. Message: " + ex.Message);
+                Logger.Log("An error occured while checking for SYNCX.TXT files. Message: " + ex.ToString());
             }
             return copied;
         }
@@ -360,7 +360,7 @@ namespace DTAClient.DXGUI
                 }
                 catch (Exception ex)
                 {
-                    Logger.Log("ProcessScreenshots: An error occured trying to create Screenshots directory. Message: " + ex.Message);
+                    Logger.Log("ProcessScreenshots: An error occured trying to create Screenshots directory. Message: " + ex.ToString());
                     return;
                 }
             }
@@ -378,7 +378,7 @@ namespace DTAClient.DXGUI
                 }
                 catch (Exception ex)
                 {
-                    Logger.Log("ProcessScreenshots: Error occured when trying to save " + Path.GetFileNameWithoutExtension(file.FullName) + ".png. Message: " + ex.Message);
+                    Logger.Log("ProcessScreenshots: Error occured when trying to save " + Path.GetFileNameWithoutExtension(file.FullName) + ".png. Message: " + ex.ToString());
                     continue;
                 }
 

--- a/DXMainClient/DXGUI/Generic/MainMenu.cs
+++ b/DXMainClient/DXGUI/Generic/MainMenu.cs
@@ -377,7 +377,7 @@ namespace DTAClient.DXGUI.Generic
             }
             catch (Exception ex)
             {
-                Logger.Log("Refreshing settings failed! Exception message: " + ex.Message);
+                Logger.Log("Refreshing settings failed! Exception message: " + ex.ToString());
                 // We don't want to show the dialog when starting a game
                 //XNAMessageBox.Show(WindowManager, "Saving settings failed",
                 //    "Saving settings failed! Error message: " + ex.Message);
@@ -941,7 +941,7 @@ namespace DTAClient.DXGUI.Generic
                 }
                 catch (InvalidOperationException ex)
                 {
-                    Logger.Log("Playing main menu music failed! " + ex.Message);
+                    Logger.Log("Playing main menu music failed! " + ex.ToString());
                 }
             }
         }
@@ -1036,7 +1036,7 @@ namespace DTAClient.DXGUI.Generic
             }
             catch (Exception ex)
             {
-                Logger.Log("Turning music off failed! Message: " + ex.Message);
+                Logger.Log("Turning music off failed! Message: " + ex.ToString());
             }
         }
 
@@ -1052,9 +1052,9 @@ namespace DTAClient.DXGUI.Generic
                 MediaState state = MediaPlayer.State;
                 return true;
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Logger.Log("Error encountered when checking media player availability. Error message: " + e.Message);
+                Logger.Log("Error encountered when checking media player availability. Error message: " + ex.ToString());
                 return false;
             }
         }

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
@@ -1554,7 +1554,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             }
             catch (Exception ex)
             {
-                Logger.Log("Game parsing error: " + ex.Message);
+                Logger.Log("Game parsing error: " + ex.ToString());
             }
         }
 

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -664,7 +664,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             }
             catch (IOException ex)
             {
-                Logger.Log($"Deleting map {Map.BaseFilePath} failed! Message: {ex.Message}");
+                Logger.Log($"Deleting map {Map.BaseFilePath} failed! Message: {ex.ToString()}");
                 XNAMessageBox.Show(WindowManager, "Deleting Map Failed".L10N("Client:Main:DeleteMapFailedTitle"),
                     "Deleting map failed! Reason:".L10N("Client:Main:DeleteMapFailedText") + " " + ex.Message);
             }
@@ -1610,11 +1610,11 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                     File.Copy(file, SafePath.CombineFilePath(ProgramConstants.GamePath, supplementalFileName), true);
                     supplementalFileNames.Add(supplementalFileName);
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
                     string errorMessage = "Unable to copy supplemental map file".L10N("Client:Main:SupplementalFileCopyError") + $" {file}";
                     Logger.Log(errorMessage);
-                    Logger.Log(e.Message);
+                    Logger.Log(ex.ToString());
                     XNAMessageBox.Show(WindowManager, "Error".L10N("Client:Main:Error"), errorMessage);
                     
                 }
@@ -1639,11 +1639,11 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 {
                     File.Delete(supplementalMapFilename);
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
                     string errorMessage = "Unable to delete supplemental map file".L10N("Client:Main:SupplementalFileDeleteError") + $" {supplementalMapFilename}";
                     Logger.Log(errorMessage);
-                    Logger.Log(e.Message);
+                    Logger.Log(ex.ToString());
                     XNAMessageBox.Show(WindowManager, "Error".L10N("Client:Main:Error"), errorMessage);
                 }
             }

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
@@ -193,7 +193,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 }
                 catch (Exception ex)
                 {
-                    Logger.Log("Listener error: " + ex.Message);
+                    Logger.Log("Listener error: " + ex.ToString());
                     break;
                 }
 
@@ -237,7 +237,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 }
                 catch (Exception ex)
                 {
-                    Logger.Log("Socket error with client " + lpInfo.IPAddress + "; removing. Message: " + ex.Message);
+                    Logger.Log("Socket error with client " + lpInfo.IPAddress + "; removing. Message: " + ex.ToString());
                     break;
                 }
 
@@ -365,7 +365,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 }
                 catch (Exception ex)
                 {
-                    Logger.Log("Reading data from the server failed! Message: " + ex.Message);
+                    Logger.Log("Reading data from the server failed! Message: " + ex.ToString());
                     BtnLeaveGame_LeftClick(this, EventArgs.Empty);
                     break;
                 }

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/SkirmishLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/SkirmishLobby.cs
@@ -296,7 +296,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             }
             catch (Exception ex)
             {
-                Logger.Log("Saving skirmish settings failed! Reason: " + ex.Message);
+                Logger.Log("Saving skirmish settings failed! Reason: " + ex.ToString());
             }
         }
 

--- a/DXMainClient/DXGUI/Multiplayer/LANGameLoadingLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/LANGameLoadingLobby.cs
@@ -167,7 +167,7 @@ namespace DTAClient.DXGUI.Multiplayer
                 }
                 catch (Exception ex)
                 {
-                    Logger.Log("Listener error: " + ex.Message);
+                    Logger.Log("Listener error: " + ex.ToString());
                     break;
                 }
 
@@ -197,7 +197,7 @@ namespace DTAClient.DXGUI.Multiplayer
                 }
                 catch (Exception ex)
                 {
-                    Logger.Log("Socket error with client " + lpInfo.IPAddress + "; removing. Message: " + ex.Message);
+                    Logger.Log("Socket error with client " + lpInfo.IPAddress + "; removing. Message: " + ex.ToString());
                     break;
                 }
 
@@ -328,7 +328,7 @@ namespace DTAClient.DXGUI.Multiplayer
                 }
                 catch (Exception ex)
                 {
-                    Logger.Log("Reading data from the server failed! Message: " + ex.Message);
+                    Logger.Log("Reading data from the server failed! Message: " + ex.ToString());
                     LeaveGame();
                     break;
                 }

--- a/DXMainClient/DXGUI/Multiplayer/LANLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/LANLobby.cs
@@ -353,7 +353,7 @@ namespace DTAClient.DXGUI.Multiplayer
             }
             catch (SocketException ex)
             {
-                Logger.Log("Creating LAN socket failed! Message: " + ex.Message);
+                Logger.Log("Creating LAN socket failed! Message: " + ex.ToString());
                 lbChatMessages.AddMessage(new ChatMessage(Color.Red,
                     "Creating LAN socket failed! Message:".L10N("Client:Main:SocketFailure1") + " " + ex.Message));
                 lbChatMessages.AddMessage(new ChatMessage(Color.Red,
@@ -405,7 +405,7 @@ namespace DTAClient.DXGUI.Multiplayer
             }
             catch (Exception ex)
             {
-                Logger.Log("LAN socket listener: exception: " + ex.Message);
+                Logger.Log("LAN socket listener: exception: " + ex.ToString());
             }
         }
 

--- a/DXMainClient/Domain/Multiplayer/CnCNet/CnCNetTunnel.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/CnCNetTunnel.cs
@@ -61,7 +61,7 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
             {
                 if (ex is FormatException || ex is OverflowException || ex is IndexOutOfRangeException)
                 {
-                    Logger.Log("Parsing tunnel information failed: " + ex.Message + Environment.NewLine + "Parsed string: " + str);
+                    Logger.Log("Parsing tunnel information failed: " + ex.ToString() + Environment.NewLine + "Parsed string: " + str);
                     return null;
                 }
 
@@ -119,7 +119,7 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
             }
             catch (Exception ex)
             {
-                Logger.Log("Unable to connect to the specified tunnel server. Returned error message: " + ex.Message);
+                Logger.Log("Unable to connect to the specified tunnel server. Returned error message: " + ex.ToString());
             }
 
             return new List<int>();
@@ -137,7 +137,7 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
                 }
                 catch (PingException ex)
                 {
-                    Logger.Log($"Caught an exception when pinging {Name} tunnel server: {ex.Message}");
+                    Logger.Log($"Caught an exception when pinging {Name} tunnel server: {ex.ToString()}");
                 }
             }
         }

--- a/DXMainClient/Domain/Multiplayer/CnCNet/MapSharer.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/MapSharer.cs
@@ -326,7 +326,7 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
             }
             catch (Exception ex)
             {
-                Logger.Log("MapSharer: ERROR " + ex.Message);
+                Logger.Log("MapSharer: ERROR " + ex.ToString());
             }
 
             string mapPath = DownloadMain(sha1, myGameId, mapName, out success);

--- a/DXMainClient/Domain/Multiplayer/CnCNet/TunnelHandler.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/TunnelHandler.cs
@@ -165,7 +165,7 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
             }
             catch (Exception ex)
             {
-                Logger.Log("Error when downloading tunnel server info: " + ex.Message);
+                Logger.Log("Error when downloading tunnel server info: " + ex.ToString());
                 Logger.Log("Retrying.");
                 try
                 {
@@ -210,7 +210,7 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
                 }
                 catch (Exception ex)
                 {
-                    Logger.Log("Caught an exception when parsing a tunnel server: " + ex.Message);
+                    Logger.Log("Caught an exception when parsing a tunnel server: " + ex.ToString());
                 }
             }
 
@@ -230,7 +230,7 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
                 }
                 catch (Exception ex)
                 {
-                    Logger.Log("Refreshing tunnel cache file failed! Returned error: " + ex.Message);
+                    Logger.Log("Refreshing tunnel cache file failed! Returned error: " + ex.ToString());
                 }
             }
 

--- a/DXMainClient/Domain/Multiplayer/LAN/LANPlayerInfo.cs
+++ b/DXMainClient/Domain/Multiplayer/LAN/LANPlayerInfo.cs
@@ -151,7 +151,7 @@ namespace DTAClient.Domain.Multiplayer.LAN
                 catch (Exception ex)
                 {
                     //a socket error has occured
-                    Logger.Log("Socket error with client " + Name + "; removing. Message: " + ex.Message);
+                    Logger.Log("Socket error with client " + Name + "; removing. Message: " + ex.ToString());
                     ConnectionLost?.Invoke(this, EventArgs.Empty);
                     break;
                 }
@@ -206,7 +206,7 @@ namespace DTAClient.Domain.Multiplayer.LAN
                 }
                 catch (PingException ex)
                 {
-                    Logger.Log($"Caught an exception when pinging {Name} LAN player: {ex.Message}");
+                    Logger.Log($"Caught an exception when pinging {Name} LAN player: {ex.ToString()}");
                 }
             }
         }

--- a/DXMainClient/Domain/Multiplayer/Map.cs
+++ b/DXMainClient/Domain/Multiplayer/Map.cs
@@ -428,7 +428,7 @@ namespace DTAClient.Domain.Multiplayer
             }
             catch (Exception ex)
             {
-                Logger.Log("Setting info for " + BaseFilePath + " failed! Reason: " + ex.Message);
+                Logger.Log("Setting info for " + BaseFilePath + " failed! Reason: " + ex.ToString());
                 PreStartup.LogException(ex);
                 return false;
             }
@@ -455,9 +455,9 @@ namespace DTAClient.Domain.Multiplayer
                         TeamStartMappings = TeamStartMapping.FromListString(teamStartMappingPreset)
                     });
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    Logger.Log($"Unable to parse team start mappings. Map: \"{Name}\", Error: {e.Message}");
+                    Logger.Log($"Unable to parse team start mappings. Map: \"{Name}\", Error: {ex.Message}");
                     TeamStartMappingPresets = new List<TeamStartMappingPreset>();
                 }
             }

--- a/DXMainClient/Domain/Multiplayer/MapPreviewExtractor.cs
+++ b/DXMainClient/Domain/Multiplayer/MapPreviewExtractor.cs
@@ -134,9 +134,9 @@ namespace DTAClient.Domain.Multiplayer
                 errorMessage = null;
                 return dataDest;
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                errorMessage = "Error encountered decompressing preview data. Message: " + e.Message;
+                errorMessage = "Error encountered decompressing preview data. Message: " + ex.Message;
                 return null;
             }
         }
@@ -213,9 +213,9 @@ namespace DTAClient.Domain.Multiplayer
 
                 return image;
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                errorMessage = "Error encountered creating preview bitmap. Message: " + e.Message;
+                errorMessage = "Error encountered creating preview bitmap. Message: " + ex.Message;
                 return null;
             }
         }

--- a/DXMainClient/Domain/SavedGame.cs
+++ b/DXMainClient/Domain/SavedGame.cs
@@ -57,7 +57,7 @@ namespace DTAClient.Domain
             catch (Exception ex)
             {
                 Logger.Log("An error occured while parsing saved game " + FileName + ":" +
-                    ex.Message);
+                    ex.ToString());
                 return false;
             }
         }

--- a/DXMainClient/Online/CnCNetUserData.cs
+++ b/DXMainClient/Online/CnCNetUserData.cs
@@ -99,7 +99,7 @@ namespace DTAClient.Online
             }
             catch (Exception ex)
             {
-                Logger.Log($"Saving {path} failed! Error message: " + ex.Message);
+                Logger.Log($"Saving {path} failed! Error message: " + ex.ToString());
             }
         }
 
@@ -116,7 +116,7 @@ namespace DTAClient.Online
             }
             catch (Exception ex)
             {
-                Logger.Log($"Saving {path} failed! Error message: " + ex.Message);
+                Logger.Log($"Saving {path} failed! Error message: " + ex.ToString());
             }
         }
 

--- a/DXMainClient/Online/Connection.cs
+++ b/DXMainClient/Online/Connection.cs
@@ -207,7 +207,7 @@ namespace DTAClient.Online
                 }
                 catch (Exception ex)
                 {
-                    Logger.Log("Unable to connect to the server. " + ex.Message);
+                    Logger.Log("Unable to connect to the server. " + ex.ToString());
                 }
             }
 
@@ -252,7 +252,7 @@ namespace DTAClient.Online
                 }
                 catch (Exception ex)
                 {
-                    Logger.Log("Disconnected from CnCNet due to a socket error. Message: " + ex.Message);
+                    Logger.Log("Disconnected from CnCNet due to a socket error. Message: " + ex.ToString());
                     errorTimes++;
 
                     if (errorTimes > MAX_RECONNECT_COUNT)
@@ -349,7 +349,7 @@ namespace DTAClient.Online
                     }
                     catch (SocketException ex)
                     {
-                        Logger.Log($"Caught an exception when DNS resolving {serverName} ({serverHostnameOrIPAddress}) Lobby server: {ex.Message}");
+                        Logger.Log($"Caught an exception when DNS resolving {serverName} ({serverHostnameOrIPAddress}) Lobby server: {ex.ToString()}");
                     }
 
                     return _serverInfos;
@@ -441,7 +441,7 @@ namespace DTAClient.Online
                         }
                         catch (PingException ex)
                         {
-                            Logger.Log($"Caught an exception when pinging {serverNames} ({serverIPAddress}) Lobby server: {ex.Message}");
+                            Logger.Log($"Caught an exception when pinging {serverNames} ({serverIPAddress}) Lobby server: {ex.ToString()}");
 
                             return new Tuple<Server, long>(server, long.MaxValue);
                         }
@@ -968,7 +968,7 @@ namespace DTAClient.Online
                 }
                 catch (IOException ex)
                 {
-                    Logger.Log("Sending message to the server failed! Reason: " + ex.Message);
+                    Logger.Log("Sending message to the server failed! Reason: " + ex.ToString());
                 }
             }
         }

--- a/DXMainClient/PreStartup.cs
+++ b/DXMainClient/PreStartup.cs
@@ -138,7 +138,7 @@ namespace DTAClient
             }
             catch (Exception ex)
             {
-                Logger.Log("Failed to load the translation file. " + ex.Message);
+                Logger.Log("Failed to load the translation file. " + ex.ToString());
                 Translation.Instance = new Translation(UserINISettings.Instance.Translation);
             }
 
@@ -169,7 +169,7 @@ namespace DTAClient
             }
             catch (Exception ex)
             {
-                Logger.Log("Failed to generate the translation stub: " + ex.Message);
+                Logger.Log("Failed to generate the translation stub: " + ex.ToString());
             }
 
             // Delete obsolete files from old target project versions
@@ -185,10 +185,9 @@ namespace DTAClient
             {
                 LogException(ex);
 
-                string error = "Deleting wsock32.dll failed! Please close any " +
-                    "applications that could be using the file, and then start the client again."
-                    + Environment.NewLine + Environment.NewLine +
-                    "Message: " + ex.Message;
+                string error = ("Deleting wsock32.dll failed! Please close any " +
+                    "applications that could be using the file, and then start the client again." + "\n\n" +
+                    "Message:").L10N("Client:Main:DeleteWsock32Failed") + " " + ex.Message;
 
                 ProgramConstants.DisplayErrorAction(null, error, true);
             }

--- a/DXMainClient/Startup.cs
+++ b/DXMainClient/Startup.cs
@@ -161,10 +161,10 @@ namespace DTAClient
                             if (fileInfo.CreationTime <= pruneThresholdTime)
                                 fileInfo.Delete();
                         }
-                        catch (Exception e)
+                        catch (Exception ex)
                         {
                             Logger.Log("PruneFiles: Could not delete file " + fsEntry.Name +
-                                ". Error message: " + e.Message);
+                                ". Error message: " + ex.ToString());
                             continue;
                         }
                     }
@@ -176,7 +176,7 @@ namespace DTAClient
             catch (Exception ex)
             {
                 Logger.Log("PruneFiles: An error occurred while pruning files from " +
-                   directory.Name + ". Message: " + ex.Message);
+                   directory.Name + ". Message: " + ex.ToString());
             }
         }
 #endif
@@ -232,7 +232,7 @@ namespace DTAClient
             {
                 Logger.Log("MigrateLogFiles: An error occured while moving log files from " +
                     currentDirectory.Name + " to " +
-                    newDirectory.Name + ". Message: " + ex.Message);
+                    newDirectory.Name + ". Message: " + ex.ToString());
             }
         }
 


### PR DESCRIPTION
```diff
-Logger.Log(ex.Message);
+Logger.Log(ex.ToString());
```

`ex.ToString()` contains stack trace. Currently the client will not record stack trace for non critical exceptions and it's bad.

For those `ex.Message` acting as UI strings, they are untouched