### PR TITLE
Ignore case when selecting default translation code

### DIFF
--- a/ClientCore/I18N/Translation.cs
+++ b/ClientCore/I18N/Translation.cs
@@ -191,7 +191,7 @@ public class Translation : ICloneable
     /// <returns>Locale code -> display name pairs.</returns>
     public static Dictionary<string, string> GetTranslations()
     {
-        var translations = new Dictionary<string, string>
+        var translations = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase)
         {
             // Add default localization so that we always have it in the list even if the localization does not exist
             [ProgramConstants.HARDCODED_LOCALE_CODE] = GetLanguageName(ProgramConstants.HARDCODED_LOCALE_CODE)
@@ -224,6 +224,7 @@ public class Translation : ICloneable
         {
             string translation = culture.Name;
 
+            // the keys in 'translations' are case-insensitive
             if (translations.ContainsKey(translation))
                 return translation;
         }

--- a/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
@@ -679,7 +679,7 @@ namespace DTAConfig.OptionPanels
                 ddi => (string)ddi.Tag == UserINISettings.Instance.ClientTheme);
             ddClientTheme.SelectedIndex = selectedThemeIndex > -1 ? selectedThemeIndex : 0;
 
-            foreach (string localeCode in [UserINISettings.Instance.Translation, Translation.GetDefaultTranslationLocaleCode(), ProgramConstants.HARDCODED_LOCALE_CODE])
+            foreach (string localeCode in new string[] { UserINISettings.Instance.Translation, Translation.GetDefaultTranslationLocaleCode(), ProgramConstants.HARDCODED_LOCALE_CODE })
             {
                 int selectedTranslationIndex = ddTranslation.Items.FindIndex(
                     ddi => localeCode.Equals((string)ddi.Tag, StringComparison.InvariantCultureIgnoreCase));

--- a/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
@@ -19,6 +19,7 @@ using System.Runtime.Versioning;
 #endif
 using System.IO;
 using ClientCore.I18N;
+using System.Diagnostics;
 
 namespace DTAConfig.OptionPanels
 {
@@ -693,19 +694,19 @@ namespace DTAConfig.OptionPanels
                 ddi => (string)ddi.Tag == UserINISettings.Instance.ClientTheme);
             ddClientTheme.SelectedIndex = selectedThemeIndex > -1 ? selectedThemeIndex : 0;
 
-            int selectedTranslationIndex = ddTranslation.Items.FindIndex(
-                ddi => (string)ddi.Tag == UserINISettings.Instance.Translation);
+            foreach (string localeCode in new string[] { UserINISettings.Instance.Translation, Translation.GetDefaultTranslationLocaleCode(), ProgramConstants.HARDCODED_LOCALE_CODE })
+            {
+                int selectedTranslationIndex = ddTranslation.Items.FindIndex(
+                    ddi => localeCode.Equals((string)ddi.Tag, StringComparison.InvariantCultureIgnoreCase));
 
-            if (selectedTranslationIndex > -1)
-            {
-                ddTranslation.SelectedIndex = selectedTranslationIndex;
+                if (selectedTranslationIndex > -1)
+                {
+                    ddTranslation.SelectedIndex = selectedTranslationIndex;
+                    break;
+                }
             }
-            else
-            {
-                string defaultTranslationCode = Translation.GetDefaultTranslationLocaleCode();
-                ddTranslation.SelectedIndex = ddTranslation.Items.FindIndex(
-                    ddi => (string)ddi.Tag == defaultTranslationCode);
-            }
+
+            Debug.Assert(ddTranslation.SelectedIndex > -1, "No translation was selected");
 
 #if TS
             chkBackBufferInVRAM.Checked = !UserINISettings.Instance.BackBufferInVRAM;
@@ -800,7 +801,7 @@ namespace DTAConfig.OptionPanels
 
             IniSettings.ClientTheme.Value = (string)ddClientTheme.SelectedItem.Tag;
 
-            restartRequired = restartRequired || IniSettings.Translation != (string)ddTranslation.SelectedItem.Tag;
+            restartRequired = restartRequired || !IniSettings.Translation.ToString().Equals((string)ddTranslation.SelectedItem.Tag, StringComparison.InvariantCultureIgnoreCase);
 
             IniSettings.Translation.Value = (string)ddTranslation.SelectedItem.Tag;
 

--- a/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
@@ -679,7 +679,7 @@ namespace DTAConfig.OptionPanels
                 ddi => (string)ddi.Tag == UserINISettings.Instance.ClientTheme);
             ddClientTheme.SelectedIndex = selectedThemeIndex > -1 ? selectedThemeIndex : 0;
 
-            foreach (string localeCode in new string[] { UserINISettings.Instance.Translation, Translation.GetDefaultTranslationLocaleCode(), ProgramConstants.HARDCODED_LOCALE_CODE })
+            foreach (string localeCode in [UserINISettings.Instance.Translation, Translation.GetDefaultTranslationLocaleCode(), ProgramConstants.HARDCODED_LOCALE_CODE])
             {
                 int selectedTranslationIndex = ddTranslation.Items.FindIndex(
                     ddi => localeCode.Equals((string)ddi.Tag, StringComparison.InvariantCultureIgnoreCase));


### PR DESCRIPTION
Although the constructor `new CultureInfo(string)` is [defined](https://learn.microsoft.com/en-us/dotnet/api/system.globalization.cultureinfo.-ctor?view=net-8.0#system-globalization-cultureinfo-ctor(system-string)) as case-insensitive, the client does not fully comply with this convention right now.

As a result, when translators created a folder named `zh-hans` (while the normalized name should be `zh-Hans`), the client will not be able to select this translation as the default.

This PR fixes this issue, allowing the folder name be case-insensitive.