### PR TITLE
Upgrade GitVersion.MsBuild to 5.12.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
     <DotnetLibrariesVersion>8.0.0</DotnetLibrariesVersion>
   </PropertyGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="GitVersion.MsBuild" Version="5.11.1" />
+    <GlobalPackageReference Include="GitVersion.MsBuild" Version="5.12.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="DiscordRichPresence" Version="1.1.3.18" />


### PR DESCRIPTION
Sometimes GitVersion causes GitHub action fails occasionally, for example, https://github.com/CnCNet/xna-cncnet-client/actions/runs/11033021431/job/30643231232?pr=557

```
C:\Users\runneradmin\.nuget\packages\gitversion.msbuild\5.11.1\tools\GitVersion.MsBuild.targets(13,9): error : IOException: The process cannot access the file 'D:\a\_temp\_runner_file_commands\set_env_1eb70c4f-ee40-4336-baf6-ec520a3b333f' because it is being used by another process. [D:\a\xna-cncnet-client\xna-cncnet-client\ClientUpdater\ClientUpdater.csproj::TargetFramework=net48]
```

The last version that supports .NET Framework 4.8 is `5.12.0`, while we are using `5.11.1`. Not sure whether this issue is fully solved in `5.12.0`, but upgrading to this last version released one and a half year ago should not bring problems.