### PR TITLE
Implement forced team start mappings

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -1312,11 +1312,11 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                     pInfo.TeamId = 1;
             }
 
-            var teamStartMappings = new List<TeamStartMapping>(0);
-            if (PlayerExtraOptionsPanel != null)
-            {
+            List<TeamStartMapping> teamStartMappings = [];
+            if (GameMode.ForceTeamStartMappings)
+                teamStartMappings = GameMode.TeamStartMappings;
+            else if (PlayerExtraOptionsPanel != null)
                 teamStartMappings = PlayerExtraOptionsPanel.GetTeamStartMappings();
-            }
 
             PlayerHouseInfo[] houseInfos = Randomize(teamStartMappings);
 
@@ -2205,7 +2205,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             disableGameOptionUpdateBroadcast = false;
 
-            PlayerExtraOptionsPanel?.UpdateForMap(Map);
+            PlayerExtraOptionsPanel?.UpdateForMap(GameModeMap);
         }
 
         private void ApplyForcedCheckBoxOptions(List<GameLobbyCheckBox> optionList,

--- a/DXMainClient/Domain/Multiplayer/GameMode.cs
+++ b/DXMainClient/Domain/Multiplayer/GameMode.cs
@@ -1,8 +1,10 @@
-﻿using ClientCore;
-using ClientCore.Extensions;
-using Rampastring.Tools;
-using System;
+﻿using System;
 using System.Collections.Generic;
+
+using ClientCore;
+using ClientCore.Extensions;
+
+using Rampastring.Tools;
 
 namespace DTAClient.Domain.Multiplayer
 {
@@ -56,6 +58,16 @@ namespace DTAClient.Domain.Multiplayer
         public bool ForceNoTeams { get; private set; }
 
         /// <summary>
+        /// If set, given start mapping 'TeamStartMappings' is forced on this game mode.
+        /// </summary>
+        public bool ForceTeamStartMappings { get; private set; }
+
+        /// <summary>
+        /// If 'ForceTeamStartMappings' is set, this variable indicates the start mapping being forced on this game mode.
+        /// </summary>
+        public List<TeamStartMapping> TeamStartMappings { get; private set; } = [];
+
+        /// <summary>
         /// List of side indices players cannot select in this game mode.
         /// </summary>
         public List<int> DisallowedPlayerSides = new List<int>();
@@ -88,6 +100,8 @@ namespace DTAClient.Domain.Multiplayer
             MultiplayerOnly = forcedOptionsIni.GetBooleanValue(Name, "MultiplayerOnly", false);
             HumanPlayersOnly = forcedOptionsIni.GetBooleanValue(Name, "HumanPlayersOnly", false);
             ForceRandomStartLocations = forcedOptionsIni.GetBooleanValue(Name, "ForceRandomStartLocations", false);
+            ForceTeamStartMappings = forcedOptionsIni.GetBooleanValue(Name, "ForceTeamStartMappings", false);
+            TeamStartMappings = TeamStartMapping.FromListString(forcedOptionsIni.GetStringValue(Name, "TeamStartMappings", string.Empty));
             ForceNoTeams = forcedOptionsIni.GetBooleanValue(Name, "ForceNoTeams", false);
             MinPlayersOverride = forcedOptionsIni.GetIntValue(Name, "MinPlayersOverride", -1);
             forcedOptionsSection = forcedOptionsIni.GetStringValue(Name, "ForcedOptions", string.Empty);


### PR DESCRIPTION
This PR added a forced team start mapping for game modes such as a 2v2 mode.

It added two settings for a game mode:
- ForceTeamStartMappings
- TeamStartMappings

Example in `MPMaps.ini` file:
```ini
[Tournament 2v2]
CustomIniPath=INI\Tournament 2v2.ini
ForcedOptions=Tournament 2v2ForcedOptions
MinPlayersOverride=4
ForceNoTeams=false
ForceTeamStartMappings=true
TeamStartMappings=A,B,A,B
```

`A,B,A,B` enforces Player 1 & 3 is allying against 2 & 4

Example screenshot:
![Snipaste_2024-09-17_19-10-10](https://github.com/user-attachments/assets/069cd730-de56-40be-92ca-2094d510f3fd)

----

Note: originally in commit 4cf9b33b03795eb51e445b4907927cb69d82c4bc, `RefreshTeamStartMappingPresets()` was called in each for loop iteration. [Link](https://github.com/CnCNet/xna-cncnet-client/commit/4cf9b33b03795eb51e445b4907927cb69d82c4bc#diff-0f663cd55e1e258ba5e528a223295e0a889038a00d66fb6e1b1e42369a59e253R118). This is changed to call it only once after the loop.
