### PR TITLE
Fix privileges evaluation

### DIFF
--- a/ClientCore/ProgramConstants.cs
+++ b/ClientCore/ProgramConstants.cs
@@ -4,9 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Reflection;
-#if WINFORMS
-using System.Windows.Forms;
-#endif
 using Rampastring.Tools;
 using ClientCore.Extensions;
 
@@ -117,33 +114,6 @@ namespace ClientCore
         public static List<string> AI_PLAYER_NAMES => new List<string> { "Easy AI".L10N("Client:Main:EasyAIName"), "Medium AI".L10N("Client:Main:MediumAIName"), "Hard AI".L10N("Client:Main:HardAIName") };
 
         public static string LogFileName { get; set; }
-
-        private static Action<string, string, bool> displayErrorAction = null;
-        /// <summary>
-        /// Gets or sets the action to perform to notify the user of an error.
-        /// </summary>
-        public static Action<string, string, bool> DisplayErrorAction
-        {
-            get => displayErrorAction ??= DefaultDisplayErrorAction;
-            set => displayErrorAction = value;
-        }
-
-        public static Action<string, string, bool> DefaultDisplayErrorAction = (title, error, exit) =>
-        {
-            Logger.Log(FormattableString.Invariant($"{(title is null ? null : title + Environment.NewLine + Environment.NewLine)}{error}"));
-#if WINFORMS
-#if NETFRAMEWORK
-            MessageBox.Show(error, title, MessageBoxButtons.OK);
-#else
-            TaskDialog.ShowDialog(new() { Caption = title, Heading = error });
-#endif
-#else
-            ProcessLauncher.StartShellProcess(LogFileName);
-#endif
-
-            if (exit)
-                Environment.Exit(1);
-        };
 
         /// <summary>
         /// This method finds the "Resources" directory by traversing the directory tree upwards from the startup path.

--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -132,7 +132,7 @@ namespace DTAClient.DXGUI
 
             wm.ControlINIAttributeParsers.Add(new TranslationINIParser());
 
-            ProgramConstants.DisplayErrorAction = (title, error, exit) =>
+            MainClientConstants.DisplayErrorAction = (title, error, exit) =>
             {
                 new XNAMessageBox(wm, title, error, XNAMessageBoxButtons.OK)
                 {

--- a/DXMainClient/Domain/MainClientConstants.cs
+++ b/DXMainClient/Domain/MainClientConstants.cs
@@ -28,7 +28,8 @@ namespace DTAClient.Domain
 
         public static OSVersion OSId = OSVersion.UNKNOWN;
 
-        public static bool LoggerInitialized = false;
+        // TODO: remove this variable after `Logger.Initialized` property is implemented by upstream
+        public static bool LoggerInitialized { get; set; } = false;
 
         private static Action<string, string, bool> displayErrorAction = null;
         /// <summary>

--- a/DXMainClient/Domain/MainClientConstants.cs
+++ b/DXMainClient/Domain/MainClientConstants.cs
@@ -37,7 +37,14 @@ namespace DTAClient.Domain
             set => displayErrorAction = value;
         }
 
-        public static Action<string, string, bool> InitialDisplayErrorAction = (title, error, exit) =>
+        /// <summary>
+        /// Show an error in console as well as Win32 MessageBox. For non-Windows platforms, this creates and opens a temporary text file containing the error message in a GUI editor.
+        /// This action handles errors before the logger is initialized.
+        /// </summary>
+        /// <param name="title">The title.</param>
+        /// <param name="error">The error.</param>
+        /// <param name="exit">Whether the client exits.</param>
+        public static void InitialDisplayErrorAction(string title, string error, bool exit)
         {
             Console.WriteLine(title);
             Console.WriteLine();
@@ -56,9 +63,16 @@ namespace DTAClient.Domain
 #endif
             if (exit)
                 Environment.Exit(1);
-        };
+        }
 
