### PR TITLE
Add Chinese language code examples to translation documentation

### DIFF
--- a/Docs/Translation.md
+++ b/Docs/Translation.md
@@ -33,6 +33,10 @@ For example:
       * ...
     - uk
       * ...
+    - zh-Hans
+      * ...
+    - zh-Hant
+      * ...
   * someAsset.png
   * ...
 ```
@@ -42,7 +46,7 @@ For example:
 The translation folder name is used to match it to the system locale code (as defined by BCP-47), so it is advised to name the translation folders according to that (for example, see how [the locales Windows uses](https://learn.microsoft.com/ru-ru/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c) are coded). That allows the client to choose the appropriate translation based on the system locale and also automatically fetch the name of the translation.
 
 > **Note**
-> Unless you're aiming for making a translation for a specific country (e.g. `en-US` and `en-GB`), it's advised to use simply a [language code](http://www.loc.gov/standards/iso639-2/php/code_list.php) (for example, `ru`, `de`, `en` etc.)
+> Unless you're aiming for making a translation for a specific country (e.g. `en-US` and `en-GB`), it's advised to use simply a [language code](http://www.loc.gov/standards/iso639-2/php/code_list.php) (for example, `ru`, `de`, `en`, `zh-Hans`, `zh-Hant` etc.)
 
 The folder name doesn't explicitly need to match the existing locale code. However, in that case you would want to provide an explicit name in the translation INI, and the translation won't be automatically picked in any case.
 

--- a/Docs/Translation.md
+++ b/Docs/Translation.md
@@ -25,7 +25,7 @@ For example:
   - Translations
     - ru
       - Some Theme Folder
-	* Translation.ini
+        * Translation.ini
         * someThemeAsset.png
         * ...
       * Translation.ini


### PR DESCRIPTION
Unlike other languages codes, there are two country-irrelevant language codes for Chinese: `zh-Hans` (Simplified Chinese, used in the mainland of China, Singapore, and Malaysia) and `zh-Hant` (Traditional Chinese, used in Chinese Hong Kong, Macao, and Taiwan). Although these two are regarded as Chinese variants, majority of the characters are different. 

Translators tend to explicitly differ Simplified Chinese and Traditional Chinese. However, some translators use a wrong language code (e.g., `zh_cn`, where the underscore is unexpected), or a county-specific language code (e.g., `zh-cn`, ignoring Singapore users). This makes me feel it is necessary to add Chinese language code examples so they could just follow the best practice.

The following list demonstrates the language code preference for a user in mainland of China:
- zh-CN
- zh-CHS (deprecated)
- zh-Hans
- zh

Therefore, different from other languages, `zh-Hans` and `zh-Hant` both act like contry-irrelevant language codes, despite there is a hyphen in each code name. We'd better to explicitly demonstrate these two examples.