### PR TITLE
Refactor ScreenResolution and enable HiDef profile

### DIFF
--- a/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
@@ -81,11 +81,9 @@ namespace DTAConfig.OptionPanels
                 lblIngameResolution.Right + 12,
                 lblIngameResolution.Y - 2, 120, 19);
 
-            var clientConfig = ClientConfiguration.Instance;
-
             // Add in-game resolutions
             {
-                var maximumIngameResolution = new ScreenResolution(clientConfig.MaximumIngameWidth, clientConfig.MaximumIngameHeight);
+                var maximumIngameResolution = new ScreenResolution(ClientConfiguration.Instance.MaximumIngameWidth, ClientConfiguration.Instance.MaximumIngameHeight);
 
 #if XNA
                 if (!ScreenResolution.HiDefLimitResolution.Fit(maximumIngameResolution))
@@ -93,7 +91,7 @@ namespace DTAConfig.OptionPanels
 #endif
 
                 SortedSet<ScreenResolution> resolutions = ScreenResolution.GetFullScreenResolutions(
-                    clientConfig.MinimumIngameWidth, clientConfig.MinimumIngameHeight,
+                    ClientConfiguration.Instance.MinimumIngameWidth, ClientConfiguration.Instance.MinimumIngameHeight,
                     maximumIngameResolution.Width, maximumIngameResolution.Height);
 
                 foreach (var res in resolutions)
@@ -187,7 +185,7 @@ namespace DTAConfig.OptionPanels
 
             // Add client resolutions
             {
-                List<ScreenResolution> recommendedResolutions = clientConfig.RecommendedResolutions.Select(resolution => (ScreenResolution)resolution).ToList();
+                List<ScreenResolution> recommendedResolutions = ClientConfiguration.Instance.RecommendedResolutions.Select(resolution => (ScreenResolution)resolution).ToList();
                 SortedSet<ScreenResolution> scaledRecommendedResolutions = [.. recommendedResolutions.SelectMany(resolution => resolution.GetIntegerScaledResolutions())];
 
                 SortedSet<ScreenResolution> resolutions = [
@@ -207,6 +205,7 @@ namespace DTAConfig.OptionPanels
 
                 // So we add the optimal resolutions to the list, sort it and then find
                 // out the optimal resolution index - it's inefficient, but works
+                // Note: ddClientResolution.PreferredItemIndexes is assumed in ascending order
 
                 foreach (ScreenResolution scaledRecommendedResolution in scaledRecommendedResolutions)
                 {
@@ -339,6 +338,13 @@ namespace DTAConfig.OptionPanels
             AddChild(ddDetailLevel);
             AddChild(lblIngameResolution);
             AddChild(ddIngameResolution);
+        }
+
+        public static ScreenResolution GetBestRecommendedResolution()
+        {
+            List<ScreenResolution> recommendedResolutions = ClientConfiguration.Instance.RecommendedResolutions.Select(resolution => (ScreenResolution)resolution).ToList();
+            SortedSet<ScreenResolution> scaledRecommendedResolutions = [.. recommendedResolutions.SelectMany(resolution => resolution.GetIntegerScaledResolutions())];
+            return scaledRecommendedResolutions.Max();
         }
 
         private void GetRenderers()
@@ -571,7 +577,8 @@ namespace DTAConfig.OptionPanels
 
                 if (ddClientResolution.PreferredItemIndexes.Count > 0)
                 {
-                    int optimalWindowedResIndex = ddClientResolution.PreferredItemIndexes[0];
+                    // Note: ddClientResolution.PreferredItemIndexes is assumed in ascending order
+                    int optimalWindowedResIndex = ddClientResolution.PreferredItemIndexes[^1];
                     ddClientResolution.SelectedIndex = optimalWindowedResIndex;
                 }
             }

--- a/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
@@ -197,7 +197,7 @@ namespace DTAConfig.OptionPanels
                 ];
                 List<ScreenResolution> resolutionList = resolutions.ToList();
 
-                foreach (var res in resolutionList)
+                foreach (ScreenResolution res in resolutionList)
                 {
                     var item = new XNADropDownItem();
                     item.Text = res.ToString();

--- a/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
@@ -559,8 +559,7 @@ namespace DTAConfig.OptionPanels
             {
                 ddClientResolution.AllowDropDown = false;
 #if WINFORMS
-                string nativeRes = Screen.PrimaryScreen.Bounds.Width +
-                    "x" + Screen.PrimaryScreen.Bounds.Height;
+                string nativeRes = ScreenResolution.SafeFullScreenResolution;
 
                 int nativeResIndex = ddClientResolution.Items.FindIndex(i => (string)i.Tag == nativeRes);
                 if (nativeResIndex > -1)

--- a/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
@@ -19,6 +19,7 @@ using System.Runtime.Versioning;
 #endif
 using System.IO;
 using ClientCore.I18N;
+using System.Linq;
 
 namespace DTAConfig.OptionPanels
 {
@@ -91,10 +92,9 @@ namespace DTAConfig.OptionPanels
                     maximumIngameResolution = ScreenResolution.HiDefLimitResolution;
 #endif
 
-                var resolutions = ScreenResolution.GetFullScreenResolutions(clientConfig.MinimumIngameWidth, clientConfig.MinimumIngameHeight,
+                SortedSet<ScreenResolution> resolutions = ScreenResolution.GetFullScreenResolutions(
+                    clientConfig.MinimumIngameWidth, clientConfig.MinimumIngameHeight,
                     maximumIngameResolution.Width, maximumIngameResolution.Height);
-
-                resolutions.Sort();
 
                 foreach (var res in resolutions)
                     ddIngameResolution.AddItem(res.ToString());
@@ -187,14 +187,11 @@ namespace DTAConfig.OptionPanels
 
             // Add client resolutions
             {
-                var screenResolutions = ScreenResolution.GetFullScreenResolutions(minWidth: 800, minHeight: 600);
-                // Add "optimal" client resolutions for windowed mode if they're not supported in fullscreen mode
-                var windowedResolutions = ScreenResolution.GetWindowedResolutions(minWidth: 800, minHeight: 600);
+                SortedSet<ScreenResolution> resolutions = [.. ScreenResolution.GetFullScreenResolutions(minWidth: 800, minHeight: 600),
+                    .. ScreenResolution.GetWindowedResolutions(minWidth: 800, minHeight: 600)];
+                List<ScreenResolution> resolutionList = resolutions.ToList();
 
-                List<ScreenResolution> resolutions = [.. screenResolutions, .. windowedResolutions];
-                resolutions.Sort();
-
-                foreach (var res in resolutions)
+                foreach (var res in resolutionList)
                 {
                     var item = new XNADropDownItem();
                     item.Text = res.ToString();
@@ -207,10 +204,9 @@ namespace DTAConfig.OptionPanels
 
                 string[] recommendedResolutions = clientConfig.RecommendedResolutions;
 
-                foreach (string resolution in recommendedResolutions)
+                foreach (string resolution in recommendedResolutions.Select(resolution => resolution.Trim()))
                 {
-                    string trimmedresolution = resolution.Trim();
-                    int index = resolutions.FindIndex(res => res.ToString() == trimmedresolution);
+                    int index = resolutionList.FindIndex(res => res.ToString() == resolution);
                     if (index > -1)
                         ddClientResolution.PreferredItemIndexes.Add(index);
                 }

--- a/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
@@ -739,15 +739,12 @@ namespace DTAConfig.OptionPanels
 
             IniSettings.DetailLevel.Value = ddDetailLevel.SelectedIndex;
 
-            string[] resolution = ddIngameResolution.SelectedItem.Text.Split('x');
+            ScreenResolution ingameRes = ddIngameResolution.SelectedItem.Text;
 
-            int[] ingameRes = new int[2] { int.Parse(resolution[0]), int.Parse(resolution[1]) };
-
-            IniSettings.IngameScreenWidth.Value = ingameRes[0];
-            IniSettings.IngameScreenHeight.Value = ingameRes[1];
+            (IniSettings.IngameScreenWidth.Value, IniSettings.IngameScreenHeight.Value) = ingameRes;
 
             // Calculate drag selection distance, scale it with resolution width
-            int dragDistance = ingameRes[0] / ORIGINAL_RESOLUTION_WIDTH * DRAG_DISTANCE_DEFAULT;
+            int dragDistance = ingameRes.Width / ORIGINAL_RESOLUTION_WIDTH * DRAG_DISTANCE_DEFAULT;
             IniSettings.DragDistance.Value = dragDistance;
 
             DirectDrawWrapper originalRenderer = selectedRenderer;
@@ -759,16 +756,13 @@ namespace DTAConfig.OptionPanels
             IniSettings.BorderlessWindowedMode.Value = chkBorderlessWindowedMode.Checked &&
                 string.IsNullOrEmpty(selectedRenderer.BorderlessWindowedModeKey);
 
-            string[] clientResolution = ((string)ddClientResolution.SelectedItem.Tag).Split('x');
+            ScreenResolution clientRes = (string)ddClientResolution.SelectedItem.Tag;
 
-            int[] clientRes = new int[2] { int.Parse(clientResolution[0]), int.Parse(clientResolution[1]) };
-
-            if (clientRes[0] != IniSettings.ClientResolutionX.Value ||
-                clientRes[1] != IniSettings.ClientResolutionY.Value)
+            if (clientRes.Width != IniSettings.ClientResolutionX.Value ||
+                clientRes.Height != IniSettings.ClientResolutionY.Value)
                 restartRequired = true;
 
-            IniSettings.ClientResolutionX.Value = clientRes[0];
-            IniSettings.ClientResolutionY.Value = clientRes[1];
+            (IniSettings.ClientResolutionX.Value, IniSettings.ClientResolutionY.Value) = clientRes;
 
             if (IniSettings.BorderlessWindowedClient.Value != chkBorderlessClient.Checked)
                 restartRequired = true;
@@ -854,9 +848,9 @@ namespace DTAConfig.OptionPanels
 
                 SafePath.DeleteFileIfExists(languageDllDestinationPath);
 
-                if (ingameRes[0] >= 1024 && ingameRes[1] >= 720)
+                if (ingameRes.Width >= 1024 && ingameRes.Height >= 720)
                     System.IO.File.Copy(SafePath.CombineFilePath(ProgramConstants.GamePath, "Resources", "language_1024x720.dll"), languageDllDestinationPath);
-                else if (ingameRes[0] >= 800 && ingameRes[1] >= 600)
+                else if (ingameRes.Width >= 800 && ingameRes.Height >= 600)
                     System.IO.File.Copy(SafePath.CombineFilePath(ProgramConstants.GamePath, "Resources", "language_800x600.dll"), languageDllDestinationPath);
                 else
                     System.IO.File.Copy(SafePath.CombineFilePath(ProgramConstants.GamePath, "Resources", "language_640x480.dll"), languageDllDestinationPath);

--- a/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
@@ -187,8 +187,14 @@ namespace DTAConfig.OptionPanels
 
             // Add client resolutions
             {
-                SortedSet<ScreenResolution> resolutions = [.. ScreenResolution.GetFullScreenResolutions(minWidth: 800, minHeight: 600),
-                    .. ScreenResolution.GetWindowedResolutions(minWidth: 800, minHeight: 600)];
+                List<ScreenResolution> recommendedResolutions = clientConfig.RecommendedResolutions.Select(resolution => (ScreenResolution)resolution).ToList();
+                List<ScreenResolution> scaledRecommendedResolutions = recommendedResolutions.SelectMany(resolution => resolution.GetIntegerScaledResolutions()).ToList();
+
+                SortedSet<ScreenResolution> resolutions = [
+                    ..ScreenResolution.GetFullScreenResolutions(minWidth: 800, minHeight: 600),
+                    ..ScreenResolution.GetWindowedResolutions(minWidth: 800, minHeight: 600),
+                    ..scaledRecommendedResolutions
+                ];
                 List<ScreenResolution> resolutionList = resolutions.ToList();
 
                 foreach (var res in resolutionList)
@@ -202,11 +208,9 @@ namespace DTAConfig.OptionPanels
                 // So we add the optimal resolutions to the list, sort it and then find
                 // out the optimal resolution index - it's inefficient, but works
 
-                string[] recommendedResolutions = clientConfig.RecommendedResolutions;
-
-                foreach (string resolution in recommendedResolutions.Select(resolution => resolution.Trim()))
+                foreach (ScreenResolution scaledRecommendedResolution in scaledRecommendedResolutions)
                 {
-                    int index = resolutionList.FindIndex(res => res.ToString() == resolution);
+                    int index = resolutionList.FindIndex(res => res == scaledRecommendedResolution);
                     if (index > -1)
                         ddClientResolution.PreferredItemIndexes.Add(index);
                 }

--- a/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
@@ -558,13 +558,12 @@ namespace DTAConfig.OptionPanels
             if (chkBorderlessClient.Checked)
             {
                 ddClientResolution.AllowDropDown = false;
-#if WINFORMS
+
                 string nativeRes = ScreenResolution.SafeFullScreenResolution;
 
                 int nativeResIndex = ddClientResolution.Items.FindIndex(i => (string)i.Tag == nativeRes);
                 if (nativeResIndex > -1)
                     ddClientResolution.SelectedIndex = nativeResIndex;
-#endif
             }
             else
             {

--- a/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
@@ -82,9 +82,21 @@ namespace DTAConfig.OptionPanels
 
             var clientConfig = ClientConfiguration.Instance;
 
+            int maximumIngameWidth = clientConfig.MaximumIngameWidth;
+            int maximumIngameHeight = clientConfig.MaximumIngameHeight;
+
+#if XNA
+            // We do not enable HiDef on XNA builds. Therefore, drop resolutions larger than 3840x3840.
+            // Refer to GameClass constructor for more details
+            if (maximumIngameWidth > 3840)
+                maximumIngameWidth = 3840;
+            if (maximumIngameHeight > 3840)
+                maximumIngameHeight = 3840;
+#endif
+
             var resolutions = GetResolutions(clientConfig.MinimumIngameWidth,
                 clientConfig.MinimumIngameHeight,
-                clientConfig.MaximumIngameWidth, clientConfig.MaximumIngameHeight);
+                maximumIngameWidth, maximumIngameHeight);
 
             resolutions.Sort();
 
@@ -176,10 +188,18 @@ namespace DTAConfig.OptionPanels
             ddClientResolution.AllowDropDown = false;
             ddClientResolution.PreferredItemLabel = "(recommended)".L10N("Client:DTAConfig:Recommended");
 
-            int width = GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width;
-            int height = GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height;
+            int desktopWidth = GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width;
+            int desktopHeight = GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height;
+#if XNA
+            // We do not enable HiDef on XNA builds. Therefore, drop resolutions larger than 3840x3840.
+            // Refer to GameClass constructor for more details
+            if (desktopWidth > 3840)
+                desktopWidth = 3840;
+            if (desktopHeight > 3840)
+                desktopHeight = 3840;
+#endif
 
-            resolutions = GetResolutions(800, 600, width, height);
+            resolutions = GetResolutions(800, 600, desktopWidth, desktopHeight);
 
             // Add "optimal" client resolutions for windowed mode
             // if they're not supported in fullscreen mode

--- a/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
@@ -188,12 +188,12 @@ namespace DTAConfig.OptionPanels
             // Add client resolutions
             {
                 List<ScreenResolution> recommendedResolutions = clientConfig.RecommendedResolutions.Select(resolution => (ScreenResolution)resolution).ToList();
-                List<ScreenResolution> scaledRecommendedResolutions = recommendedResolutions.SelectMany(resolution => resolution.GetIntegerScaledResolutions()).ToList();
+                SortedSet<ScreenResolution> scaledRecommendedResolutions = [.. recommendedResolutions.SelectMany(resolution => resolution.GetIntegerScaledResolutions())];
 
                 SortedSet<ScreenResolution> resolutions = [
-                    ..ScreenResolution.GetFullScreenResolutions(minWidth: 800, minHeight: 600),
-                    ..ScreenResolution.GetWindowedResolutions(minWidth: 800, minHeight: 600),
-                    ..scaledRecommendedResolutions
+                    .. ScreenResolution.GetFullScreenResolutions(minWidth: 800, minHeight: 600),
+                    .. ScreenResolution.GetWindowedResolutions(minWidth: 800, minHeight: 600),
+                    .. scaledRecommendedResolutions
                 ];
                 List<ScreenResolution> resolutionList = resolutions.ToList();
 

--- a/DTAConfig/ScreenResolution.cs
+++ b/DTAConfig/ScreenResolution.cs
@@ -77,15 +77,15 @@ namespace DTAConfig
         // The default graphic profile supports resolution up to 4096x4096. The number gets even smaller in practice. Therefore, we select 3840 as the limit.
         public static ScreenResolution HiDefLimitResolution { get; } = "3840x3840";
 
-        private static ScreenResolution _safeDesktopResolution = null;
+        private static ScreenResolution _safeMaximumResolution = null;
         public static ScreenResolution SafeMaximumResolution
         {
             get
             {
 #if XNA
-                return _safeDesktopResolution ??= HiDefLimitResolution.Fit(DesktopResolution) ? DesktopResolution : HiDefLimitResolution;
+                return _safeMaximumResolution ??= HiDefLimitResolution.Fit(DesktopResolution) ? DesktopResolution : HiDefLimitResolution;
 #else
-                return _safeDesktopResolution ??= DesktopResolution;
+                return _safeMaximumResolution ??= DesktopResolution;
 #endif
             }
         }

--- a/DTAConfig/ScreenResolution.cs
+++ b/DTAConfig/ScreenResolution.cs
@@ -125,13 +125,13 @@ namespace DTAConfig
             "1280x800",
         ];
 
-        public const int MAX_INT_SCALE = 10;
+        public const int MAX_INT_SCALE = 9;
 
         public SortedSet<ScreenResolution> GetIntegerScaledResolutions() => GetIntegerScaledResolutions(SafeMaximumResolution);
         public SortedSet<ScreenResolution> GetIntegerScaledResolutions(ScreenResolution maxResolution)
         {
             SortedSet<ScreenResolution> resolutions = [];
-            for (int i = 1; i < MAX_INT_SCALE; i++)
+            for (int i = 1; i <= MAX_INT_SCALE; i++)
             {
                 ScreenResolution scaledResolution = (this.Width * i, this.Height * i);
 

--- a/DTAConfig/ScreenResolution.cs
+++ b/DTAConfig/ScreenResolution.cs
@@ -157,13 +157,10 @@ namespace DTAConfig
 
             foreach (ScreenResolution optimalResolution in optimalResolutions)
             {
-                foreach (ScreenResolution scaledResolution in optimalResolution.GetIntegerScaledResolutions(maxResolution))
-                {
-                    if (scaledResolution.Width < minWidth || scaledResolution.Height < minHeight)
-                        continue;
+                if (optimalResolution.Width < minWidth || optimalResolution.Height < minHeight)
+                    continue;
 
-                    windowedResolutions.Add(scaledResolution);
-                }
+                windowedResolutions.Add(optimalResolution);
             }
 
             return windowedResolutions;

--- a/DTAConfig/ScreenResolution.cs
+++ b/DTAConfig/ScreenResolution.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.Xna.Framework.Graphics;
+
+namespace DTAConfig
+{
+    /// <summary>
+    /// A single screen resolution.
+    /// </summary>
+    public sealed record ScreenResolution : IComparable<ScreenResolution>
+    {
+        public ScreenResolution(int width, int height)
+        {
+            Width = width;
+            Height = height;
+        }
+
+        /// <summary>
+        /// The width of the resolution in pixels.
+        /// </summary>
+        public int Width { get; set; }
+
+        /// <summary>
+        /// The height of the resolution in pixels.
+        /// </summary>
+        public int Height { get; set; }
+
+        public override string ToString()
+        {
+            return Width + "x" + Height;
+        }
+
+        public void Deconstruct(out int width, out int height)
+        {
+            width = this.Width;
+            height = this.Height;
+        }
+
+        public static implicit operator ScreenResolution((int Width, int Height) resolutionTuple) => new(resolutionTuple.Width, resolutionTuple.Height);
+
+        public static implicit operator (int Width, int Height)(ScreenResolution resolution) => new(resolution.Width, resolution.Height);
+
+        public static implicit operator ScreenResolution(string resolution)
+        {
+            List<int> resolutionList = resolution.Split('x').Take(2).Select(int.Parse).ToList();
+            return new(resolutionList[0], resolutionList[1]);
+        }
+
+        public static implicit operator string(ScreenResolution resolution) => resolution.ToString();
+
+        public bool Fit(ScreenResolution child)
+        {
+            return this.Width >= child.Width && this.Height >= child.Height;
+        }
+
+        public int CompareTo(ScreenResolution res2)
+        {
+            if (this.Width < res2.Width)
+                return -1;
+            else if (this.Width > res2.Width)
+                return 1;
+            else // equal
+            {
+                if (this.Height < res2.Height)
+                    return -1;
+                else if (this.Height > res2.Height)
+                    return 1;
+                else return 0;
+            }
+        }
+
+        private static ScreenResolution _desktopResolution = null;
+        public static ScreenResolution DesktopResolution => _desktopResolution ??= new(GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width, GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height);
+
+        // The default graphic profile supports resolution up to 4096x4096. The number gets even smaller in practice. Therefore, we select 3840 as the limit.
+        public static ScreenResolution HiDefLimitResolution { get; } = "3840x3840";
+
+        private static ScreenResolution _safeDesktopResolution = null;
+        public static ScreenResolution SafeDesktopResolution
+        {
+            get
+            {
+#if XNA
+                return _safeDesktopResolution ??= HiDefLimitResolution.Fit(DesktopResolution) ? DesktopResolution : HiDefLimitResolution;
+#else
+                return _safeDesktopResolution ??= DesktopResolution;
+#endif
+            }
+        }
+
+        public static List<ScreenResolution> GetFullScreenResolutions(int minWidth, int minHeight) => GetFullScreenResolutions(minWidth, minHeight, SafeDesktopResolution.Width, SafeDesktopResolution.Height);
+        public static List<ScreenResolution> GetFullScreenResolutions(int minWidth, int minHeight, int maxWidth, int maxHeight)
+        {
+            var screenResolutions = new List<ScreenResolution>();
+
+            foreach (DisplayMode dm in GraphicsAdapter.DefaultAdapter.SupportedDisplayModes)
+            {
+                if (dm.Width < minWidth || dm.Height < minHeight || dm.Width > maxWidth || dm.Height > maxHeight)
+                    continue;
+
+                var resolution = new ScreenResolution(dm.Width, dm.Height);
+
+                // SupportedDisplayModes can include the same resolution multiple times
+                // because it takes the refresh rate into consideration.
+                // Which means that we have to check if the resolution is already listed
+                if (screenResolutions.Find(res => res.Equals(resolution)) != null)
+                    continue;
+
+                screenResolutions.Add(resolution);
+            }
+
+            return screenResolutions;
+        }
+
+        public static IReadOnlyList<ScreenResolution> OptimalWindowedResolutions { get; } = [
+            "1024x600",
+            "1024x720",
+            "1280x600",
+            "1280x720",
+            "1280x768",
+            "1280x800",
+        ];
+
+        public const int MAX_INT_SCALE = 10;
+
+        public static List<ScreenResolution> GetWindowedResolutions(int minWidth, int minHeight) => GetWindowedResolutions(minWidth, minHeight, SafeDesktopResolution.Width, SafeDesktopResolution.Height);
+        public static List<ScreenResolution> GetWindowedResolutions(int minWidth, int minHeight, int maxWidth, int maxHeight)
+        {
+            ScreenResolution maxResolution = (maxWidth, maxHeight);
+
+            var windowedResolutions = new List<ScreenResolution>();
+
+            foreach (ScreenResolution optimalResolution in OptimalWindowedResolutions)
+            {
+                for (int i = 1; i < MAX_INT_SCALE; i++)
+                {
+                    ScreenResolution scaledResolution = (optimalResolution.Width * i, optimalResolution.Height * i);
+
+                    if (scaledResolution.Width < minWidth || scaledResolution.Height < minHeight)
+                        continue;
+
+                    if (maxResolution.Fit(scaledResolution))
+                        windowedResolutions.Add(scaledResolution);
+                    else
+                        break;
+                }
+            }
+
+            return windowedResolutions;
+        }
+    }
+}

--- a/DTAConfig/ScreenResolution.cs
+++ b/DTAConfig/ScreenResolution.cs
@@ -71,6 +71,7 @@ namespace DTAConfig
             }
         }
 
+        // TODO: accessing GraphicsAdapter.DefaultAdapter requiring DXMainClient.GameClass has been constructed. Lazy loading prevents possible null reference issues for now.
         private static ScreenResolution _desktopResolution = null;
         public static ScreenResolution DesktopResolution => _desktopResolution ??= new(GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width, GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height);
 

--- a/DTAConfig/ScreenResolution.cs
+++ b/DTAConfig/ScreenResolution.cs
@@ -108,7 +108,7 @@ namespace DTAConfig
 
                 // SupportedDisplayModes can include the same resolution multiple times
                 // because it takes the refresh rate into consideration.
-                // Which will be filltered out by HashSet
+                // Which will be filtered out by HashSet
 
                 screenResolutions.Add(resolution);
             }

--- a/DTAConfig/ScreenResolution.cs
+++ b/DTAConfig/ScreenResolution.cs
@@ -44,7 +44,7 @@ namespace DTAConfig
 
         public static implicit operator ScreenResolution(string resolution)
         {
-            List<int> resolutionList = resolution.Split('x').Take(2).Select(int.Parse).ToList();
+            List<int> resolutionList = resolution.Trim().Split('x').Take(2).Select(int.Parse).ToList();
             return new(resolutionList[0], resolutionList[1]);
         }
 
@@ -140,14 +140,19 @@ namespace DTAConfig
             return resolutions;
         }
 
-        public static SortedSet<ScreenResolution> GetWindowedResolutions(int minWidth, int minHeight) => GetWindowedResolutions(minWidth, minHeight, SafeDesktopResolution.Width, SafeDesktopResolution.Height);
-        public static SortedSet<ScreenResolution> GetWindowedResolutions(int minWidth, int minHeight, int maxWidth, int maxHeight)
+        public static SortedSet<ScreenResolution> GetWindowedResolutions(int minWidth, int minHeight) =>
+            GetWindowedResolutions(minWidth, minHeight, SafeDesktopResolution.Width, SafeDesktopResolution.Height);
+        public static SortedSet<ScreenResolution> GetWindowedResolutions(IEnumerable<ScreenResolution> optimalResolutions, int minWidth, int minHeight) =>
+            GetWindowedResolutions(OptimalWindowedResolutions, minWidth, minHeight, SafeDesktopResolution.Width, SafeDesktopResolution.Height);
+        public static SortedSet<ScreenResolution> GetWindowedResolutions(int minWidth, int minHeight, int maxWidth, int maxHeight) =>
+            GetWindowedResolutions(OptimalWindowedResolutions, minWidth, minHeight, maxWidth, maxHeight);
+        public static SortedSet<ScreenResolution> GetWindowedResolutions(IEnumerable<ScreenResolution> optimalResolutions, int minWidth, int minHeight, int maxWidth, int maxHeight)
         {
             ScreenResolution maxResolution = (maxWidth, maxHeight);
 
             var windowedResolutions = new SortedSet<ScreenResolution>();
 
-            foreach (ScreenResolution optimalResolution in OptimalWindowedResolutions)
+            foreach (ScreenResolution optimalResolution in optimalResolutions)
             {
                 foreach (ScreenResolution scaledResolution in optimalResolution.GetIntegerScaledResolutions(maxResolution))
                 {

--- a/DTAConfig/ScreenResolution.cs
+++ b/DTAConfig/ScreenResolution.cs
@@ -71,7 +71,7 @@ namespace DTAConfig
             }
         }
 
-        // TODO: accessing GraphicsAdapter.DefaultAdapter requiring DXMainClient.GameClass has been constructed. Lazy loading prevents possible null reference issues for now.
+        // Accessing GraphicsAdapter.DefaultAdapter requiring DXMainClient.GameClass has been constructed. Lazy loading prevents possible null reference issues for now.
         private static ScreenResolution _desktopResolution = null;
         public static ScreenResolution DesktopResolution => _desktopResolution ??= new(GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width, GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height);
 

--- a/DTAConfig/ScreenResolution.cs
+++ b/DTAConfig/ScreenResolution.cs
@@ -78,7 +78,7 @@ namespace DTAConfig
         public static ScreenResolution HiDefLimitResolution { get; } = "3840x3840";
 
         private static ScreenResolution _safeDesktopResolution = null;
-        public static ScreenResolution SafeDesktopResolution
+        public static ScreenResolution SafeMaximumResolution
         {
             get
             {
@@ -90,7 +90,10 @@ namespace DTAConfig
             }
         }
 
-        public static SortedSet<ScreenResolution> GetFullScreenResolutions(int minWidth, int minHeight) => GetFullScreenResolutions(minWidth, minHeight, SafeDesktopResolution.Width, SafeDesktopResolution.Height);
+        private static ScreenResolution _safeFullScreenResolution = null;
+        public static ScreenResolution SafeFullScreenResolution = _safeFullScreenResolution ??= GetFullScreenResolutions(minWidth: 800, minHeight: 600).Max();
+
+        public static SortedSet<ScreenResolution> GetFullScreenResolutions(int minWidth, int minHeight) => GetFullScreenResolutions(minWidth, minHeight, SafeMaximumResolution.Width, SafeMaximumResolution.Height);
         public static SortedSet<ScreenResolution> GetFullScreenResolutions(int minWidth, int minHeight, int maxWidth, int maxHeight)
         {
             var screenResolutions = new SortedSet<ScreenResolution>();
@@ -123,7 +126,7 @@ namespace DTAConfig
 
         public const int MAX_INT_SCALE = 10;
 
-        public SortedSet<ScreenResolution> GetIntegerScaledResolutions() => GetIntegerScaledResolutions(SafeDesktopResolution);
+        public SortedSet<ScreenResolution> GetIntegerScaledResolutions() => GetIntegerScaledResolutions(SafeMaximumResolution);
         public SortedSet<ScreenResolution> GetIntegerScaledResolutions(ScreenResolution maxResolution)
         {
             SortedSet<ScreenResolution> resolutions = [];
@@ -141,9 +144,9 @@ namespace DTAConfig
         }
 
         public static SortedSet<ScreenResolution> GetWindowedResolutions(int minWidth, int minHeight) =>
-            GetWindowedResolutions(minWidth, minHeight, SafeDesktopResolution.Width, SafeDesktopResolution.Height);
+            GetWindowedResolutions(minWidth, minHeight, SafeMaximumResolution.Width, SafeMaximumResolution.Height);
         public static SortedSet<ScreenResolution> GetWindowedResolutions(IEnumerable<ScreenResolution> optimalResolutions, int minWidth, int minHeight) =>
-            GetWindowedResolutions(OptimalWindowedResolutions, minWidth, minHeight, SafeDesktopResolution.Width, SafeDesktopResolution.Height);
+            GetWindowedResolutions(OptimalWindowedResolutions, minWidth, minHeight, SafeMaximumResolution.Width, SafeMaximumResolution.Height);
         public static SortedSet<ScreenResolution> GetWindowedResolutions(int minWidth, int minHeight, int maxWidth, int maxHeight) =>
             GetWindowedResolutions(OptimalWindowedResolutions, minWidth, minHeight, maxWidth, maxHeight);
         public static SortedSet<ScreenResolution> GetWindowedResolutions(IEnumerable<ScreenResolution> optimalResolutions, int minWidth, int minHeight, int maxWidth, int maxHeight)

--- a/DTAConfig/ScreenResolution.cs
+++ b/DTAConfig/ScreenResolution.cs
@@ -91,7 +91,7 @@ namespace DTAConfig
         }
 
         private static ScreenResolution _safeFullScreenResolution = null;
-        public static ScreenResolution SafeFullScreenResolution = _safeFullScreenResolution ??= GetFullScreenResolutions(minWidth: 800, minHeight: 600).Max();
+        public static ScreenResolution SafeFullScreenResolution => _safeFullScreenResolution ??= GetFullScreenResolutions(minWidth: 800, minHeight: 600).Max();
 
         public static SortedSet<ScreenResolution> GetFullScreenResolutions(int minWidth, int minHeight) => GetFullScreenResolutions(minWidth, minHeight, SafeMaximumResolution.Width, SafeMaximumResolution.Height);
         public static SortedSet<ScreenResolution> GetFullScreenResolutions(int minWidth, int minHeight, int maxWidth, int maxHeight)

--- a/DTAConfig/ScreenResolution.cs
+++ b/DTAConfig/ScreenResolution.cs
@@ -90,10 +90,10 @@ namespace DTAConfig
             }
         }
 
-        public static List<ScreenResolution> GetFullScreenResolutions(int minWidth, int minHeight) => GetFullScreenResolutions(minWidth, minHeight, SafeDesktopResolution.Width, SafeDesktopResolution.Height);
-        public static List<ScreenResolution> GetFullScreenResolutions(int minWidth, int minHeight, int maxWidth, int maxHeight)
+        public static SortedSet<ScreenResolution> GetFullScreenResolutions(int minWidth, int minHeight) => GetFullScreenResolutions(minWidth, minHeight, SafeDesktopResolution.Width, SafeDesktopResolution.Height);
+        public static SortedSet<ScreenResolution> GetFullScreenResolutions(int minWidth, int minHeight, int maxWidth, int maxHeight)
         {
-            var screenResolutions = new List<ScreenResolution>();
+            var screenResolutions = new SortedSet<ScreenResolution>();
 
             foreach (DisplayMode dm in GraphicsAdapter.DefaultAdapter.SupportedDisplayModes)
             {
@@ -104,9 +104,7 @@ namespace DTAConfig
 
                 // SupportedDisplayModes can include the same resolution multiple times
                 // because it takes the refresh rate into consideration.
-                // Which means that we have to check if the resolution is already listed
-                if (screenResolutions.Find(res => res.Equals(resolution)) != null)
-                    continue;
+                // Which will be filltered out by HashSet
 
                 screenResolutions.Add(resolution);
             }
@@ -125,12 +123,12 @@ namespace DTAConfig
 
         public const int MAX_INT_SCALE = 10;
 
-        public static List<ScreenResolution> GetWindowedResolutions(int minWidth, int minHeight) => GetWindowedResolutions(minWidth, minHeight, SafeDesktopResolution.Width, SafeDesktopResolution.Height);
-        public static List<ScreenResolution> GetWindowedResolutions(int minWidth, int minHeight, int maxWidth, int maxHeight)
+        public static SortedSet<ScreenResolution> GetWindowedResolutions(int minWidth, int minHeight) => GetWindowedResolutions(minWidth, minHeight, SafeDesktopResolution.Width, SafeDesktopResolution.Height);
+        public static SortedSet<ScreenResolution> GetWindowedResolutions(int minWidth, int minHeight, int maxWidth, int maxHeight)
         {
             ScreenResolution maxResolution = (maxWidth, maxHeight);
 
-            var windowedResolutions = new List<ScreenResolution>();
+            var windowedResolutions = new SortedSet<ScreenResolution>();
 
             foreach (ScreenResolution optimalResolution in OptimalWindowedResolutions)
             {

--- a/DTAConfig/ScreenResolution.cs
+++ b/DTAConfig/ScreenResolution.cs
@@ -27,10 +27,7 @@ namespace DTAConfig
         /// </summary>
         public int Height { get; set; }
 
-        public override string ToString()
-        {
-            return Width + "x" + Height;
-        }
+        public override string ToString() => Width + "x" + Height;
 
         public void Deconstruct(out int width, out int height)
         {
@@ -50,16 +47,14 @@ namespace DTAConfig
 
         public static implicit operator string(ScreenResolution resolution) => resolution.ToString();
 
-        public bool Fit(ScreenResolution child)
-        {
-            return this.Width >= child.Width && this.Height >= child.Height;
-        }
+        public bool Fit(ScreenResolution child) => this.Width >= child.Width && this.Height >= child.Height;
 
         public int CompareTo(ScreenResolution other) => (this.Width, this.Height).CompareTo(other);
 
         // Accessing GraphicsAdapter.DefaultAdapter requiring DXMainClient.GameClass has been constructed. Lazy loading prevents possible null reference issues for now.
         private static ScreenResolution _desktopResolution = null;
-        public static ScreenResolution DesktopResolution => _desktopResolution ??= new(GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width, GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height);
+        public static ScreenResolution DesktopResolution =>
+            _desktopResolution ??= new(GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width, GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height);
 
         // The default graphic profile supports resolution up to 4096x4096. The number gets even smaller in practice. Therefore, we select 3840 as the limit.
         public static ScreenResolution HiDefLimitResolution { get; } = "3840x3840";
@@ -80,10 +75,11 @@ namespace DTAConfig
         private static ScreenResolution _safeFullScreenResolution = null;
         public static ScreenResolution SafeFullScreenResolution => _safeFullScreenResolution ??= GetFullScreenResolutions(minWidth: 800, minHeight: 600).Max();
 
-        public static SortedSet<ScreenResolution> GetFullScreenResolutions(int minWidth, int minHeight) => GetFullScreenResolutions(minWidth, minHeight, SafeMaximumResolution.Width, SafeMaximumResolution.Height);
+        public static SortedSet<ScreenResolution> GetFullScreenResolutions(int minWidth, int minHeight) =>
+            GetFullScreenResolutions(minWidth, minHeight, SafeMaximumResolution.Width, SafeMaximumResolution.Height);
         public static SortedSet<ScreenResolution> GetFullScreenResolutions(int minWidth, int minHeight, int maxWidth, int maxHeight)
         {
-            var screenResolutions = new SortedSet<ScreenResolution>();
+            SortedSet<ScreenResolution> screenResolutions = [];
 
             foreach (DisplayMode dm in GraphicsAdapter.DefaultAdapter.SupportedDisplayModes)
             {
@@ -114,7 +110,8 @@ namespace DTAConfig
 
         public const int MAX_INT_SCALE = 9;
 
-        public SortedSet<ScreenResolution> GetIntegerScaledResolutions() => GetIntegerScaledResolutions(SafeMaximumResolution);
+        public SortedSet<ScreenResolution> GetIntegerScaledResolutions() =>
+            GetIntegerScaledResolutions(SafeMaximumResolution);
         public SortedSet<ScreenResolution> GetIntegerScaledResolutions(ScreenResolution maxResolution)
         {
             SortedSet<ScreenResolution> resolutions = [];
@@ -141,7 +138,7 @@ namespace DTAConfig
         {
             ScreenResolution maxResolution = (maxWidth, maxHeight);
 
-            var windowedResolutions = new SortedSet<ScreenResolution>();
+            SortedSet<ScreenResolution> windowedResolutions = [];
 
             foreach (ScreenResolution optimalResolution in optimalResolutions)
             {

--- a/DTAConfig/ScreenResolution.cs
+++ b/DTAConfig/ScreenResolution.cs
@@ -55,21 +55,7 @@ namespace DTAConfig
             return this.Width >= child.Width && this.Height >= child.Height;
         }
 
-        public int CompareTo(ScreenResolution res2)
-        {
-            if (this.Width < res2.Width)
-                return -1;
-            else if (this.Width > res2.Width)
-                return 1;
-            else // equal
-            {
-                if (this.Height < res2.Height)
-                    return -1;
-                else if (this.Height > res2.Height)
-                    return 1;
-                else return 0;
-            }
-        }
+        public int CompareTo(ScreenResolution other) => (this.Width, this.Height).CompareTo(other);
 
         // Accessing GraphicsAdapter.DefaultAdapter requiring DXMainClient.GameClass has been constructed. Lazy loading prevents possible null reference issues for now.
         private static ScreenResolution _desktopResolution = null;

--- a/DTAConfig/ScreenResolution.cs
+++ b/DTAConfig/ScreenResolution.cs
@@ -20,12 +20,12 @@ namespace DTAConfig
         /// <summary>
         /// The width of the resolution in pixels.
         /// </summary>
-        public int Width { get; set; }
+        public int Width { get; }
 
         /// <summary>
         /// The height of the resolution in pixels.
         /// </summary>
-        public int Height { get; set; }
+        public int Height { get; }
 
         public override string ToString() => Width + "x" + Height;
 

--- a/DTAConfig/ScreenResolution.cs
+++ b/DTAConfig/ScreenResolution.cs
@@ -116,7 +116,8 @@ namespace DTAConfig
             return screenResolutions;
         }
 
-        public static IReadOnlyList<ScreenResolution> OptimalWindowedResolutions { get; } = [
+        public static readonly IReadOnlyList<ScreenResolution> OptimalWindowedResolutions =
+        [
             "1024x600",
             "1024x720",
             "1280x600",

--- a/DTAConfig/ScreenResolution.cs
+++ b/DTAConfig/ScreenResolution.cs
@@ -11,11 +11,6 @@ namespace DTAConfig
     /// </summary>
     public sealed record ScreenResolution : IComparable<ScreenResolution>
     {
-        public ScreenResolution(int width, int height)
-        {
-            Width = width;
-            Height = height;
-        }
 
         /// <summary>
         /// The width of the resolution in pixels.
@@ -27,7 +22,24 @@ namespace DTAConfig
         /// </summary>
         public int Height { get; }
 
-        public override string ToString() => Width + "x" + Height;
+        public ScreenResolution(int width, int height)
+        {
+            Width = width;
+            Height = height;
+        }
+
+        public ScreenResolution(string resolution)
+        {
+            List<int> resolutionList = resolution.Trim().Split('x').Take(2).Select(int.Parse).ToList();
+            Width = resolutionList[0];
+            Height = resolutionList[1];
+        }
+
+        public static implicit operator ScreenResolution(string resolution) => new(resolution);
+
+        public sealed override string ToString() => Width + "x" + Height;
+
+        public static implicit operator string(ScreenResolution resolution) => resolution.ToString();
 
         public void Deconstruct(out int width, out int height)
         {
@@ -38,14 +50,6 @@ namespace DTAConfig
         public static implicit operator ScreenResolution((int Width, int Height) resolutionTuple) => new(resolutionTuple.Width, resolutionTuple.Height);
 
         public static implicit operator (int Width, int Height)(ScreenResolution resolution) => new(resolution.Width, resolution.Height);
-
-        public static implicit operator ScreenResolution(string resolution)
-        {
-            List<int> resolutionList = resolution.Trim().Split('x').Take(2).Select(int.Parse).ToList();
-            return new(resolutionList[0], resolutionList[1]);
-        }
-
-        public static implicit operator string(ScreenResolution resolution) => resolution.ToString();
 
         public bool Fit(ScreenResolution child) => this.Width >= child.Width && this.Height >= child.Height;
 

--- a/DTAConfig/ScreenResolution.cs
+++ b/DTAConfig/ScreenResolution.cs
@@ -123,6 +123,23 @@ namespace DTAConfig
 
         public const int MAX_INT_SCALE = 10;
 
+        public SortedSet<ScreenResolution> GetIntegerScaledResolutions() => GetIntegerScaledResolutions(SafeDesktopResolution);
+        public SortedSet<ScreenResolution> GetIntegerScaledResolutions(ScreenResolution maxResolution)
+        {
+            SortedSet<ScreenResolution> resolutions = [];
+            for (int i = 1; i < MAX_INT_SCALE; i++)
+            {
+                ScreenResolution scaledResolution = (this.Width * i, this.Height * i);
+
+                if (maxResolution.Fit(scaledResolution))
+                    resolutions.Add(scaledResolution);
+                else
+                    break;
+            }
+
+            return resolutions;
+        }
+
         public static SortedSet<ScreenResolution> GetWindowedResolutions(int minWidth, int minHeight) => GetWindowedResolutions(minWidth, minHeight, SafeDesktopResolution.Width, SafeDesktopResolution.Height);
         public static SortedSet<ScreenResolution> GetWindowedResolutions(int minWidth, int minHeight, int maxWidth, int maxHeight)
         {
@@ -132,17 +149,12 @@ namespace DTAConfig
 
             foreach (ScreenResolution optimalResolution in OptimalWindowedResolutions)
             {
-                for (int i = 1; i < MAX_INT_SCALE; i++)
+                foreach (ScreenResolution scaledResolution in optimalResolution.GetIntegerScaledResolutions(maxResolution))
                 {
-                    ScreenResolution scaledResolution = (optimalResolution.Width * i, optimalResolution.Height * i);
-
                     if (scaledResolution.Width < minWidth || scaledResolution.Height < minHeight)
                         continue;
 
-                    if (maxResolution.Fit(scaledResolution))
-                        windowedResolutions.Add(scaledResolution);
-                    else
-                        break;
+                    windowedResolutions.Add(scaledResolution);
                 }
             }
 

--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -320,7 +320,7 @@ namespace DTAClient.DXGUI
 
             bool borderlessWindowedClient = UserINISettings.Instance.BorderlessWindowedClient;
 
-            (int desktopWidth, int desktopHeight) = ScreenResolution.SafeDesktopResolution;
+            (int desktopWidth, int desktopHeight) = ScreenResolution.SafeMaximumResolution;
 
             if (desktopWidth >= windowWidth && desktopHeight >= windowHeight)
             {

--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -48,9 +48,7 @@ namespace DTAClient.DXGUI
             graphics.HardwareModeSwitch = false;
 
             // Enable HiDef on a large monitor.
-            // The default graphic profile supports resolution up to 4096x4096. The number gets even smaller in practice. Therefore, we select 3840 as the limit.
-            if (GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width > 3840 ||
-                GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height > 3840)
+            if (!ScreenResolution.HiDefLimitResolution.Fit(ScreenResolution.DesktopResolution))
             {
                 // Enable HiDef profile drops legacy GPUs not supporting DirectX 10.
                 // In practical, it's recommended to have a DirectX 11 capable GPU.
@@ -321,10 +319,10 @@ namespace DTAClient.DXGUI
             int windowHeight = UserINISettings.Instance.ClientResolutionY;
 
             bool borderlessWindowedClient = UserINISettings.Instance.BorderlessWindowedClient;
-            int currentWidth = GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width;
-            int currentHeight = GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height;
 
-            if (currentWidth >= windowWidth && currentHeight >= windowHeight)
+            (int desktopWidth, int desktopHeight) = ScreenResolution.SafeDesktopResolution;
+
+            if (desktopWidth >= windowWidth && desktopHeight >= windowHeight)
             {
                 if (!wm.InitGraphicsMode(windowWidth, windowHeight, false))
                     throw new GraphicsModeInitializationException("Setting graphics mode failed!".L10N("Client:Main:SettingGraphicModeFailed") + " " + windowWidth + "x" + windowHeight);

--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -321,6 +321,8 @@ namespace DTAClient.DXGUI
             }
             else
             {
+                // fallback to the minimum supported resolution when the desktop is not sufficient to contain the client
+                // e.g., when users set a lower desktop resolution but the client resolution in the settings file remains high
                 if (!wm.InitGraphicsMode(1024, 600, false))
                     throw new GraphicsModeInitializationException("Setting default graphics mode failed!".L10N("Client:Main:SettingDefaultGraphicModeFailed"));
             }

--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -358,7 +358,7 @@ namespace DTAClient.DXGUI
             if (ratio > 1.0)
             {
                 // Check whether we could sharp-scale our client window
-                for (int i = 2; i < 10; i++)
+                for (int i = 2; i < ScreenResolution.MAX_INT_SCALE; i++)
                 {
                     int sharpScaleRenderResX = windowWidth / i;
                     int sharpScaleRenderResY = windowHeight / i;

--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -389,17 +389,17 @@ namespace DTAClient.DXGUI
 
             if (borderlessWindowedClient)
             {
-                // Note: on full screen mode, the client resolution must exactly match the desktop resolution. Otherwise buttons outside of client resolution are unclickable.
+                // Note: on fullscreen mode, the client resolution must exactly match the desktop resolution. Otherwise buttons outside of client resolution are unclickable.
                 ScreenResolution clientResolution = (windowWidth, windowHeight);
                 if (ScreenResolution.DesktopResolution == clientResolution)
                 {
-                    Logger.Log($"Entering full screen mode with resolution {ScreenResolution.DesktopResolution}.");
+                    Logger.Log($"Entering fullscreen mode with resolution {ScreenResolution.DesktopResolution}.");
                     graphics.IsFullScreen = true;
                     graphics.ApplyChanges();
                 }
                 else
                 {
-                    Logger.Log($"Not entering full screen mode due to resolution mismatch. Desktop: {ScreenResolution.DesktopResolution}, Client: {clientResolution}.");
+                    Logger.Log($"Not entering fullscreen mode due to resolution mismatch. Desktop: {ScreenResolution.DesktopResolution}, Client: {clientResolution}.");
                 }
             }
 

--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -358,7 +358,7 @@ namespace DTAClient.DXGUI
             if (ratio > 1.0)
             {
                 // Check whether we could sharp-scale our client window
-                for (int i = 2; i < ScreenResolution.MAX_INT_SCALE; i++)
+                for (int i = 2; i <= ScreenResolution.MAX_INT_SCALE; i++)
                 {
                     int sharpScaleRenderResX = windowWidth / i;
                     int sharpScaleRenderResY = windowHeight / i;

--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -389,8 +389,18 @@ namespace DTAClient.DXGUI
 
             if (borderlessWindowedClient)
             {
-                graphics.IsFullScreen = true;
-                graphics.ApplyChanges();
+                // Note: on full screen mode, the client resolution must exactly match the desktop resolution. Otherwise buttons outside of client resolution are unclickable.
+                ScreenResolution clientResolution = (windowWidth, windowHeight);
+                if (ScreenResolution.DesktopResolution == clientResolution)
+                {
+                    Logger.Log($"Entering full screen mode with resolution {ScreenResolution.DesktopResolution}.");
+                    graphics.IsFullScreen = true;
+                    graphics.ApplyChanges();
+                }
+                else
+                {
+                    Logger.Log($"Not entering full screen mode due to resolution mismatch. Desktop: {ScreenResolution.DesktopResolution}, Client: {clientResolution}.");
+                }
             }
 
 #endif

--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -50,8 +50,8 @@ namespace DTAClient.DXGUI
             // Enable HiDef on a large monitor.
             if (!ScreenResolution.HiDefLimitResolution.Fit(ScreenResolution.DesktopResolution))
             {
-                // Enable HiDef profile drops legacy GPUs not supporting DirectX 10.
-                // In practical, it's recommended to have a DirectX 11 capable GPU.
+                // Enabling HiDef profile drops legacy GPUs not supporting DirectX 10.
+                // In practice, it's recommended to have a DirectX 11 capable GPU.
                 graphics.GraphicsProfile = GraphicsProfile.HiDef;
             }
 #endif

--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -46,6 +46,16 @@ namespace DTAClient.DXGUI
             graphics.SynchronizeWithVerticalRetrace = false;
 #if !XNA
             graphics.HardwareModeSwitch = false;
+
+            // Enable HiDef on a large monitor.
+            // The default graphic profile supports resolution up to 4096x4096. The number gets even smaller in practice. Therefore, we select 3840 as the limit.
+            if (GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width > 3840 ||
+                GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height > 3840)
+            {
+                // Enable HiDef profile drops legacy GPUs not supporting DirectX 10.
+                // In practical, it's recommended to have a DirectX 11 capable GPU.
+                graphics.GraphicsProfile = GraphicsProfile.HiDef;
+            }
 #endif
             content = new ContentManager(Services);
         }

--- a/DXMainClient/Program.cs
+++ b/DXMainClient/Program.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 #if !NETFRAMEWORK
 using System.Runtime.Loader;
 #endif
@@ -57,8 +59,10 @@ namespace DTAClient
         private static string COMMON_LIBRARY_PATH;
         private static string SPECIFIC_LIBRARY_PATH;
 
-        static void InitializeApplicationConfiguration() {
+        static void InitializeApplicationConfiguration()
+        {
 #if WINFORMS
+
 #if NET6_0_OR_GREATER
             // .NET 6.0 brings a source generator ApplicationConfiguration which is not available in previous .NET versions
             // https://medium.com/c-sharp-progarmming/whats-new-in-windows-forms-in-net-6-0-840c71856751
@@ -67,8 +71,16 @@ namespace DTAClient
             System.Windows.Forms.Application.EnableVisualStyles();
             System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(false);
 #endif
+
+#else
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                SetProcessDPIAware();
 #endif
         }
+
+        [DllImport("user32.dll")]
+        [SupportedOSPlatform("windows")]
+        private static extern bool SetProcessDPIAware();
 
         /// <summary>
         /// The main entry point for the application.
@@ -144,7 +156,7 @@ namespace DTAClient
                     mutex.ReleaseMutex();
             }
         }
- 
+
 #if !NETFRAMEWORK
         private static Assembly DefaultAssemblyLoadContextOnResolving(AssemblyLoadContext assemblyLoadContext, AssemblyName assemblyName)
         {

--- a/DXMainClient/Program.cs
+++ b/DXMainClient/Program.cs
@@ -84,6 +84,7 @@ namespace DTAClient
         }
 
         [DllImport("user32.dll")]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         [SupportedOSPlatform("windows")]
         private static extern bool SetProcessDPIAware();
 

--- a/DXMainClient/Program.cs
+++ b/DXMainClient/Program.cs
@@ -68,6 +68,11 @@ namespace DTAClient
             // https://medium.com/c-sharp-progarmming/whats-new-in-windows-forms-in-net-6-0-840c71856751
             ApplicationConfiguration.Initialize();
 #else
+
+#if NETCOREAPP3_0_OR_GREATER
+            System.Windows.Forms.Application.SetHighDpiMode(System.Windows.Forms.HighDpiMode.PerMonitorV2);
+#endif
+
             System.Windows.Forms.Application.EnableVisualStyles();
             System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(false);
 #endif

--- a/DXMainClient/Startup.cs
+++ b/DXMainClient/Startup.cs
@@ -128,7 +128,7 @@ namespace DTAClient
             GameClass gameClass = new GameClass();
 
             // Find the largest full screen resolution as the default
-            var resolution = ScreenResolution.GetFullScreenResolutions(minWidth: 800, minHeight: 600).Max();
+            var resolution = ScreenResolution.SafeFullScreenResolution;
 
             UserINISettings.Instance.ClientResolutionX = new IntSetting(UserINISettings.Instance.SettingsIni, UserINISettings.VIDEO, "ClientResolutionX", resolution.Width);
             UserINISettings.Instance.ClientResolutionY = new IntSetting(UserINISettings.Instance.SettingsIni, UserINISettings.VIDEO, "ClientResolutionY", resolution.Height);

--- a/DXMainClient/Startup.cs
+++ b/DXMainClient/Startup.cs
@@ -19,6 +19,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using ClientCore.Settings;
 using Microsoft.Xna.Framework.Graphics;
+using DTAConfig;
 
 namespace DTAClient
 {
@@ -126,11 +127,11 @@ namespace DTAClient
 
             GameClass gameClass = new GameClass();
 
-            int currentWidth = GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width;
-            int currentHeight = GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height;
+            // Find the largest full screen resolution as the default
+            var resolution = ScreenResolution.GetFullScreenResolutions(minWidth: 800, minHeight: 600).Max();
 
-            UserINISettings.Instance.ClientResolutionX = new IntSetting(UserINISettings.Instance.SettingsIni, UserINISettings.VIDEO, "ClientResolutionX", currentWidth);
-            UserINISettings.Instance.ClientResolutionY = new IntSetting(UserINISettings.Instance.SettingsIni, UserINISettings.VIDEO, "ClientResolutionY", currentHeight);
+            UserINISettings.Instance.ClientResolutionX = new IntSetting(UserINISettings.Instance.SettingsIni, UserINISettings.VIDEO, "ClientResolutionX", resolution.Width);
+            UserINISettings.Instance.ClientResolutionY = new IntSetting(UserINISettings.Instance.SettingsIni, UserINISettings.VIDEO, "ClientResolutionY", resolution.Height);
 
             gameClass.Run();
         }

--- a/DXMainClient/Startup.cs
+++ b/DXMainClient/Startup.cs
@@ -127,7 +127,7 @@ namespace DTAClient
 
             GameClass gameClass = new GameClass();
 
-            // Find the largest full screen resolution as the default
+            // Find the largest fullscreen resolution as the default
             var resolution = ScreenResolution.SafeFullScreenResolution;
 
             UserINISettings.Instance.ClientResolutionX = new IntSetting(UserINISettings.Instance.SettingsIni, UserINISettings.VIDEO, "ClientResolutionX", resolution.Width);

--- a/DXMainClient/Startup.cs
+++ b/DXMainClient/Startup.cs
@@ -20,6 +20,7 @@ using System.Runtime.Versioning;
 using ClientCore.Settings;
 using Microsoft.Xna.Framework.Graphics;
 using DTAConfig;
+using System.Collections.Generic;
 
 namespace DTAClient
 {
@@ -127,11 +128,23 @@ namespace DTAClient
 
             GameClass gameClass = new GameClass();
 
-            // Find the largest fullscreen resolution as the default
-            var resolution = ScreenResolution.SafeFullScreenResolution;
+            if (!UserINISettings.Instance.BorderlessWindowedClient)
+            {
+                // Find the largest recommended resolution as the default windowed resolution
+                List<ScreenResolution> recommendedResolutions = ClientConfiguration.Instance.RecommendedResolutions.Select(resolution => (ScreenResolution)resolution).ToList();
+                SortedSet<ScreenResolution> scaledRecommendedResolutions = [.. recommendedResolutions.SelectMany(resolution => resolution.GetIntegerScaledResolutions())];
+                var bestRecommendedResolution = scaledRecommendedResolutions.Max();
 
-            UserINISettings.Instance.ClientResolutionX = new IntSetting(UserINISettings.Instance.SettingsIni, UserINISettings.VIDEO, "ClientResolutionX", resolution.Width);
-            UserINISettings.Instance.ClientResolutionY = new IntSetting(UserINISettings.Instance.SettingsIni, UserINISettings.VIDEO, "ClientResolutionY", resolution.Height);
+                UserINISettings.Instance.ClientResolutionX = new IntSetting(UserINISettings.Instance.SettingsIni, UserINISettings.VIDEO, "ClientResolutionX", bestRecommendedResolution.Width);
+                UserINISettings.Instance.ClientResolutionY = new IntSetting(UserINISettings.Instance.SettingsIni, UserINISettings.VIDEO, "ClientResolutionY", bestRecommendedResolution.Height);
+            }
+            else
+            {
+                // Find the largest fullscreen resolution as the default fullscreen resolution
+                var resolution = ScreenResolution.SafeFullScreenResolution;
+                UserINISettings.Instance.ClientResolutionX = new IntSetting(UserINISettings.Instance.SettingsIni, UserINISettings.VIDEO, "ClientResolutionX", resolution.Width);
+                UserINISettings.Instance.ClientResolutionY = new IntSetting(UserINISettings.Instance.SettingsIni, UserINISettings.VIDEO, "ClientResolutionY", resolution.Height);
+            }
 
             gameClass.Run();
         }


### PR DESCRIPTION
Fixes #359.

This PR includes the following changes:
- Class `DTAConfig.OptionPanels.DisplayOptionsPanel.ScreenResolution` has been refactored as `DTAConfig.ScreenResolution`. This is necessary to simplify the handling work about the ultra resolution limitation.
- Support for ultra resolutions (where either the width or height exceeds 3840 pixels) across DX and GL builds
- Prevent XNA builds from listing or applying ultra resolutions.
- Add additional integer-scaled windowed client resolutions for recommended resolutions. (see the screenshot in the end)
- Previously, the UGL build does not declare high DPI awareness, which brings unnecessary blurry. It has been fixed.
- Previously, the UGL build fails to constraint the client resolution equaling desktop resolution on full screen mode. This causes some buttons unclickable if the constraint above does not match. It has been fixed. 
- An additional check has been added when entering the real full-screen mode, preventing inconsistency if the client resolution is modified through the user config file, or due to ultra-resolution limitations. 
- The client will now select the best recommended client solution when either
  - the client definition is not defined (e.g., first launch) and not in full-screen mode (currently, it requires `BorderlessWindowedClient=false`)
  - the user unchecked the fullscreen checkbox in settings panel. (Before this PR, the first recommended resolution was selected.)

Note: Ultra-resolution support is only enabled if either the width or height of the desktop resolution exceeds 3840 pixels (not included). When enabled, the support for legacy graphic cards will be dropped. Considering the fact that these cards do not support ultra resolutions by hardware, it should have no impact on these legacy computers.

Reference: 
- https://github.com/Rampastring/WorldAlteringEditor/blob/d61209c91e53f21884b7de8521c936ab2b96e9d6/src/TSMapEditor/Rendering/GameClass.cs#L57
- https://docs.monogame.net/api/Microsoft.Xna.Framework.Graphics.GraphicsProfile.html

--------

![Snipaste_2024-09-08_20-21-57](https://github.com/user-attachments/assets/8847732b-79a7-4444-b023-13143bdc82c4)

This screenshot demonstrates a 2x scaling for recommended resolution `1280x800`, specifying only `RecommendedResolutions=1280x800` in the `ClientDefinitions.ini` file. Most mods prefer only one resolution that exactly matches the design, e.g., `1280x800`. Before this PR, hardcoded resolutions like `1280x800` are added, but the scaling version of the resolution is not added, for example `2560x1600` here. This makes users owning a high PPI monitor (e.g., a 27-inch 4K monitor) find it hard to perfectly zoom the client in windowed mode. This PR solves this burden by additionally adding possible scalings for recommended resolutions.

After this PR, I suggest modders only specify `RecommendedResolutions` as those solutions that exactly matches the UI design, e.g., `1280x800`. (no less than `$"{MinimumRenderWidth}x{MinimumRenderHeight}"`, no more than `$"{MaximumRenderWidth}x{MaximumRenderHeight}"`)


-----

This screenshot demonstrates that the client now supports ultra-wide monitors (5120x1440).

![image](https://github.com/user-attachments/assets/d45fab1f-2f4a-4e4a-b004-69e817358a13)
