### PR TITLE
Add integer scaling feature and make client window resizable

### DIFF
--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -16,6 +16,7 @@ namespace ClientCore
         private const string SETTINGS = "Settings";
         private const string LINKS = "Links";
         private const string TRANSLATIONS = "Translations";
+        private const string USER_DEFAULTS = "UserDefaults";
 
         private const string CLIENT_SETTINGS = "DTACnCNetClient.ini";
         private const string GAME_OPTIONS = "GameOptions.ini";
@@ -193,7 +194,8 @@ namespace ClientCore
 
         public int MaximumRenderHeight => clientDefinitionsIni.GetIntValue(SETTINGS, "MaximumRenderHeight", 800);
 
-        public string[] RecommendedResolutions => clientDefinitionsIni.GetStringValue(SETTINGS, "RecommendedResolutions", "1280x720,2560x1440,3840x2160").Split(',');
+        public string[] RecommendedResolutions => clientDefinitionsIni.GetStringValue(SETTINGS, "RecommendedResolutions",
+            $"{MinimumRenderWidth}x{MinimumRenderHeight},{MaximumRenderWidth}x{MaximumRenderHeight}").Split(',');
 
         public string WindowTitle => clientDefinitionsIni.GetStringValue(SETTINGS, "WindowTitle", string.Empty)
             .L10N("INI:ClientDefinitions:WindowTitle");
@@ -405,6 +407,16 @@ namespace ClientCore
 
         #endregion
 
+        #region User default settings
+
+        public bool UserDefault_BorderlessWindowedClient => clientDefinitionsIni.GetBooleanValue(USER_DEFAULTS, "BorderlessWindowedClient", true);
+
+        public bool UserDefault_IntegerScaledClient => clientDefinitionsIni.GetBooleanValue(USER_DEFAULTS, "IntegerScaledClient", false);
+
+        public bool UserDefault_WriteInstallationPathToRegistry => clientDefinitionsIni.GetBooleanValue(USER_DEFAULTS, "WriteInstallationPathToRegistry", true);
+
+        #endregion
+
         public List<string> GetIRCServers()
         {
             List<string> servers = [];
@@ -419,7 +431,7 @@ namespace ClientCore
         }
 
         public bool DiscordIntegrationGloballyDisabled => string.IsNullOrWhiteSpace(DiscordAppId) || DisableDiscordIntegration;
-        
+
         public OSVersion GetOperatingSystemVersion()
         {
 #if NETFRAMEWORK

--- a/ClientCore/Settings/UserINISettings.cs
+++ b/ClientCore/Settings/UserINISettings.cs
@@ -63,7 +63,8 @@ namespace ClientCore
             Renderer = new StringSetting(iniFile, COMPATIBILITY, "Renderer", string.Empty);
             WindowedMode = new BoolSetting(iniFile, VIDEO, WINDOWED_MODE_KEY, false);
             BorderlessWindowedMode = new BoolSetting(iniFile, VIDEO, "NoWindowFrame", false);
-            BorderlessWindowedClient = new BoolSetting(iniFile, VIDEO, "BorderlessWindowedClient", true);
+            BorderlessWindowedClient = new BoolSetting(iniFile, VIDEO, "BorderlessWindowedClient", ClientConfiguration.Instance.UserDefault_BorderlessWindowedClient);
+            IntegerScaledClient = new BoolSetting(iniFile, VIDEO, "IntegerScaledClient", ClientConfiguration.Instance.UserDefault_IntegerScaledClient);
             ClientFPS = new IntSetting(iniFile, VIDEO, "ClientFPS", 60);
             DisplayToggleableExtraTextures = new BoolSetting(iniFile, VIDEO, "DisplayToggleableExtraTextures", true);
 
@@ -86,7 +87,7 @@ namespace ClientCore
             ChatColor = new IntSetting(iniFile, MULTIPLAYER, "ChatColor", -1);
             LANChatColor = new IntSetting(iniFile, MULTIPLAYER, "LANChatColor", -1);
             PingUnofficialCnCNetTunnels = new BoolSetting(iniFile, MULTIPLAYER, "PingCustomTunnels", true);
-            WritePathToRegistry = new BoolSetting(iniFile, OPTIONS, "WriteInstallationPathToRegistry", true);
+            WritePathToRegistry = new BoolSetting(iniFile, OPTIONS, "WriteInstallationPathToRegistry", ClientConfiguration.Instance.UserDefault_WriteInstallationPathToRegistry);
             PlaySoundOnGameHosted = new BoolSetting(iniFile, MULTIPLAYER, "PlaySoundOnGameHosted", true);
             SkipConnectDialog = new BoolSetting(iniFile, MULTIPLAYER, "SkipConnectDialog", false);
             PersistentMode = new BoolSetting(iniFile, MULTIPLAYER, "PersistentMode", false);
@@ -151,6 +152,7 @@ namespace ClientCore
         public IntSetting ClientResolutionX { get; set; }
         public IntSetting ClientResolutionY { get; set; }
         public BoolSetting BorderlessWindowedClient { get; private set; }
+        public BoolSetting IntegerScaledClient { get; private set; }
         public IntSetting ClientFPS { get; private set; }
         public BoolSetting DisplayToggleableExtraTextures { get; private set; }
 

--- a/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
@@ -231,7 +231,6 @@ namespace DTAConfig.OptionPanels
                 lblClientResolution.X,
                 lblRenderer.Y, 0, 0);
             chkIntegerScaledClient.Text = "Integer Scaled Client".L10N("Client:DTAConfig:IntegerScaledClient");
