### PR TITLE
Allow disabling specific sides for human or AI players only

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -501,6 +501,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 CopyPlayerDataToUI();
                 UpdateDiscordPresence();
                 ClearReadyStatuses();
+                CheckDisallowedSides();
             }
         }
 
@@ -551,6 +552,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             {
                 Players[0].Ready = true;
                 CopyPlayerDataToUI();
+
+                CheckDisallowedSides();
             }
 
             if (Players.Count >= playerLimit)
@@ -960,6 +963,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                     Players.Add(pInfo);
                     i += HUMAN_PLAYER_OPTIONS_LENGTH;
                 }
+
+                CheckDisallowedSides();
             }
 
             CopyPlayerDataToUI();

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -501,7 +501,6 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 CopyPlayerDataToUI();
                 UpdateDiscordPresence();
                 ClearReadyStatuses();
-                CheckDisallowedSides();
             }
         }
 
@@ -552,8 +551,6 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             {
                 Players[0].Ready = true;
                 CopyPlayerDataToUI();
-
-                CheckDisallowedSides();
             }
 
             if (Players.Count >= playerLimit)
@@ -963,8 +960,6 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                     Players.Add(pInfo);
                     i += HUMAN_PLAYER_OPTIONS_LENGTH;
                 }
-
-                CheckDisallowedSides();
             }
 
             CopyPlayerDataToUI();

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -1068,11 +1068,12 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
         /// <summary>
         /// Applies disallowed side indexes to the side option drop-downs
-        /// and player options.
+        /// and player options for human or computer players.
         /// </summary>
-        protected void CheckDisallowedSides()
+        protected void CheckDisallowedSidesForGroup(bool forHumanPlayers)
         {
-            var disallowedSideArray = GetDisallowedSides();
+            var disallowedSideArray = GetDisallowedSidesForGroup(forHumanPlayers);
+            var players = forHumanPlayers ? Players : AIPlayers;
             int defaultSide = 0;
             int allowedSideCount = disallowedSideArray.Count(b => b == false);
 
@@ -1086,28 +1087,25 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                         defaultSide = i + RandomSelectorCount;
                 }
 
-                foreach (XNADropDown dd in ddPlayerSides)
+                foreach (var pInfo in players)
                 {
-                    //dd.Items[0].Selectable = false;
+                    var dd = ddPlayerSides[pInfo.Index];
                     for (int i = 0; i < RandomSelectorCount; i++)
                         dd.Items[i].Selectable = false;
                 }
             }
             else
             {
-                foreach (XNADropDown dd in ddPlayerSides)
+                foreach (var pInfo in players)
                 {
-                    //dd.Items[0].Selectable = true;
+                    var dd = ddPlayerSides[pInfo.Index];
                     for (int i = 0; i < RandomSelectorCount; i++)
                         dd.Items[i].Selectable = true;
                 }
             }
 
-            var concatPlayerList = Players.Concat(AIPlayers);
-
             // Disable custom random groups if all or all except one of included sides are unavailable.
             int c = 0;
