### PR TITLE
Enable arguments passing for XNALinkButton URL

### DIFF
--- a/ClientCore/ProcessLauncher.cs
+++ b/ClientCore/ProcessLauncher.cs
@@ -4,11 +4,12 @@ namespace ClientCore
 {
     public static class ProcessLauncher
     {
-        public static void StartShellProcess(string commandLine)
+        public static void StartShellProcess(string commandLine, string arguments = null)
         {
             using var _ = Process.Start(new ProcessStartInfo
             {
                 FileName = commandLine,
+                Arguments = arguments,
                 UseShellExecute = true
             });
         }

--- a/ClientGUI/XNALinkButton.cs
+++ b/ClientGUI/XNALinkButton.cs
@@ -11,6 +11,7 @@ namespace ClientGUI
 
         public string URL { get; set; }
         public string UnixURL { get; set; }
+        public string Arguments { get; set; }
 
         protected override void ParseControlINIAttribute(IniFile iniFile, string key, string value)
         {
@@ -26,6 +27,12 @@ namespace ClientGUI
                 return;
             }
 
+            if (key == "Arguments")
+            {
+                Arguments = value;
+                return;
+            }
+
             base.ParseControlINIAttribute(iniFile, key, value);
         }
 
@@ -34,9 +41,9 @@ namespace ClientGUI
             OSVersion osVersion = ClientConfiguration.Instance.GetOperatingSystemVersion();
 
             if (osVersion == OSVersion.UNIX && !string.IsNullOrEmpty(UnixURL))
-                ProcessLauncher.StartShellProcess(UnixURL);
+                ProcessLauncher.StartShellProcess(UnixURL, Arguments);
             else if (!string.IsNullOrEmpty(URL))
-                ProcessLauncher.StartShellProcess(URL);
+                ProcessLauncher.StartShellProcess(URL, Arguments);
 
             base.OnLeftClick();
         }


### PR DESCRIPTION
Hello~

I think it will be great to enable the arguments configuration for the `ini` file. Then we can pass arguments like `-speedcontrol` to the executable when we click the `Campaign` button at here https://github.com/CnCNet/cncnet-yr-client-package/blob/develop/package/Resources/Allied%20Theme/ExtrasWindow.ini#L18 

Looking forward to any suggestions.