### PR TITLE
Allows passing arguments to gamemd.exe

### DIFF
--- a/ClientGUI/GameProcessLogic.cs
+++ b/ClientGUI/GameProcessLogic.cs
@@ -69,6 +69,9 @@ namespace ClientGUI
 
             string extraCommandLine = ClientConfiguration.Instance.ExtraExeCommandLineParameters;
 
+            if (Environment.CommandLine.Contains(" -- "))
+                extraCommandLine += Environment.CommandLine[(Environment.CommandLine.IndexOf("--") + 2)..];
+
             SafePath.DeleteFileIfExists(ProgramConstants.GamePath, "DTA.LOG");
             SafePath.DeleteFileIfExists(ProgramConstants.GamePath, "TI.LOG");
             SafePath.DeleteFileIfExists(ProgramConstants.GamePath, "TS.LOG");


### PR DESCRIPTION
Allows passing arguments to gamemd.exe using something like `clientdx.exe -- <options>`.

```powershell
clientdx.exe -MULTIPLEINSTANCE -- -SPAWN # Pass the -SPAWN argument to gamemd.exe
```

Close #471