### PR TITLE
Refactor calculating file hashes

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetGameLoadingLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetGameLoadingLobby.cs
@@ -230,7 +230,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
         public void OnJoined()
         {
             FileHashCalculator fhc = new FileHashCalculator();
-            fhc.CalculateHashes(gameModes);
+            fhc.CalculateHashes();
 
             if (IsHost)
             {

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -257,7 +257,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         public void OnJoined()
         {
             FileHashCalculator fhc = new FileHashCalculator();
-            fhc.CalculateHashes(GameModeMaps.GameModes);
+            fhc.CalculateHashes();
 
             gameFilesHash = fhc.GetCompleteHash();
 
@@ -1299,7 +1299,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             AddNotice("Starting game...".L10N("Client:Main:StartingGame"));
 
             FileHashCalculator fhc = new FileHashCalculator();
-            fhc.CalculateHashes(GameModeMaps.GameModes);
+            fhc.CalculateHashes();
 
             if (gameFilesHash != fhc.GetCompleteHash())
             {

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
@@ -150,7 +150,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 this.client.GetStream().Flush();
 
                 var fhc = new FileHashCalculator();
-                fhc.CalculateHashes(GameModeMaps.GameModes);
+                fhc.CalculateHashes();
                 localFileHash = fhc.GetCompleteHash();
 
                 RefreshMapSelectionUI();
@@ -171,7 +171,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         public void PostJoin()
         {
             var fhc = new FileHashCalculator();
-            fhc.CalculateHashes(GameModeMaps.GameModes);
+            fhc.CalculateHashes();
             SendMessageToHost(FILE_HASH_COMMAND + " " + fhc.GetCompleteHash());
             ResetAutoReadyCheckbox();
         }

--- a/DXMainClient/DXGUI/Multiplayer/LANGameLoadingLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/LANGameLoadingLobby.cs
@@ -126,7 +126,7 @@ namespace DTAClient.DXGUI.Multiplayer
                 this.client.GetStream().Flush();
 
                 var fhc = new FileHashCalculator();
-                fhc.CalculateHashes(gameModes);
+                fhc.CalculateHashes();
                 localFileHash = fhc.GetCompleteHash();
             }
             else
@@ -145,7 +145,7 @@ namespace DTAClient.DXGUI.Multiplayer
         public void PostJoin()
         {
             var fhc = new FileHashCalculator();
-            fhc.CalculateHashes(gameModes);
+            fhc.CalculateHashes();
             SendMessageToHost(FILE_HASH_COMMAND + " " + fhc.GetCompleteHash());
             UpdateDiscordPresence(true);
         }

--- a/DXMainClient/Online/FileHashCalculator.cs
+++ b/DXMainClient/Online/FileHashCalculator.cs
@@ -11,8 +11,6 @@ using ClientCore.I18N;
 
 using Rampastring.Tools;
 
-using Utilities = Rampastring.Tools.Utilities;
-
 namespace DTAClient.Online
 {
     public class FileHashCalculator

--- a/DXMainClient/Online/FileHashCalculator.cs
+++ b/DXMainClient/Online/FileHashCalculator.cs
@@ -20,7 +20,7 @@ namespace DTAClient.Online
 
         private static readonly IReadOnlyList<string> knownTextFileExtensions = [".txt", ".ini", ".json", ".xml"];
 
-        private string[] fileNamesToCheck = new string[]
+        private static readonly IReadOnlyList<string> fileNamesToCheck = new string[]
         {
 #if ARES
             "Ares.dll",

--- a/DXMainClient/Online/FileHashCalculator.cs
+++ b/DXMainClient/Online/FileHashCalculator.cs
@@ -82,37 +82,37 @@ namespace DTAClient.Online
         {
             FileHashes fh = new()
             {
-                GameOptionsHash = Utilities.CalculateSHA1ForFile(SafePath.CombineFilePath(ProgramConstants.GamePath, ProgramConstants.BASE_RESOURCE_PATH, "GameOptions.ini")),
-                ClientDXHash = Utilities.CalculateSHA1ForFile(SafePath.CombineFilePath(ProgramConstants.GetBaseResourcePath(), "clientdx.exe")),
-                ClientXNAHash = Utilities.CalculateSHA1ForFile(SafePath.CombineFilePath(ProgramConstants.GetBaseResourcePath(), "clientxna.exe")),
-                ClientOGLHash = Utilities.CalculateSHA1ForFile(SafePath.CombineFilePath(ProgramConstants.GetBaseResourcePath(), "clientogl.exe")),
+                GameOptionsHash = CalculateSHA1ForFile(SafePath.CombineFilePath(ProgramConstants.GamePath, ProgramConstants.BASE_RESOURCE_PATH, "GameOptions.ini")),
+                ClientDXHash = CalculateSHA1ForFile(SafePath.CombineFilePath(ProgramConstants.GetBaseResourcePath(), "clientdx.exe")),
+                ClientXNAHash = CalculateSHA1ForFile(SafePath.CombineFilePath(ProgramConstants.GetBaseResourcePath(), "clientxna.exe")),
+                ClientOGLHash = CalculateSHA1ForFile(SafePath.CombineFilePath(ProgramConstants.GetBaseResourcePath(), "clientogl.exe")),
                 ClientDXNET8Hash = string.Empty,
                 ClientXNANET8Hash = string.Empty,
                 ClientOGLNET8Hash = string.Empty,
                 ClientUGLNET8Hash = string.Empty,
                 GameExeHash = calculateGameExeHash ?
-                Utilities.CalculateSHA1ForFile(SafePath.CombineFilePath(ProgramConstants.GamePath, ClientConfiguration.Instance.GetGameExecutableName())) : string.Empty,
-                LauncherExeHash = Utilities.CalculateSHA1ForFile(SafePath.CombineFilePath(ProgramConstants.GamePath, ClientConfiguration.Instance.GameLauncherExecutableName)),
-                MPMapsHash = Utilities.CalculateSHA1ForFile(SafePath.CombineFilePath(ProgramConstants.GamePath, ClientConfiguration.Instance.MPMapsIniPath)),
-                FHCConfigHash = Utilities.CalculateSHA1ForFile(SafePath.CombineFilePath(ProgramConstants.BASE_RESOURCE_PATH, CONFIGNAME)),
+                CalculateSHA1ForFile(SafePath.CombineFilePath(ProgramConstants.GamePath, ClientConfiguration.Instance.GetGameExecutableName())) : string.Empty,
+                LauncherExeHash = CalculateSHA1ForFile(SafePath.CombineFilePath(ProgramConstants.GamePath, ClientConfiguration.Instance.GameLauncherExecutableName)),
+                MPMapsHash = CalculateSHA1ForFile(SafePath.CombineFilePath(ProgramConstants.GamePath, ClientConfiguration.Instance.MPMapsIniPath)),
+                FHCConfigHash = CalculateSHA1ForFile(SafePath.CombineFilePath(ProgramConstants.BASE_RESOURCE_PATH, CONFIGNAME)),
             };
 
             // .NET 8 hashes are optional
             FileInfo fileDX8 = SafePath.GetFile(ProgramConstants.GetBaseResourcePath(), "BinariesNET8", "Windows", "clientdx.dll");
             if (fileDX8.Exists)
-                fh.ClientDXNET8Hash = Utilities.CalculateSHA1ForFile(fileDX8.FullName);
+                fh.ClientDXNET8Hash = CalculateSHA1ForFile(fileDX8.FullName);
 
             FileInfo fileXNA8 = SafePath.GetFile(ProgramConstants.GetBaseResourcePath(), "BinariesNET8", "XNA", "clientxna.dll");
             if (fileXNA8.Exists)
-                fh.ClientXNANET8Hash = Utilities.CalculateSHA1ForFile(fileXNA8.FullName);
+                fh.ClientXNANET8Hash = CalculateSHA1ForFile(fileXNA8.FullName);
 
             FileInfo fileOGL8 = SafePath.GetFile(ProgramConstants.GetBaseResourcePath(), "BinariesNET8", "OpenGL", "clientogl.dll");
             if (fileOGL8.Exists)
-                fh.ClientOGLNET8Hash = Utilities.CalculateSHA1ForFile(fileOGL8.FullName);
+                fh.ClientOGLNET8Hash = CalculateSHA1ForFile(fileOGL8.FullName);
 
             FileInfo fileUGL8 = SafePath.GetFile(ProgramConstants.GetBaseResourcePath(), "BinariesNET8", "UniversalGL", "clientogl.dll");
             if (fileUGL8.Exists)
-                fh.ClientUGLNET8Hash = Utilities.CalculateSHA1ForFile(fileUGL8.FullName);
+                fh.ClientUGLNET8Hash = CalculateSHA1ForFile(fileUGL8.FullName);
 
             Logger.Log("Hash for " + ProgramConstants.BASE_RESOURCE_PATH + CONFIGNAME + ": " + fh.FHCConfigHash);
             Logger.Log("Hash for " + ProgramConstants.BASE_RESOURCE_PATH + "\\GameOptions.ini: " + fh.GameOptionsHash);

--- a/DXMainClient/Online/FileHashCalculator.cs
+++ b/DXMainClient/Online/FileHashCalculator.cs
@@ -20,7 +20,7 @@ namespace DTAClient.Online
 
         private static readonly IReadOnlyList<string> knownTextFileExtensions = [".txt", ".ini", ".json", ".xml"];
 
-        private static readonly IReadOnlyList<string> fileNamesToCheck = new string[]
+        private string[] fileNamesToCheck = new string[]
         {
 #if ARES
             "Ares.dll",

--- a/DXMainClient/Online/FileHashCalculator.cs
+++ b/DXMainClient/Online/FileHashCalculator.cs
@@ -1,22 +1,28 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
 using ClientCore;
 using ClientCore.I18N;
-using DTAClient.Domain.Multiplayer;
+
 using Rampastring.Tools;
+
 using Utilities = Rampastring.Tools.Utilities;
 
 namespace DTAClient.Online
 {
     public class FileHashCalculator
     {
-        private FileHashes fh;
         private const string CONFIGNAME = "FHCConfig.ini";
         private bool calculateGameExeHash = true;
 
-        string[] fileNamesToCheck = new string[]
+        private static readonly IReadOnlyList<string> knownTextFileExtensions = [".txt", ".ini", ".json", ".xml"];
+
+        private string[] fileNamesToCheck = new string[]
         {
 #if ARES
             "Ares.dll",
@@ -72,9 +78,11 @@ namespace DTAClient.Online
 
         public FileHashCalculator() => ParseConfigFile();
 
-        public void CalculateHashes(List<GameMode> gameModes)
+        private string finalHash = string.Empty;
+
+        public void CalculateHashes()
         {
-            fh = new FileHashes
+            FileHashes fh = new()
             {
                 GameOptionsHash = Utilities.CalculateSHA1ForFile(SafePath.CombineFilePath(ProgramConstants.GamePath, ProgramConstants.BASE_RESOURCE_PATH, "GameOptions.ini")),
                 ClientDXHash = Utilities.CalculateSHA1ForFile(SafePath.CombineFilePath(ProgramConstants.GetBaseResourcePath(), "clientdx.exe")),
@@ -89,7 +97,6 @@ namespace DTAClient.Online
                 LauncherExeHash = Utilities.CalculateSHA1ForFile(SafePath.CombineFilePath(ProgramConstants.GamePath, ClientConfiguration.Instance.GameLauncherExecutableName)),
                 MPMapsHash = Utilities.CalculateSHA1ForFile(SafePath.CombineFilePath(ProgramConstants.GamePath, ClientConfiguration.Instance.MPMapsIniPath)),
                 FHCConfigHash = Utilities.CalculateSHA1ForFile(SafePath.CombineFilePath(ProgramConstants.BASE_RESOURCE_PATH, CONFIGNAME)),
-                INIHashes = string.Empty
             };
 
             // .NET 8 hashes are optional
@@ -106,7 +113,7 @@ namespace DTAClient.Online
                 fh.ClientOGLNET8Hash = Utilities.CalculateSHA1ForFile(fileOGL8.FullName);
 
             FileInfo fileUGL8 = SafePath.GetFile(ProgramConstants.GetBaseResourcePath(), "BinariesNET8", "UniversalGL", "clientogl.dll");
-            if (fileUGL8.Exists) 
+            if (fileUGL8.Exists)
                 fh.ClientUGLNET8Hash = Utilities.CalculateSHA1ForFile(fileUGL8.FullName);
 
             Logger.Log("Hash for " + ProgramConstants.BASE_RESOURCE_PATH + CONFIGNAME + ": " + fh.FHCConfigHash);
@@ -126,11 +133,12 @@ namespace DTAClient.Online
             if (!string.IsNullOrEmpty(ClientConfiguration.Instance.GameLauncherExecutableName))
                 Logger.Log("Hash for " + ClientConfiguration.Instance.GameLauncherExecutableName + ": " + fh.LauncherExeHash);
 
-            foreach (string filePath in fileNamesToCheck)
+            foreach (string relativePath in fileNamesToCheck)
             {
-                fh.INIHashes = AddToStringIfFileExists(fh.INIHashes, filePath);
-                Logger.Log("Hash for " + filePath + ": " +
-                    Utilities.CalculateSHA1ForFile(SafePath.CombineFilePath(ProgramConstants.GamePath, filePath)));
+                string fullPath = SafePath.CombineFilePath(ProgramConstants.GamePath, relativePath);
+                string hash = fh.AddHashForFileIfExists(relativePath, fullPath);
+                if (!string.IsNullOrEmpty(hash))
+                    Logger.Log("Hash for " + relativePath + ": " + hash);
             }
 
             DirectoryInfo[] iniPaths =
@@ -145,15 +153,15 @@ namespace DTAClient.Online
             {
                 if (path.Exists)
                 {
-                    List<string> files = path.EnumerateFiles("*", SearchOption.AllDirectories).Select(s => s.Name).ToList();
-
-                    files.Sort(StringComparer.Ordinal);
-
-                    foreach (string filename in files)
+                    foreach (string filename in path.EnumerateFiles("*", SearchOption.AllDirectories).Select(s => s.Name))
                     {
-                        string sha1 = Utilities.CalculateSHA1ForFile(SafePath.CombineFilePath(ProgramConstants.GamePath, filename));
-                        fh.INIHashes += sha1;
-                        Logger.Log("Hash for " + filename + ": " + sha1);
+                        string fileRelativePath = SafePath.CombineFilePath(path.Name, filename);
+                        string fileFullPath = SafePath.CombineFilePath(path.FullName, filename);
+                        Debug.Assert(File.Exists(fileFullPath), $"File {fileFullPath} is supposed to but does not exist.");
+
+                        string hash = fh.AddHashForFileIfExists(fileRelativePath, fileFullPath);
+                        if (!string.IsNullOrEmpty(hash))
+                            Logger.Log("Hash for " + fileRelativePath + ": " + hash);
                     }
                 }
             }
@@ -171,53 +179,21 @@ namespace DTAClient.Online
                 {
                     foreach (TranslationGameFile tgf in translationGameFiles)
                     {
-                        string filePath = SafePath.CombineFilePath(translationFolder.FullName, tgf.Source);
-                        if (File.Exists(filePath))
-                        {
-                            string sha1 = Utilities.CalculateSHA1ForFile(filePath);
-                            fh.INIHashes += sha1;
+                        string fileRelativePath = SafePath.CombineFilePath(translationFolder.Name, tgf.Source);
+                        string fileFullPath = SafePath.CombineFilePath(translationFolder.FullName, tgf.Source);
 
-                            string fileRelativePath = filePath;
-                            if (filePath.StartsWith(ProgramConstants.GamePath))
-                                fileRelativePath = fileRelativePath.Substring(ProgramConstants.GamePath.Length).TrimStart(Path.DirectorySeparatorChar);
-
-                            Logger.Log("Hash for " + fileRelativePath + ": " + sha1);
-                        }
+                        string hash = fh.AddHashForFileIfExists(fileRelativePath, fileFullPath);
+                        if (!string.IsNullOrEmpty(hash))
+                            Logger.Log("Hash for " + fileRelativePath + ": " + hash);
                     }
                 }
             }
 
-            fh.INIHashes = Utilities.CalculateSHA1ForString(fh.INIHashes);
+            finalHash = fh.GetFinalHash();
+            Logger.Log("Complete hash: " + finalHash);
         }
 
-        string AddToStringIfFileExists(string str, string path)
-        {
-            if (File.Exists(path))
-                return str + Utilities.CalculateSHA1ForFile(SafePath.CombineFilePath(ProgramConstants.GamePath, path));
-
-            return str;
-        }
-
-        public string GetCompleteHash()
-        {
-            string str = fh.GameOptionsHash;
-            str += fh.ClientDXHash;
-            str += fh.ClientXNAHash;
-            str += fh.ClientOGLHash;
-            str += fh.ClientDXNET8Hash;
-            str += fh.ClientXNANET8Hash;
-            str += fh.ClientOGLNET8Hash;
-            str += fh.ClientUGLNET8Hash;
-            str += fh.GameExeHash;
-            str += fh.LauncherExeHash;
-            str += fh.INIHashes;
-            str += fh.MPMapsHash;
-            str += fh.FHCConfigHash;
-
-            Logger.Log("Complete hash: " + Utilities.CalculateSHA1ForString(str));
-
-            return Utilities.CalculateSHA1ForString(str);
-        }
+        public string GetCompleteHash() => finalHash;
 
         private void ParseConfigFile()
         {
@@ -238,19 +214,106 @@ namespace DTAClient.Online
             fileNamesToCheck = filenames.ToArray();
         }
 
-        private record struct FileHashes(
-            string GameOptionsHash,
-            string ClientDXHash,
-            string ClientXNAHash,
-            string ClientOGLHash,
-            string ClientDXNET8Hash,
-            string ClientXNANET8Hash,
-            string ClientOGLNET8Hash,
-            string ClientUGLNET8Hash,
-            string INIHashes,
-            string MPMapsHash,
-            string GameExeHash,
-            string LauncherExeHash,
-            string FHCConfigHash);
+        private static string NormalizePath(string path) => path.Replace('\\', '/');
+
+        private static string CalculateSHA1ForFile(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+                return string.Empty;
+
+            FileInfo file = SafePath.GetFile(path);
+            if (!file.Exists)
+                return string.Empty;
+
+            using Stream inputStream = file.OpenRead();
+
+            if (knownTextFileExtensions.Contains(file.Extension, StringComparer.InvariantCultureIgnoreCase))
+            {
+                // Normalize line endings to LF
+                UTF8Encoding utf8Encoding = new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
+
+                using StreamReader reader = new(inputStream, utf8Encoding, detectEncodingFromByteOrderMarks: false);
+                string text = reader.ReadToEnd();
+                text = text.Replace("\r\n", "\n");
+
+                byte[] bytes = utf8Encoding.GetBytes(text);
+
+                using SHA1 sha1 = SHA1.Create();
+                return BytesToString(sha1.ComputeHash(bytes));
+            }
+            else
+            {
+                using SHA1 sha1 = SHA1.Create();
+                return BytesToString(sha1.ComputeHash(inputStream));
+            }
+        }
+
+        private static string BytesToString(byte[] bytes) =>
+            BitConverter.ToString(bytes).Replace("-", string.Empty).ToLowerInvariant();
+
+        private class FileHashes()
+        {
+            public string GameOptionsHash;
+            public string ClientDXHash;
+            public string ClientXNAHash;
+            public string ClientOGLHash;
+            public string ClientDXNET8Hash;
+            public string ClientXNANET8Hash;
+            public string ClientOGLNET8Hash;
+            public string ClientUGLNET8Hash;
+            public string MPMapsHash;
+            public string GameExeHash;
+            public string LauncherExeHash;
+            public string FHCConfigHash;
+
+            public readonly SortedDictionary<string, string> AdditionalFileHashes = new(StringComparer.InvariantCultureIgnoreCase);
+
+            public string AddHashForFileIfExists(string relativePath) =>
+                AddHashForFileIfExists(relativePath, relativePath);
+
+            public string AddHashForFileIfExists(string relativePath, string filePath)
+            {
+                Debug.Assert(!relativePath.StartsWith(ProgramConstants.GamePath), $"File path {relativePath} should be a relative path.");
+
+                string hash = CalculateSHA1ForFile(filePath);
+                if (!string.IsNullOrEmpty(hash))
+                {
+                    AdditionalFileHashes[NormalizePath(relativePath)] = hash;
+                    return hash;
+                }
+                else
+                {
+                    return string.Empty;
+                }
+            }
+
+            public string GetFinalHash()
+            {
+                var sb = new StringBuilder();
+                sb.Append(GameOptionsHash);
+                sb.Append(ClientDXHash);
+                sb.Append(ClientXNAHash);
+                sb.Append(ClientOGLHash);
+                sb.Append(ClientDXNET8Hash);
+                sb.Append(ClientXNANET8Hash);
+                sb.Append(ClientOGLNET8Hash);
+                sb.Append(ClientUGLNET8Hash);
+                sb.Append(GameExeHash);
+                sb.Append(LauncherExeHash);
+                sb.Append(MPMapsHash);
+                sb.Append(FHCConfigHash);
+
+                // Append additional file hashes, ordered by key
+                foreach (string fileHash in AdditionalFileHashes.Values)
+                    sb.Append(fileHash);
+
+                // Merge hashes
+                string finalHash = sb.ToString();
+                byte[] buffer = Encoding.ASCII.GetBytes(finalHash);
+                using SHA1 sha1 = SHA1.Create();
+                byte[] hash = sha1.ComputeHash(buffer);
+                return BytesToString(hash);
+            }
+        }
     }
 }

--- a/DXMainClient/Online/FileHashCalculator.cs
+++ b/DXMainClient/Online/FileHashCalculator.cs
@@ -234,7 +234,7 @@ namespace DTAClient.Online
 
                 using StreamReader reader = new(inputStream, utf8Encoding, detectEncodingFromByteOrderMarks: false);
                 string text = reader.ReadToEnd();
-                text = text.Replace("\r\n", "\n");
+                text = text.Replace("\r\n", "\n").Trim();
 
                 byte[] bytes = utf8Encoding.GetBytes(text);
 

--- a/DXMainClient/Startup.cs
+++ b/DXMainClient/Startup.cs
@@ -146,6 +146,14 @@ namespace DTAClient
                 UserINISettings.Instance.ClientResolutionY = new IntSetting(UserINISettings.Instance.SettingsIni, UserINISettings.VIDEO, "ClientResolutionY", resolution.Height);
             }
 
+#if DEBUG
+            // Calculate hashes
+            {
+                FileHashCalculator fhc = new();
+                fhc.CalculateHashes();
+            }
+#endif
+
             gameClass.Run();
         }
 


### PR DESCRIPTION
This PR reworks the file hash calculator to:

- Fix a bug introduced in https://github.com/CnCNet/xna-cncnet-client/pull/341/ (codes [here](https://github.com/SadPencil/xna-cncnet-client/blob/6426387f1c49b8c7a777974f317aa5dacaee5984/DXMainClient/Online/FileHashCalculator.cs#L122), diff [here](https://github.com/SadPencil/xna-cncnet-client/commit/6426387f1c49b8c7a777974f317aa5dacaee5984#diff-8b0a3b31ace8601b4fae1ee40f79eff20dcaf8b0382207d36b492f7845a85681R122)), where all files in "Map Code" and "Game Options" folders are not included. This bug should be a threat for anti-cheating detection.

  TLDR: the bug is introduced because:
  ```csharp
  string folderName = @"E:\SteamLibrary";
  string fileName1 = Directory.GetFiles(folderName).First().Dump(); // "E:\SteamLibrary\libraryfolder.vdf"
  string fileName2 = new DirectoryInfo(folderName).EnumerateFiles("*").First().Name.Dump(); // "libraryfolder.vdf"
  ```
- Fix a potential bug introduced in implementing multi-language support. Files in  `ClientConfiguration.Instance.TranslationGameFiles.Where(tgf => tgf.Checked)` (these files should be checked) are not sorted, leaving the file order as uncertain, especially in cross-platform scenarios. Now, all enumerated files will be sorted with path separators normalized.
- For known text file extensions like `.ini`, when computing hashes, the client will try to normalize the difference between Windows (`\r\n` in the end of every line except for the last) and UNIX (`\n` in the end of every line).
- Remove redundancy parameter in `CalculateHashes(List<GameMode> gameModes)` that has been unused since 801bee2b39a55640055fee01cf9e86622748d102