-        public static Action<string, string, bool> DefaultDisplayErrorAction = (title, error, exit) =>
+        /// <summary>
+        /// Show an error in Win32 MessageBox. For non-Windows platforms, this launches the log file in a GUI editor.
+        /// This action handles errors after the logger is available, but XNA windows are not initialized yet.
+        /// </summary>
+        /// <param name="title">The title.</param>
+        /// <param name="error">The error.</param>
+        /// <param name="exit">Whether the client exits.</param>
+        public static void DefaultDisplayErrorAction(string title, string error, bool exit)
         {
             Logger.Log(FormattableString.Invariant($"{(title is null ? null : title + Environment.NewLine + Environment.NewLine)}{error}"));
 #if WINFORMS
@@ -69,7 +83,7 @@ namespace DTAClient.Domain
 
             if (exit)
                 Environment.Exit(1);
-        };
+        }
 
         public static void Initialize()
         {

--- a/DXMainClient/Domain/MainClientConstants.cs
+++ b/DXMainClient/Domain/MainClientConstants.cs
@@ -61,7 +61,7 @@ namespace DTAClient.Domain
                 ProcessLauncher.StartShellProcess(ProgramConstants.LogFileName);
             else
             {
-                string tempfile = SafePath.CombineFilePath(Path.GetTempPath(), "xna-cncnet-client-error.txt");
+                string tempfile = SafePath.CombineFilePath(Path.GetTempPath(), "xna-cncnet-client-error.log");
                 using (StreamWriter writer = new StreamWriter(tempfile))
                 {
                     writer.WriteLine(title);

--- a/DXMainClient/Domain/MainClientConstants.cs
+++ b/DXMainClient/Domain/MainClientConstants.cs
@@ -53,7 +53,9 @@ namespace DTAClient.Domain
             Console.WriteLine();
             Console.WriteLine(error);
 
-            Logger.Log(FormattableString.Invariant($"{(title is null ? null : title + Environment.NewLine + Environment.NewLine)}{error}"));
+            if (LoggerInitialized)
+                Logger.Log(FormattableString.Invariant($"{(title is null ? null : title + Environment.NewLine + Environment.NewLine)}{error}"));
+
 #if WINFORMS
             MessageBox.Show(error, title, MessageBoxButtons.OK, MessageBoxIcon.Error);
 #else

--- a/DXMainClient/PreStartup.cs
+++ b/DXMainClient/PreStartup.cs
@@ -268,11 +268,11 @@ namespace DTAClient
                 return;
 
             string error = string.Format(("You seem to be running {0} from a write-protected directory.\n\n" +
-                "For {1} to function properly when run from a write-protected directory, it needs administrative priveleges.\n\n"+
-                "Please also make sure that your security software isn't blocking {0}.").L10N("Client:Main:AdminRequiredText1"),
+                "For {1} to function properly when run from a write-protected directory, it needs administrative priveleges.\n\n" +
+                "Please also make sure that your security software isn't blocking {0}.").L10N("Client:Main:AdminRequiredExplanation"),
                 MainClientConstants.GAME_NAME_LONG, MainClientConstants.GAME_NAME_SHORT);
 
-            string question = string.Format("Would you like to restart the client with administrative rights?".L10N("Client:Main:AdminRequiredText2"), MainClientConstants.GAME_NAME_SHORT);
+            string question = "Would you like to restart the client with administrative rights?".L10N("Client:Main:AdminRequiredRestartPrompt");
 
             string title = "Administrative privileges required".L10N("Client:Main:AdminRequiredTitle");
 

--- a/DXMainClient/PreStartup.cs
+++ b/DXMainClient/PreStartup.cs
@@ -82,6 +82,7 @@ namespace DTAClient
 
             Logger.Initialize(clientUserFilesDirectory.FullName, clientLogFile.Name);
             Logger.WriteLogFile = true;
+            MainClientConstants.LoggerInitialized = true;
 
             if (!clientUserFilesDirectory.Exists)
                 clientUserFilesDirectory.Create();

--- a/DXMainClient/PreStartup.cs
+++ b/DXMainClient/PreStartup.cs
@@ -267,11 +267,11 @@ namespace DTAClient
                 return;
 
             string error = string.Format(("You seem to be running {0} from a write-protected directory.\n\n" +
-                "For {1} to function properly when run from a write-protected directory, it needs administrative priveleges.").L10N("Client:Main:AdminRequiredText1"),
+                "For {1} to function properly when run from a write-protected directory, it needs administrative priveleges.\n\n"+
+                "Please also make sure that your security software isn't blocking {0}.").L10N("Client:Main:AdminRequiredText1"),
                 MainClientConstants.GAME_NAME_LONG, MainClientConstants.GAME_NAME_SHORT);
 
-            string question = string.Format(("Would you like to restart the client with administrative rights?\n\n" +
-                "Please also make sure that your security software isn't blocking {0}.").L10N("Client:Main:AdminRequiredText2"), MainClientConstants.GAME_NAME_SHORT);
+            string question = string.Format("Would you like to restart the client with administrative rights?".L10N("Client:Main:AdminRequiredText2"), MainClientConstants.GAME_NAME_SHORT);
 
             string title = "Administrative privileges required".L10N("Client:Main:AdminRequiredTitle");
 

--- a/DXMainClient/PreStartup.cs
+++ b/DXMainClient/PreStartup.cs
@@ -269,7 +269,7 @@ namespace DTAClient
 
             string error = string.Format(("You seem to be running {0} from a write-protected directory.\n\n" +
                 "For {1} to function properly when run from a write-protected directory, it needs administrative priveleges.\n\n" +
-                "Please also make sure that your security software isn't blocking {0}.").L10N("Client:Main:AdminRequiredExplanation"),
+                "Please also make sure that your security software isn't blocking {1}.").L10N("Client:Main:AdminRequiredExplanation"),
                 MainClientConstants.GAME_NAME_LONG, MainClientConstants.GAME_NAME_SHORT);
 
             string question = "Would you like to restart the client with administrative rights?".L10N("Client:Main:AdminRequiredRestartPrompt");