-            var playerInfos = concatPlayerList.ToList();
             foreach (int[] randomSides in RandomSelectors)
             {
                 int disableCount = 0;
@@ -1120,11 +1118,11 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
                 bool disabled = disableCount >= randomSides.Length - 1;
 
-                foreach (XNADropDown dd in ddPlayerSides)
+                foreach (var pInfo in players)
+                {
+                    var dd = ddPlayerSides[pInfo.Index];
                     dd.Items[1 + c].Selectable = !disabled;
 
-                foreach (PlayerInfo pInfo in playerInfos)
-                {
                     if (pInfo.SideId == 1 + c && disabled)
                         pInfo.SideId = defaultSide;
                 }
@@ -1140,28 +1138,31 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
                 if (disabled)
                 {
-                    foreach (XNADropDown dd in ddPlayerSides)
-                        dd.Items[i + RandomSelectorCount].Selectable = false;
-
                     // Change the sides of players that use the disabled
                     // side to the default side
-                    foreach (PlayerInfo pInfo in playerInfos)
+                    foreach (var pInfo in players)
                     {
+                        var dd = ddPlayerSides[pInfo.Index];
+                        dd.Items[i + RandomSelectorCount].Selectable = false;
+
                         if (pInfo.SideId == i + RandomSelectorCount)
                             pInfo.SideId = defaultSide;
                     }
                 }
                 else
                 {
-                    foreach (XNADropDown dd in ddPlayerSides)
+                    foreach (var pInfo in players)
+                    {
+                        var dd = ddPlayerSides[pInfo.Index];
                         dd.Items[i + RandomSelectorCount].Selectable = true;
+                    }
                 }
             }
 
             // If only 1 side is allowed, change all players' sides to that
             if (allowedSideCount == 1)
             {
-                foreach (PlayerInfo pInfo in playerInfos)
+                foreach (PlayerInfo pInfo in players)
                 {
                     if (pInfo.SideId == 0)
                         pInfo.SideId = defaultSide;
@@ -1172,26 +1173,55 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             {
                 // Disallow spectator
 
-                foreach (PlayerInfo pInfo in playerInfos)
+                foreach (PlayerInfo pInfo in players)
                 {
                     if (pInfo.SideId == GetSpectatorSideIndex())
                         pInfo.SideId = defaultSide;
                 }
 
-                foreach (XNADropDown dd in ddPlayerSides)
+                foreach (var pInfo in players)
                 {
+                    var dd = ddPlayerSides[pInfo.Index];
                     if (dd.Items.Count > GetSpectatorSideIndex())
                         dd.Items[SideCount + RandomSelectorCount].Selectable = false;
                 }
             }
             else
             {
-                foreach (XNADropDown dd in ddPlayerSides)
+                foreach (var pInfo in players)
                 {
+                    var dd = ddPlayerSides[pInfo.Index];
                     if (dd.Items.Count > SideCount + RandomSelectorCount)
                         dd.Items[SideCount + RandomSelectorCount].Selectable = true;
                 }
             }
+        }
+
+        /// <summary>
+        /// Applies disallowed side indexes to the side option drop-downs
+        /// and player options.
+        /// </summary>
+        protected void CheckDisallowedSides()
+        {
+            CheckDisallowedSidesForGroup(forHumanPlayers:false);
+            CheckDisallowedSidesForGroup(forHumanPlayers:true);
+        }
+
+        /// <summary>
+        /// Gets a list of side indexes that are disallowed for human or computer players.
+        /// </summary>
+        /// <returns>A list of disallowed side indexes.</returns>
+        protected bool[] GetDisallowedSidesForGroup(bool forHumanPlayers)
+        {
+            var returnValue = GetDisallowedSides();
+            var sides = forHumanPlayers ? GameMode?.DisallowedHumanPlayerSides : GameMode?.DisallowedComputerPlayerSides;
+            if (sides != null)
+            {
+                foreach (int i in sides)
+                    returnValue[i] = true;
+            }
+
+            return returnValue;
         }
 
         /// <summary>
@@ -1292,13 +1322,20 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             {
                 PlayerInfo pInfo;
                 PlayerHouseInfo pHouseInfo = houseInfos[i];
+                bool[] disallowedSides;
 
                 if (i < Players.Count)
+                {
                     pInfo = Players[i];
+                    disallowedSides = GetDisallowedSidesForGroup(forHumanPlayers:true);
+                }
                 else
+                {
                     pInfo = AIPlayers[i - Players.Count];
+                    disallowedSides = GetDisallowedSidesForGroup(forHumanPlayers:false);
+                }
 
-                pHouseInfo.RandomizeSide(pInfo, SideCount, random, GetDisallowedSides(), RandomSelectors, RandomSelectorCount);
+                pHouseInfo.RandomizeSide(pInfo, SideCount, random, disallowedSides, RandomSelectors, RandomSelectorCount);
 
                 pHouseInfo.RandomizeColor(pInfo, freeColors, MPColors, random);
                 pHouseInfo.RandomizeStart(pInfo, random, freeStartingLocations, takenStartingLocations, teamStartMappings.Any());

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -1949,8 +1949,6 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             CopyPlayerDataToUI();
             btnLaunchGame.SetRank(GetRank());
 
-            CheckDisallowedSides();
-
             if (oldSideId != Players.Find(p => p.Name == ProgramConstants.PLAYERNAME)?.SideId)
                 UpdateDiscordPresence();
         }
@@ -2097,6 +2095,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             MapPreviewBox.UpdateStartingLocationTexts();
             UpdateMapPreviewBoxEnabledStatus();
 
+            CheckDisallowedSides();
+
             PlayerUpdatingInProgress = false;
         }
 
@@ -2235,8 +2235,6 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 if (!Map.IsCoop && (Map.ForceNoTeams || GameMode.ForceNoTeams))
                     pInfo.TeamId = 0;
             }
