### PR TITLE
Disable generating XML documentation files

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -58,7 +58,6 @@
   <PropertyGroup Condition="'$(MSBuildProjectName)' == 'ClientUpdater' OR '$(MSBuildProjectName)' == 'SecondStageUpdater'">
     <TargetFrameworks>net8.0;net48</TargetFrameworks>
     <Platforms>AnyCPU</Platforms>
-    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
   <!-- For Constants -->


### PR DESCRIPTION
Currently, `ClientUpdater.xml` and `SecondStageUpdater.xml` are generated when building the client. This behavior was untouched when we merge `ClientUpdater` repo into this repo. However, since these two projects are tightly coupled with the client, same as `ClientCore` does, there should be no need to retain these XML files.