--- a/DXMainClient/PreStartup.cs
+++ b/DXMainClient/PreStartup.cs
@@ -64,12 +64,12 @@ namespace DTAClient
 
             Environment.CurrentDirectory = gameDirectory.FullName;
 
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                CheckPermissions();
+
             DirectoryInfo clientUserFilesDirectory = SafePath.GetDirectory(ProgramConstants.ClientUserFilesPath);
             FileInfo clientLogFile = SafePath.GetFile(clientUserFilesDirectory.FullName, "client.log");
             ProgramConstants.LogFileName = clientLogFile.FullName;
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                CheckPermissions();
 
             if (clientLogFile.Exists)
             {
@@ -189,19 +189,8 @@ namespace DTAClient
                     "applications that could be using the file, and then start the client again." + "\n\n" +
                     "Message:").L10N("Client:Main:DeleteWsock32Failed") + " " + ex.Message;
 
-                ProgramConstants.DisplayErrorAction(null, error, true);
+                MainClientConstants.DisplayErrorAction(null, error, true);
             }
-
-#if WINFORMS
-#if NET6_0_OR_GREATER
-            // .NET 6.0 brings a source generator ApplicationConfiguration which is not available in previous .NET versions
-            // https://medium.com/c-sharp-progarmming/whats-new-in-windows-forms-in-net-6-0-840c71856751
-            ApplicationConfiguration.Initialize();
-#else
-            global::System.Windows.Forms.Application.EnableVisualStyles();
-            global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(false);
-#endif
-#endif
 
             Startup startup = new();
 #if DEBUG
@@ -213,9 +202,9 @@ namespace DTAClient
             }
             catch (Exception ex)
             {
-                // ProgramConstants.DisplayErrorAction might have been overriden by XNA messagebox, which might be unable to display an error message.
+                // MainClientConstants.DisplayErrorAction might have been overriden by XNA messagebox, which might be unable to display an error message.
                 // Fallback to MessageBox.
-                ProgramConstants.DisplayErrorAction = ProgramConstants.DefaultDisplayErrorAction;
+                MainClientConstants.DisplayErrorAction = MainClientConstants.DefaultDisplayErrorAction;
                 HandleException(startup, ex);
             }
 #endif
@@ -268,7 +257,7 @@ namespace DTAClient
                 MainClientConstants.GAME_NAME_SHORT,
                 MainClientConstants.SUPPORT_URL_SHORT);
 
-            ProgramConstants.DisplayErrorAction("KABOOOOOOOM".L10N("Client:Main:FatalErrorTitle"), error, true);
+            MainClientConstants.DisplayErrorAction("KABOOOOOOOM".L10N("Client:Main:FatalErrorTitle"), error, true);
         }
 
         [SupportedOSPlatform("windows")]
