### PR TITLE
Upgrade SixLabors.ImageSharp to 2.1.9

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,7 +24,7 @@
     <PackageVersion Include="Rampastring.XNAUI.WindowsGL.Debug" Version="$(RampastringXNAUIVersion)" />
     <PackageVersion Include="Rampastring.XNAUI.UniversalGL.Debug" Version="$(RampastringXNAUIVersion)" />
     <PackageVersion Include="Rampastring.XNAUI.WindowsXNA.Debug" Version="$(RampastringXNAUIVersion)" />
-    <PackageVersion Include="SixLabors.ImageSharp" Version="2.1.7" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="2.1.9" />
     <PackageVersion Include="System.DirectoryServices" Version="$(DotnetLibrariesVersion)" />
     <PackageVersion Include="System.Management" Version="$(DotnetLibrariesVersion)" />
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="$(DotnetLibrariesVersion)" />


### PR DESCRIPTION
As warned by MSBuild, ImageSharp 2.1.7 has the following 4 vulnerabilities, especially the out-of-bounds write.

> D:\a\xna-cncnet-client\xna-cncnet-client\DXMainClient\DXMainClient.csproj : warning NU1902: Package 'SixLabors.ImageSharp' 2.1.7 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-5x7m-6737-26cr
> D:\a\xna-cncnet-client\xna-cncnet-client\DXMainClient\DXMainClient.csproj : warning NU1903: Package 'SixLabors.ImageSharp' 2.1.7 has a known high severity vulnerability, https://github.com/advisories/GHSA-63p8-c4ww-9cg7
> D:\a\xna-cncnet-client\xna-cncnet-client\DXMainClient\DXMainClient.csproj : warning NU1902: Package 'SixLabors.ImageSharp' 2.1.7 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-g85r-6x2q-45w7
> D:\a\xna-cncnet-client\xna-cncnet-client\DXMainClient\DXMainClient.csproj : warning NU1902: Package 'SixLabors.ImageSharp' 2.1.7 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-qxrv-gp6x-rc23