### PR TITLE
Close player extra option panel when leaving the lobby

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -373,6 +373,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             }
 
             Disable();
+            PlayerExtraOptionsPanel?.Disable();
+
             connectionManager.ConnectionLost -= ConnectionManager_ConnectionLost;
             connectionManager.Disconnected -= ConnectionManager_Disconnected;
 

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
@@ -424,6 +424,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         {
             Clear();
             GameLeft?.Invoke(this, EventArgs.Empty);
+            PlayerExtraOptionsPanel?.Disable();
             Disable();
         }
 

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/SkirmishLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/SkirmishLobby.cs
@@ -181,10 +181,10 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
         protected override void BtnLeaveGame_LeftClick(object sender, EventArgs e)
         {
-            this.Enabled = false;
-            this.Visible = false;
-
             Exited?.Invoke(this, EventArgs.Empty);
+
+            PlayerExtraOptionsPanel?.Disable();
+            Disable();
 
             topBar.RemovePrimarySwitchable(this);
             ResetDiscordPresence();


### PR DESCRIPTION
Suppose a player turns on the extra option panel, leave the lobby, and then re-join a lobby, the extra option panel is still turned on, instead of the default panel that displays players with their factions, colors, and locations. 

This current behavior might be non-straightforward to players -- panel that belongs to the parent should also be closed when the parent is closed. It might be better to auto close the extra option panel when user leaves the lobby.