### PR TITLE
Fix crash on null current chat channel

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
@@ -1325,7 +1325,10 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 }
             }
 
-            currentChatChannel = (Channel)ddCurrentChannel.SelectedItem.Tag;
+            currentChatChannel = (Channel)ddCurrentChannel.SelectedItem?.Tag;
+            if (currentChatChannel == null)
+                return;
+            
             currentChatChannel.UserAdded += RefreshPlayerList;
             currentChatChannel.UserLeft += RefreshPlayerList;
             currentChatChannel.UserQuitIRC += RefreshPlayerList;

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
@@ -468,7 +468,6 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             {
                 if (!game.Supported || string.IsNullOrEmpty(game.ChatChannel))
                 {
-                    i++;
                     continue;
                 }
 
@@ -1327,7 +1326,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
             currentChatChannel = (Channel)ddCurrentChannel.SelectedItem?.Tag;
             if (currentChatChannel == null)
-                return;
+                throw new Exception("Current selected chat channel is null. This should not happen.");
             
             currentChatChannel.UserAdded += RefreshPlayerList;
             currentChatChannel.UserLeft += RefreshPlayerList;


### PR DESCRIPTION
Crash reproduce steps:

Apply the latest client binaries in develop branch to [cncnet-client-mod-base](https://github.com/Starkku/cncnet-client-mod-base) (commit: 2c24f91299be519dd0f98e56b7d8f0509c7bff9c) and run the client. 

```
27.04. 08:06:18.404    KABOOOOOOM!!! Info:
27.04. 08:06:18.404    Type: System.NullReferenceException
27.04. 08:06:18.404    Message: Object reference not set to an instance of an object.
27.04. 08:06:18.419    Source: clientdx
27.04. 08:06:18.419    TargetSite.Name: DdCurrentChannel_SelectedIndexChanged
27.04. 08:06:18.419    Stacktrace:    at DTAClient.DXGUI.Multiplayer.CnCNet.CnCNetLobby.DdCurrentChannel_SelectedIndexChanged(Object sender, EventArgs e)
```

Issue reported by typhoon_4869_68340

This PR should fixes the issue