### PR TITLE
Make CampaignID default to -1, with an optional override

### DIFF
--- a/DXMainClient/DXGUI/Generic/CampaignSelector.cs
+++ b/DXMainClient/DXGUI/Generic/CampaignSelector.cs
@@ -283,12 +283,12 @@ namespace DTAClient.DXGUI.Generic
                 if (UserINISettings.Instance.GameSpeed == 0)
                     UserINISettings.Instance.GameSpeed.Value = 1;
 
-                spawnStreamWriter.WriteLine("CampaignID=" + mission.Index);
+                spawnStreamWriter.WriteLine("CampaignID=" + mission.CampaignID);
                 spawnStreamWriter.WriteLine("GameSpeed=" + UserINISettings.Instance.GameSpeed);
 #if YR || ARES
                 spawnStreamWriter.WriteLine("Ra2Mode=" + !mission.RequiredAddon);
 #else
-            spawnStreamWriter.WriteLine("Firestorm=" + mission.RequiredAddon);
+                spawnStreamWriter.WriteLine("Firestorm=" + mission.RequiredAddon);
 #endif
                 spawnStreamWriter.WriteLine("CustomLoadScreen=" + LoadingScreenController.GetLoadScreenName(mission.Side.ToString()));
                 spawnStreamWriter.WriteLine("IsSinglePlayer=Yes");

--- a/DXMainClient/Domain/Mission.cs
+++ b/DXMainClient/Domain/Mission.cs
@@ -40,6 +40,7 @@ namespace DTAClient.Domain
 
         public int Index { get; }
         public int CD { get; }
+        public int CampaignID { get; } = -1;
         public int Side { get; }
         public string Scenario { get; }
         public string GUIName { get; }


### PR DESCRIPTION
Different parsing of duplicate entries in Battle.ini between the client and the game (Tiberian Sun) has led to the game crashing as the game sees duplicate entries as one entry, while the client sees them as separate entries. Separate entries are often used by modders to add separators to the mission list.

The game is not known to really use the campaign ID for much (only the "do you need GDI/Nod/Firestorm CD" check is known), so setting it to `-1` by default should do little harm. In case it does, there is now the possibility to manually override the campaign ID.

`-1` is interpreted by the game as `CAMPAIGN_NONE`, which allows playing with any CD.

This would also affect the game's "final campaign movie" logic (`FinalMovie=` in `Battle.ini`), but as far as I know, no distribution of TS, vanilla or modded, makes use of that logic.