@@ -278,19 +267,28 @@ namespace DTAClient
                 return;
 
             string error = string.Format(("You seem to be running {0} from a write-protected directory.\n\n" +
-                "For {1} to function properly when run from a write-protected directory, it needs administrative priveleges.\n\n" +
-                "Would you like to restart the client with administrative rights?\n\n" +
-                "Please also make sure that your security software isn't blocking {1}.").L10N("Client:Main:AdminRequiredText"), MainClientConstants.GAME_NAME_LONG, MainClientConstants.GAME_NAME_SHORT);
+                "For {1} to function properly when run from a write-protected directory, it needs administrative priveleges.").L10N("Client:Main:AdminRequiredText1"),
+                MainClientConstants.GAME_NAME_LONG, MainClientConstants.GAME_NAME_SHORT);
 
-            ProgramConstants.DisplayErrorAction("Administrative privileges required".L10N("Client:Main:AdminRequiredTitle"), error, false);
+            string question = string.Format(("Would you like to restart the client with administrative rights?\n\n" +
+                "Please also make sure that your security software isn't blocking {0}.").L10N("Client:Main:AdminRequiredText2"), MainClientConstants.GAME_NAME_SHORT);
 
-            using var _ = Process.Start(new ProcessStartInfo
+            string title = "Administrative privileges required".L10N("Client:Main:AdminRequiredTitle");
+
+#if WINFORMS && NETFRAMEWORK
+            DialogResult result = MessageBox.Show(error + "\n\n" + question, title, MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question, MessageBoxDefaultButton.Button2);
+            if (result == DialogResult.Yes)
             {
-                FileName = "dotnet",
-                Arguments = SafePath.CombineFilePath(ProgramConstants.StartupExecutable),
-                Verb = "runas",
-                CreateNoWindow = true
-            });
+                using var _ = Process.Start(new ProcessStartInfo
+                {
+                    FileName = SafePath.CombineFilePath(ProgramConstants.StartupExecutable),
+                    Verb = "runas",
+                    UseShellExecute = true,
+                });
+            }
+#else
+            MainClientConstants.DisplayErrorAction(title, error, true);
+#endif
             Environment.Exit(1);
         }
 

--- a/DXMainClient/Program.cs
+++ b/DXMainClient/Program.cs
@@ -57,6 +57,19 @@ namespace DTAClient
         private static string COMMON_LIBRARY_PATH;
         private static string SPECIFIC_LIBRARY_PATH;
 
+        static void InitializeApplicationConfiguration() {
+#if WINFORMS
+#if NET6_0_OR_GREATER
+            // .NET 6.0 brings a source generator ApplicationConfiguration which is not available in previous .NET versions
+            // https://medium.com/c-sharp-progarmming/whats-new-in-windows-forms-in-net-6-0-840c71856751
+            ApplicationConfiguration.Initialize();
+#else
+            System.Windows.Forms.Application.EnableVisualStyles();
+            System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(false);
+#endif
+#endif
+        }
+
         /// <summary>
         /// The main entry point for the application.
         /// </summary>
@@ -65,6 +78,8 @@ namespace DTAClient
 #endif
         static void Main(string[] args)
         {
+            InitializeApplicationConfiguration();
+
             bool noAudio = false;
             bool multipleInstanceMode = false;
             List<string> unknownStartupParams = new List<string>();


### PR DESCRIPTION
Fixes https://github.com/CnCNet/xna-cncnet-client/issues/458 in .NET 4.8.

This PR also moves DisplayErrorAction from ClientCore to DXMainClient because this is an GUI stuff.

For .NET 8.0:

- In Windows, there's always a black console window running dotnet.exe. This is because the window can not be hidden if ShellExecute is used, while ShellExecute is an requirement of verb runas. So in .NET 8.0 there will be no automatic evaluation because a black console window is more annoying. Users should run the launcher as admin instead.
- In non-Windows, since when this error happens, the client has no privilege to write text files on game folder (the logger cannot be initialized then), a text file xna-cncnet-client-error.txt is created in temp, in order to show error dialog.

Thus, .NET 8.0 clients are not recommended for regular Windows users