-            chkIntegerScaledClient.CheckedChanged += ChkIntegerScaling_CheckedChanged;
             chkIntegerScaledClient.Checked = IniSettings.IntegerScaledClient.Value;
 
             var lblClientTheme = new XNALabel(WindowManager);
@@ -592,16 +591,6 @@ namespace DTAConfig.OptionPanels
                     int optimalWindowedResIndex = ddClientResolution.PreferredItemIndexes[^1];
                     ddClientResolution.SelectedIndex = optimalWindowedResIndex;
                 }
-            }
-        }
-
-        private void ChkIntegerScaling_CheckedChanged(object sender, EventArgs e) 
-        {
-            if (chkIntegerScaledClient.Checked)
-            {
-            }
-            else
-            {
             }
         }
 

--- a/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
@@ -232,6 +232,16 @@ namespace DTAConfig.OptionPanels
                 lblRenderer.Y, 0, 0);
             chkIntegerScaledClient.Text = "Integer Scaled Client".L10N("Client:DTAConfig:IntegerScaledClient");
             chkIntegerScaledClient.Checked = IniSettings.IntegerScaledClient.Value;
+            chkIntegerScaledClient.ToolTipText =
+                """
+                Enable integer scaling for the client. This will cause the client to use
+                the closest fitting resolution that is required to maintain sharp graphics,
+                at the expense of black borders that may appear at some resolutions.
+
+                Additionally, enabling this option will also allow the client window 
+                to be resized (does not affect the selected client resolution).
+                """
+                .L10N("Client:DTAConfig:IntegerScaledClientToolTip");
 
             var lblClientTheme = new XNALabel(WindowManager);
             lblClientTheme.Name = "lblClientTheme";

--- a/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
@@ -42,6 +42,7 @@ namespace DTAConfig.OptionPanels
         private XNAClientCheckBox chkBackBufferInVRAM;
         private XNAClientPreferredItemDropDown ddClientResolution;
         private XNAClientCheckBox chkBorderlessClient;
+        private XNAClientCheckBox chkIntegerScaledClient;
         private XNAClientDropDown ddClientTheme;
         private XNAClientDropDown ddTranslation;
 
@@ -224,18 +225,27 @@ namespace DTAConfig.OptionPanels
             chkBorderlessClient.CheckedChanged += ChkBorderlessMenu_CheckedChanged;
             chkBorderlessClient.Checked = true;
 