-
-            CheckDisallowedSides();
 
 
             if (Map.CoopInfo != null)

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -1949,6 +1949,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             CopyPlayerDataToUI();
             btnLaunchGame.SetRank(GetRank());
 
+            CheckDisallowedSides();
+
             if (oldSideId != Players.Find(p => p.Name == ProgramConstants.PLAYERNAME)?.SideId)
                 UpdateDiscordPresence();
         }

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -1073,7 +1073,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         protected void CheckDisallowedSidesForGroup(bool forHumanPlayers)
         {
             var disallowedSideArray = GetDisallowedSidesForGroup(forHumanPlayers);
-            var players = forHumanPlayers ? Players : AIPlayers;
+            var playerInfos = forHumanPlayers ? Players : AIPlayers;
             int defaultSide = 0;
             int allowedSideCount = disallowedSideArray.Count(b => b == false);
 
@@ -1087,7 +1087,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                         defaultSide = i + RandomSelectorCount;
                 }
 
-                foreach (var pInfo in players)
+                foreach (PlayerInfo pInfo in playerInfos)
                 {
                     var dd = ddPlayerSides[pInfo.Index];
                     for (int i = 0; i < RandomSelectorCount; i++)
@@ -1096,7 +1096,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             }
             else
             {
-                foreach (var pInfo in players)
+                foreach (PlayerInfo pInfo in playerInfos)
                 {
                     var dd = ddPlayerSides[pInfo.Index];
                     for (int i = 0; i < RandomSelectorCount; i++)
@@ -1118,7 +1118,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
                 bool disabled = disableCount >= randomSides.Length - 1;
 
-                foreach (var pInfo in players)
+                foreach (PlayerInfo pInfo in playerInfos)
                 {
                     var dd = ddPlayerSides[pInfo.Index];
                     dd.Items[1 + c].Selectable = !disabled;
@@ -1140,7 +1140,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 {
                     // Change the sides of players that use the disabled
                     // side to the default side
-                    foreach (var pInfo in players)
+                    foreach (PlayerInfo pInfo in playerInfos)
                     {
                         var dd = ddPlayerSides[pInfo.Index];
                         dd.Items[i + RandomSelectorCount].Selectable = false;
@@ -1151,7 +1151,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 }
                 else
                 {
-                    foreach (var pInfo in players)
+                    foreach (PlayerInfo pInfo in playerInfos)
                     {
                         var dd = ddPlayerSides[pInfo.Index];
                         dd.Items[i + RandomSelectorCount].Selectable = true;
@@ -1162,7 +1162,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             // If only 1 side is allowed, change all players' sides to that
             if (allowedSideCount == 1)
             {
-                foreach (PlayerInfo pInfo in players)
+                foreach (PlayerInfo pInfo in playerInfos)
                 {
                     if (pInfo.SideId == 0)
                         pInfo.SideId = defaultSide;
@@ -1173,13 +1173,13 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             {
                 // Disallow spectator
 
-                foreach (PlayerInfo pInfo in players)
+                foreach (PlayerInfo pInfo in playerInfos)
                 {
                     if (pInfo.SideId == GetSpectatorSideIndex())
                         pInfo.SideId = defaultSide;
                 }
 
-                foreach (var pInfo in players)
+                foreach (PlayerInfo pInfo in playerInfos)
                 {
                     var dd = ddPlayerSides[pInfo.Index];
                     if (dd.Items.Count > GetSpectatorSideIndex())
@@ -1188,7 +1188,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             }
             else
             {
-                foreach (var pInfo in players)
+                foreach (PlayerInfo pInfo in playerInfos)
                 {
                     var dd = ddPlayerSides[pInfo.Index];
                     if (dd.Items.Count > SideCount + RandomSelectorCount)

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
@@ -836,6 +836,11 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             if (color < 0 || color > MPColors.Count)
                 return;
 
+            var disallowedSides = GetDisallowedSides();
+
+            if (side > 0 && side <= SideCount && disallowedSides[side - 1])
+                return;
+
             if (Map.CoopInfo != null)
             {
                 if (Map.CoopInfo.DisallowedPlayerSides.Contains(side - 1) || side == SideCount + RandomSelectorCount)
@@ -943,6 +948,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 pInfo.Ready = readyStatus > 0;
                 pInfo.AutoReady = readyStatus > 1;
                 pInfo.IPAddress = ipAddress;
+
+                CheckDisallowedSides();
             }
 
             CopyPlayerDataToUI();

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
@@ -948,11 +948,10 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 pInfo.Ready = readyStatus > 0;
                 pInfo.AutoReady = readyStatus > 1;
                 pInfo.IPAddress = ipAddress;
-
-                CheckDisallowedSides();
             }
 
             CopyPlayerDataToUI();
+
             localPlayer = FindLocalPlayer();
             if (localPlayer != null && oldSideId != localPlayer.SideId)
                 UpdateDiscordPresence();

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/SkirmishLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/SkirmishLobby.cs
@@ -52,8 +52,6 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             LoadSettings();
 
-            CheckDisallowedSides();
-
             CopyPlayerDataToUI();
 
             ProgramConstants.PlayerNameChanged += ProgramConstants_PlayerNameChanged;

--- a/DXMainClient/Domain/Multiplayer/GameMode.cs
+++ b/DXMainClient/Domain/Multiplayer/GameMode.cs
@@ -112,15 +112,15 @@ namespace DTAClient.Domain.Multiplayer
                 DisallowedPlayerSides.Add(int.Parse(sideIndex));
 
             disallowedSides = forcedOptionsIni
-            .GetStringValue(Name, "DisallowedHumanPlayerSides", string.Empty)
-            .Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                .GetStringValue(Name, "DisallowedHumanPlayerSides", string.Empty)
+                .Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
 
             foreach (string sideIndex in disallowedSides)
                 DisallowedHumanPlayerSides.Add(int.Parse(sideIndex));
 
             disallowedSides = forcedOptionsIni
-            .GetStringValue(Name, "DisallowedComputerPlayerSides", string.Empty)
-            .Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                .GetStringValue(Name, "DisallowedComputerPlayerSides", string.Empty)
+                .Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
 
             foreach (string sideIndex in disallowedSides)
                 DisallowedComputerPlayerSides.Add(int.Parse(sideIndex));

--- a/DXMainClient/Domain/Multiplayer/GameMode.cs
+++ b/DXMainClient/Domain/Multiplayer/GameMode.cs
@@ -60,6 +60,17 @@ namespace DTAClient.Domain.Multiplayer
         /// </summary>
         public List<int> DisallowedPlayerSides = new List<int>();
 
+        /// <summary>
+        /// List of side indices human players cannot select in this game mode.
+        /// </summary>
+        public List<int> DisallowedHumanPlayerSides = new List<int>();
+
+        /// <summary>
+        /// List of side indices computer players cannot select in this game mode.
+        /// </summary>
+        public List<int> DisallowedComputerPlayerSides = new List<int>();
+
+
         /// </summary>
         /// Override for minimum amount of players needed to play any map in this game mode.
         /// </summary>
@@ -99,6 +110,20 @@ namespace DTAClient.Domain.Multiplayer
 
             foreach (string sideIndex in disallowedSides)
                 DisallowedPlayerSides.Add(int.Parse(sideIndex));
+
+            disallowedSides = forcedOptionsIni
+            .GetStringValue(Name, "DisallowedHumanPlayerSides", string.Empty)
+            .Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+
+            foreach (string sideIndex in disallowedSides)
+                DisallowedHumanPlayerSides.Add(int.Parse(sideIndex));
+
+            disallowedSides = forcedOptionsIni
+            .GetStringValue(Name, "DisallowedComputerPlayerSides", string.Empty)
+            .Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+
+            foreach (string sideIndex in disallowedSides)
+                DisallowedComputerPlayerSides.Add(int.Parse(sideIndex));
 
             ParseForcedOptions(forcedOptionsIni);
 


### PR DESCRIPTION
Currently the only way to restrict side selection is via co-op map settings, game mode settings or game option checkboxes. This PR expands the way modders can restrict selection (only for game modes) for human players and computer players separately, using `DisallowedHumanPlayerSides` and `DisallowedComputerPlayerSides`.

Example usage in `INI/MPMaps.ini`:
```ini
[Standard]                          ; any game mode section
; (...)
DisallowedPlayerSides=7             ; already exists - disallow sides for all players
DisallowedHumanPlayerSides=1,2,3    ; new - disallow sides for human players only
DisallowedComputerPlayerSides=4,5,6 ; new - disallow sides for computer players only
```

![image](https://github.com/CnCNet/xna-cncnet-client/assets/23420063/b91d71a2-aa88-4272-8fad-269480b3c258)

![image](https://github.com/CnCNet/xna-cncnet-client/assets/23420063/ddd4d1e2-571d-4392-9646-0569e111bd22)