+            chkIntegerScaledClient = new XNAClientCheckBox(WindowManager);
+            chkIntegerScaledClient.Name = nameof(chkIntegerScaledClient);
+            chkIntegerScaledClient.ClientRectangle = new Rectangle(
+                lblClientResolution.X,
+                lblRenderer.Y, 0, 0);
+            chkIntegerScaledClient.Text = "Integer Scaled Client".L10N("Client:DTAConfig:IntegerScaledClient");
+            chkIntegerScaledClient.CheckedChanged += ChkIntegerScaling_CheckedChanged;
+            chkIntegerScaledClient.Checked = IniSettings.IntegerScaledClient.Value;
+
             var lblClientTheme = new XNALabel(WindowManager);
             lblClientTheme.Name = "lblClientTheme";
             lblClientTheme.ClientRectangle = new Rectangle(
                 lblClientResolution.X,
-                lblRenderer.Y, 0, 0);
+                chkWindowedMode.Y, 0, 0);
             lblClientTheme.Text = "Client Theme:".L10N("Client:DTAConfig:ClientTheme");
 
             ddClientTheme = new XNAClientDropDown(WindowManager);
             ddClientTheme.Name = "ddClientTheme";
             ddClientTheme.ClientRectangle = new Rectangle(
                 ddClientResolution.X,
-                ddRenderer.Y,
+                chkWindowedMode.Y,
                 ddClientResolution.Width,
                 ddRenderer.Height);
 
@@ -326,6 +336,7 @@ namespace DTAConfig.OptionPanels
             AddChild(chkBorderlessWindowedMode);
             AddChild(chkBackBufferInVRAM);
             AddChild(chkBorderlessClient);
+            AddChild(chkIntegerScaledClient);
             AddChild(lblClientTheme);
             AddChild(ddClientTheme);
             AddChild(lblTranslation);
@@ -584,6 +595,16 @@ namespace DTAConfig.OptionPanels
             }
         }
 
+        private void ChkIntegerScaling_CheckedChanged(object sender, EventArgs e) 
+        {
+            if (chkIntegerScaledClient.Checked)
+            {
+            }
+            else
+            {
+            }
+        }
+
         private void ChkWindowedMode_CheckedChanged(object sender, EventArgs e)
         {
             if (chkWindowedMode.Checked)
@@ -777,6 +798,11 @@ namespace DTAConfig.OptionPanels
                 restartRequired = true;
 
             IniSettings.BorderlessWindowedClient.Value = chkBorderlessClient.Checked;
+
+            if (IniSettings.IntegerScaledClient.Value != chkIntegerScaledClient.Checked)
+                restartRequired = true;
+
+            IniSettings.IntegerScaledClient.Value = chkIntegerScaledClient.Checked;
 
             restartRequired = restartRequired || IniSettings.ClientTheme != (string)ddClientTheme.SelectedItem.Tag;
 

--- a/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
@@ -86,7 +86,7 @@ namespace DTAConfig.OptionPanels
                 var maximumIngameResolution = new ScreenResolution(ClientConfiguration.Instance.MaximumIngameWidth, ClientConfiguration.Instance.MaximumIngameHeight);
 
 #if XNA
-                if (!ScreenResolution.HiDefLimitResolution.Fit(maximumIngameResolution))
+                if (!ScreenResolution.HiDefLimitResolution.Fits(maximumIngameResolution))
                     maximumIngameResolution = ScreenResolution.HiDefLimitResolution;
 #endif
 
@@ -768,6 +768,8 @@ namespace DTAConfig.OptionPanels
             if (clientRes.Width != IniSettings.ClientResolutionX.Value ||
                 clientRes.Height != IniSettings.ClientResolutionY.Value)
                 restartRequired = true;
+
+            // TODO: since DTAConfig must not rely on DXMainClient, we can't notify the client to dynamically change the resolution or togging borderless windowed mode. Thus, we need to restart the client as a workaround.
 
             (IniSettings.ClientResolutionX.Value, IniSettings.ClientResolutionY.Value) = clientRes;
 

--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -365,8 +365,6 @@ namespace DTAClient.DXGUI
         {
             var clientConfiguration = ClientConfiguration.Instance;
 
-            wm.IntegerScalingOnly = integerScale;
-
             (int desktopWidth, int desktopHeight) = ScreenResolution.SafeMaximumResolution;
 
             if (desktopWidth >= windowWidth && desktopHeight >= windowHeight)
@@ -398,16 +396,32 @@ namespace DTAClient.DXGUI
 
                 double ratio = xRatio > yRatio ? yRatio : xRatio;
 
-                if (720 <= clientConfiguration.MaximumRenderHeight && clientConfiguration.MaximumRenderHeight < 768)
+                // Special rule for 1360x768 and 1366x768                
+                if ((windowWidth == 1366 || windowWidth == 1360) && windowHeight == 768)
                 {
                     // Most client interface has been designed for 1280x720 or 1280x800.
                     // 1280x720 upscaled to 1366x768 doesn't look great, so we allow players with 1366x768 to use their native resolution with small black bars on the sides
                     // This behavior is enforced even if IntegerScaledClient is turned off.
-                    if ((windowWidth == 1366 || windowWidth == 1360) && windowHeight == 768)
-                    {
-                        renderResolutionX = windowWidth;
-                        renderResolutionY = windowHeight;
-                    }
+                    renderResolutionX = windowWidth;
+                    renderResolutionY = windowHeight;
+                }
+
+                // Special rule: if 1280x720 is a valid render resolution, we allow 1.5x scaling for 1920x1080.
+                if (windowWidth == 1920 && windowHeight == 1080
+                    && 1280 >= clientConfiguration.MinimumRenderWidth && 1280 <= clientConfiguration.MaximumRenderWidth
+                    && 720 >= clientConfiguration.MinimumRenderHeight && 720 <= clientConfiguration.MaximumRenderHeight)
+                {
+                    renderResolutionX = 1280;
+                    renderResolutionY = 720;
+                }
+
+                // Special rule: if 1280x800 is a valid render resolution, we allow 1.5x scaling for 1920x1200.
+                if (windowWidth == 1920 && windowHeight == 1200
+                    && 1280 >= clientConfiguration.MinimumRenderWidth && 1280 <= clientConfiguration.MaximumRenderWidth
+                    && 800 >= clientConfiguration.MinimumRenderHeight && 800 <= clientConfiguration.MaximumRenderHeight)
+                {
+                    renderResolutionX = 1280;
+                    renderResolutionY = 800;
                 }
 
                 if (ratio > 1.0)
@@ -480,6 +494,7 @@ namespace DTAClient.DXGUI
                 wm.CenterOnScreen();
 
             Logger.Log("Setting render resolution to " + renderResolutionX + "x" + renderResolutionY + ". Integer scaling: " + integerScale);
+            wm.IntegerScalingOnly = integerScale;
             wm.SetRenderResolution(renderResolutionX, renderResolutionY);
         }
     }

--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -424,9 +424,9 @@ namespace DTAClient.DXGUI
                     renderResolutionY = 800;
                 }
 
+                // Check whether we could integer-scale our client window
                 if (ratio > 1.0)
                 {
-                    // Check whether we could sharp-scale our client window
                     for (int i = 2; i <= ScreenResolution.MAX_INT_SCALE; i++)
                     {
                         int sharpScaleRenderResX = windowWidth / i;

--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -48,7 +48,7 @@ namespace DTAClient.DXGUI
             graphics.HardwareModeSwitch = false;
 
             // Enable HiDef on a large monitor.
-            if (!ScreenResolution.HiDefLimitResolution.Fit(ScreenResolution.DesktopResolution))
+            if (!ScreenResolution.HiDefLimitResolution.Fits(ScreenResolution.DesktopResolution))
             {
                 // Enabling HiDef profile drops legacy GPUs not supporting DirectX 10.
                 // In practice, it's recommended to have a DirectX 11 capable GPU.
@@ -153,10 +153,37 @@ namespace DTAClient.DXGUI
             };
 
             SetGraphicsMode(wm);
-#if WINFORMS
 
+#if WINFORMS
             wm.SetIcon(SafePath.CombineFilePath(ProgramConstants.GetBaseResourcePath(), "clienticon.ico"));
             wm.SetControlBox(true);
+
+            // Enable resizable window for non-borderless windowed client
+            if (!UserINISettings.Instance.BorderlessWindowedClient)
+            {
+                wm.SetFormBorderStyle(FormBorderStyle.Sizable);
+                wm.SetMaximizeBox(true);
+
+                //// Automatically update render resolution when the window size changes
+                //// Disabled for now. It does not work as expected.
+                //// To fix this, we need to make every window and control to be able to handle window size changes.
+                //// This is not a trivial work and does not gain much benefit since the minimum render resolution and the maximum one are close.
+                //// Example: https://github.com/Rampastring/WorldAlteringEditor/blob/71d9bd0ed9b9843d5dc15de14005f86b18e5465c/src/TSMapEditor/UI/Controls/INItializableWindow.cs#L98
+
+                //ScreenResolution lastWindowSizeCaptured = new(wm.Game.Window.ClientBounds);
+
+                //wm.WindowSizeChangedByUser += (sender, e) =>
+                //{
+                //    ScreenResolution currentWindowSize = new(wm.Game.Window.ClientBounds);
+
+                //    if (currentWindowSize != lastWindowSizeCaptured)
+                //    {
+                //        Logger.Log($"Window size changed from {lastWindowSizeCaptured} to {currentWindowSize}.");
+                //        lastWindowSizeCaptured = currentWindowSize;
+                //        SetGraphicsMode(wm, currentWindowSize.Width, currentWindowSize.Height, centerOnScreen: false);
+                //    }
+                //};
+            }
 #endif
 
             wm.Cursor.Textures = new Texture2D[]
@@ -311,14 +338,34 @@ namespace DTAClient.DXGUI
         /// TODO move to some helper class?
         /// </summary>
         /// <param name="wm">The window manager</param>
-        public static void SetGraphicsMode(WindowManager wm)
+        /// <param name="centerOnScreen">Whether to center the client window on the screen</param>
+        public static void SetGraphicsMode(WindowManager wm, bool centerOnScreen = true)
         {
-            var clientConfiguration = ClientConfiguration.Instance;
-
             int windowWidth = UserINISettings.Instance.ClientResolutionX;
             int windowHeight = UserINISettings.Instance.ClientResolutionY;
 
+            SetGraphicsMode(wm, windowWidth, windowHeight, centerOnScreen);
+        }
+
+        /// <inheritdoc cref="SetGraphicsMode(WindowManager, bool)"/>
+        /// <param name="windowWidth">The viewport width</param>
+        /// <param name="windowHeight">The viewport height</param>
+        public static void SetGraphicsMode(WindowManager wm, int windowWidth, int windowHeight, bool centerOnScreen = true)
+        {
             bool borderlessWindowedClient = UserINISettings.Instance.BorderlessWindowedClient;
+            bool integerScale = UserINISettings.Instance.IntegerScaledClient;
+
+            SetGraphicsMode(wm, windowWidth, windowHeight, borderlessWindowedClient, integerScale, centerOnScreen);
+        }
+
+        /// <inheritdoc cref="SetGraphicsMode(WindowManager, int, int, bool)"/>
+        /// <param name="borderlessWindowedClient">Whether to use borderless windowed mode</param>
+        /// <param name="integerScale">Whether to use integer scaling</param>
+        public static void SetGraphicsMode(WindowManager wm, int windowWidth, int windowHeight, bool borderlessWindowedClient, bool integerScale, bool centerOnScreen = true)
+        {
+            var clientConfiguration = ClientConfiguration.Instance;
+
+            wm.IntegerScalingOnly = integerScale;
 
             (int desktopWidth, int desktopHeight) = ScreenResolution.SafeMaximumResolution;
 
@@ -338,53 +385,78 @@ namespace DTAClient.DXGUI
             int renderResolutionX = 0;
             int renderResolutionY = 0;
 
-            int initialXRes = Math.Max(windowWidth, clientConfiguration.MinimumRenderWidth);
-            initialXRes = Math.Min(initialXRes, clientConfiguration.MaximumRenderWidth);
-
-            int initialYRes = Math.Max(windowHeight, clientConfiguration.MinimumRenderHeight);
-            initialYRes = Math.Min(initialYRes, clientConfiguration.MaximumRenderHeight);
-
-            double xRatio = (windowWidth) / (double)initialXRes;
-            double yRatio = (windowHeight) / (double)initialYRes;
-
-            double ratio = xRatio > yRatio ? yRatio : xRatio;
-
-            if ((windowWidth == 1366 || windowWidth == 1360) && windowHeight == 768)
+            if (!integerScale || windowWidth < clientConfiguration.MinimumRenderWidth || windowHeight < clientConfiguration.MinimumRenderHeight)
             {
-                renderResolutionX = windowWidth;
-                renderResolutionY = windowHeight;
-            }
+                int initialXRes = Math.Max(windowWidth, clientConfiguration.MinimumRenderWidth);
+                initialXRes = Math.Min(initialXRes, clientConfiguration.MaximumRenderWidth);
 
-            if (ratio > 1.0)
-            {
-                // Check whether we could sharp-scale our client window
-                for (int i = 2; i <= ScreenResolution.MAX_INT_SCALE; i++)
+                int initialYRes = Math.Max(windowHeight, clientConfiguration.MinimumRenderHeight);
+                initialYRes = Math.Min(initialYRes, clientConfiguration.MaximumRenderHeight);
+
+                double xRatio = (windowWidth) / (double)initialXRes;
+                double yRatio = (windowHeight) / (double)initialYRes;
+
+                double ratio = xRatio > yRatio ? yRatio : xRatio;
+
+                if (720 <= clientConfiguration.MaximumRenderHeight && clientConfiguration.MaximumRenderHeight < 768)
                 {
-                    int sharpScaleRenderResX = windowWidth / i;
-                    int sharpScaleRenderResY = windowHeight / i;
-
-                    if (sharpScaleRenderResX >= clientConfiguration.MinimumRenderWidth &&
-                        sharpScaleRenderResX <= clientConfiguration.MaximumRenderWidth &&
-                        sharpScaleRenderResY >= clientConfiguration.MinimumRenderHeight &&
-                        sharpScaleRenderResY <= clientConfiguration.MaximumRenderHeight)
+                    // Most client interface has been designed for 1280x720 or 1280x800.
+                    // 1280x720 upscaled to 1366x768 doesn't look great, so we allow players with 1366x768 to use their native resolution with small black bars on the sides
+                    // This behavior is enforced even if IntegerScaledClient is turned off.
+                    if ((windowWidth == 1366 || windowWidth == 1360) && windowHeight == 768)
                     {
-                        renderResolutionX = sharpScaleRenderResX;
-                        renderResolutionY = sharpScaleRenderResY;
-                        break;
+                        renderResolutionX = windowWidth;
+                        renderResolutionY = windowHeight;
                     }
                 }
+
+                if (ratio > 1.0)
+                {
+                    // Check whether we could sharp-scale our client window
+                    for (int i = 2; i <= ScreenResolution.MAX_INT_SCALE; i++)
+                    {
+                        int sharpScaleRenderResX = windowWidth / i;
+                        int sharpScaleRenderResY = windowHeight / i;
+
+                        if (sharpScaleRenderResX >= clientConfiguration.MinimumRenderWidth &&
+                            sharpScaleRenderResX <= clientConfiguration.MaximumRenderWidth &&
+                            sharpScaleRenderResY >= clientConfiguration.MinimumRenderHeight &&
+                            sharpScaleRenderResY <= clientConfiguration.MaximumRenderHeight)
+                        {
+                            renderResolutionX = sharpScaleRenderResX;
+                            renderResolutionY = sharpScaleRenderResY;
+                            break;
+                        }
+                    }
+                }
+
+                if (renderResolutionX == 0 || renderResolutionY == 0)
+                {
+                    renderResolutionX = initialXRes;
+                    renderResolutionY = initialYRes;
+
+                    if (ratio == xRatio)
+                        renderResolutionY = (int)(windowHeight / ratio);
+                }
             }
-
-            if (renderResolutionX == 0 || renderResolutionY == 0)
+            else
             {
-                renderResolutionX = initialXRes;
-                renderResolutionY = initialYRes;
+                // Compute integer scale ratio using minimum render resolution
+                // Note: this means we prefer larger scale ratio than render resolution.
+                // This policy works best when maximum and minimum render resolution are close.
+                int xScale = windowWidth / clientConfiguration.MinimumRenderWidth;
+                int yScale = windowHeight / clientConfiguration.MinimumRenderHeight;
+                int scale = Math.Min(xScale, yScale);
 
-                if (ratio == xRatio)
-                    renderResolutionY = (int)(windowHeight / ratio);
+                // Compute render resolution
+                renderResolutionX = Math.Min(clientConfiguration.MaximumRenderWidth,
+                    clientConfiguration.MinimumRenderWidth + (windowWidth - clientConfiguration.MinimumRenderWidth * scale) / scale);
+                renderResolutionY = Math.Min(clientConfiguration.MaximumRenderHeight,
+                    clientConfiguration.MinimumRenderHeight + (windowHeight - clientConfiguration.MinimumRenderHeight * scale) / scale);
             }
 
             wm.SetBorderlessMode(borderlessWindowedClient);
+
 #if !XNA
 
             if (borderlessWindowedClient)
@@ -404,7 +476,10 @@ namespace DTAClient.DXGUI
             }
 
 #endif
-            wm.CenterOnScreen();
+            if (centerOnScreen)
+                wm.CenterOnScreen();
+
+            Logger.Log("Setting render resolution to " + renderResolutionX + "x" + renderResolutionY + ". Integer scaling: " + integerScale);
             wm.SetRenderResolution(renderResolutionX, renderResolutionY);
         }
     }

--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -444,6 +444,7 @@ namespace DTAClient.DXGUI
                     }
                 }
 
+                // No special rules are triggered. Just zoom the client to the window size with minimal black bars.
                 if (renderResolutionX == 0 || renderResolutionY == 0)
                 {
                     renderResolutionX = initialXRes;

--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -158,8 +158,8 @@ namespace DTAClient.DXGUI
             wm.SetIcon(SafePath.CombineFilePath(ProgramConstants.GetBaseResourcePath(), "clienticon.ico"));
             wm.SetControlBox(true);
 
-            // Enable resizable window for non-borderless windowed client
-            if (!UserINISettings.Instance.BorderlessWindowedClient)
+            // Enable resizable window for non-borderless windowed client, if integer scaling is enabled
+            if (!UserINISettings.Instance.BorderlessWindowedClient && UserINISettings.Instance.IntegerScaledClient)
             {
                 wm.SetFormBorderStyle(FormBorderStyle.Sizable);
                 wm.SetMaximizeBox(true);

--- a/DXMainClient/DXMainClient.csproj
+++ b/DXMainClient/DXMainClient.csproj
@@ -9,11 +9,13 @@
     <Description>CnCNet Main Client Library</Description>
     <RootNamespace>DTAClient</RootNamespace>
     <ApplicationIcon>clienticon.ico</ApplicationIcon>
-    <ApplicationHighDpiMode Condition="'$(Engine)' != 'UniversalGL'">PerMonitorV2</ApplicationHighDpiMode>
+    <ApplicationHighDpiMode Condition="'$(Engine)' == 'UniversalGL' OR '$(Engine)' == 'WindowsGL'">SystemAware</ApplicationHighDpiMode>
+    <ApplicationHighDpiMode Condition="'$(Engine)' != 'UniversalGL' AND '$(Engine)' != 'WindowsGL'">PerMonitorV2</ApplicationHighDpiMode>
     <AssemblyName Condition="'$(Engine)' == 'WindowsDX'">clientdx</AssemblyName>
     <AssemblyName Condition="'$(Engine)' == 'UniversalGL' Or '$(Engine)' == 'WindowsGL'">clientogl</AssemblyName>
     <AssemblyName Condition="'$(Engine)' == 'WindowsXNA'">clientxna</AssemblyName>
-    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <ApplicationManifest Condition="'$(Engine)' == 'UniversalGL' OR '$(Engine)' == 'WindowsGL'">app.SystemAware.manifest</ApplicationManifest>
+    <ApplicationManifest Condition="'$(Engine)' != 'UniversalGL' AND '$(Engine)' != 'WindowsGL'">app.PerMonitorV2.manifest</ApplicationManifest>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/DXMainClient/Program.cs
+++ b/DXMainClient/Program.cs
@@ -70,7 +70,11 @@ namespace DTAClient
 #else
 
 #if NETCOREAPP3_0_OR_GREATER
+#if GL
+            System.Windows.Forms.Application.SetHighDpiMode(System.Windows.Forms.HighDpiMode.SystemAware);
+#else
             System.Windows.Forms.Application.SetHighDpiMode(System.Windows.Forms.HighDpiMode.PerMonitorV2);
+#endif
 #endif
 
             System.Windows.Forms.Application.EnableVisualStyles();

--- a/DXMainClient/app.PerMonitorV2.manifest
+++ b/DXMainClient/app.PerMonitorV2.manifest
@@ -54,6 +54,7 @@
       <!-- See https://docs.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
+
       <!-- Makes the application long-path aware. See https://docs.microsoft.com/windows/win32/fileio/maximum-file-path-limitation -->
       <!-- <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware> -->
     </windowsSettings>
@@ -73,4 +74,3 @@
     </dependentAssembly>
   </dependency>
 </assembly>
-

--- a/DXMainClient/app.SystemAware.manifest
+++ b/DXMainClient/app.SystemAware.manifest
@@ -1,0 +1,75 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity processorArchitecture="*" version="1.0.0.0" name="DXMainClient" type="win32"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+             If you want to change the Windows User Account Control level replace the 
+             requestedExecutionLevel node with one of the following.
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            Specifying requestedExecutionLevel element will disable file and registry virtualization. 
+            Remove this element if your application requires this virtualization for backwards
+            compatibility.
+        -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+
+      <!-- Windows Vista -->
+      <!-- <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" /> -->
+
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
+
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
+
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
+
+      <!-- Windows 10 & 11 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+
+    </application>
+  </compatibility>
+	
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
+      <!-- See https://docs.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+
+      <!-- Makes the application long-path aware. See https://docs.microsoft.com/windows/win32/fileio/maximum-file-path-limitation -->
+      <!-- <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware> -->
+    </windowsSettings>
+  </application>
+
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <RampastringXNAUIVersion>2.3.20</RampastringXNAUIVersion>
+    <RampastringXNAUIVersion>2.3.22</RampastringXNAUIVersion>
     <DotnetLibrariesVersion>8.0.0</DotnetLibrariesVersion>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
This PR:
1. Adds integer scaling support for rendering the client. This feature is by default turned off.
2. Makes the client window resizable for DX and XNA builds if integer scaling is turned **ON**.
3. Improves 1.5x scaling for 1920x1080/1920x1200 if integer scaling is turned **OFF**.
4. Introduces some default options that can be defined in `[UserDefaults]` section in `ClientDefinitions.ini` file by modders.
5. Downgrades the DPI awareness from PerMonitorV2 to SystemAware for OGL builds to prevent weird GL window resizing when moving the client window between two monitors with different DPI settings. DX and XNA builds stay in PerMonitorV2. UGL build stays in SystemAware.

## Note for 3:
`1280x720` will be selected as the render resolution (if valid) if the window size is `1920x1080` (1.5x). Same for `1280x800 -> 1920x1200` (1.5x).

## Note for 2:
This PR makes the client window resizable for DX and XNA builds **if integer scaling is turned on**. Note: the render resolution is not changed upon a window resizing event. It can only be changed when client restarts itself. This should not be a big issue since the minimum and maximum render resolution are close.

## Note for 4: 

The following default options can be defined in `[UserDefaults]` section in `ClientDefinitions.ini` file by modders:
- BorderlessWindowedClient
- IntegerScaledClient
- WriteInstallationPathToRegistry

Users can override these options in user settings.

## Note for 1:

To turn on integer scaling feature, modders need to specify 
```ini
[UserDefaults]
IntegerScaledClient=true
``` 
in `ClientDefinitions.ini` file.

Users can override this option from user ini settings file (e.g., `Settings.ini`):
```ini
[Video]
IntegerScaledClient=true
```
----

Project Phantom as an example:

`ClientDefinitions.ini`:
```ini
[Settings]
MinimumRenderWidth=1280
MinimumRenderHeight=768
MaximumRenderWidth=1366
MaximumRenderHeight=800
RecommendedResolutions=1280x768,1280x800,1366x800

[UserDefaults]
IntegerScaledClient=true
```

![Snipaste_2024-09-11_02-03-51](https://github.com/user-attachments/assets/8ad07d8b-7abb-4fce-8f4e-e1595a12ce40)
![Snipaste_2024-09-11_02-04-42](https://github.com/user-attachments/assets/c5c9467b-94d3-44e3-aed2-fadc291c5eb6)
![Snipaste_2024-09-11_02-05-17](https://github.com/user-attachments/assets/b37a5ada-9d99-40e8-8fe2-d3cbf5d7d7ad)
![Snipaste_2024-09-11_02-06-18](https://github.com/user-attachments/assets/42625591-504e-4f3e-8b7d-ecd20a891165)


## Dependencies:

Requires:

https://github.com/Rampastring/Rampastring.XNAUI/pull/34

```diff
diff --git a/Rampastring.XNAUI.csproj b/Rampastring.XNAUI.csproj
index b4a94f6..156de3a 100644
--- a/Rampastring.XNAUI.csproj
+++ b/Rampastring.XNAUI.csproj
@@ -151,4 +151,9 @@
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.7" />
     <PackageReference Include="TextCopy" Version="6.2.1" />
   </ItemGroup>
+       <PropertyGroup>
+               <VersionPrefix>2.3.21</VersionPrefix>
+               <VersionSuffix>private-intscale-061a412</VersionSuffix>
+       </PropertyGroup>
+
 </Project>
```

