### PR TITLE
Print detailed client version in the log

### DIFF
--- a/DXMainClient/PreStartup.cs
+++ b/DXMainClient/PreStartup.cs
@@ -91,6 +91,7 @@ namespace DTAClient
 
             Logger.Log("***Logfile for " + MainClientConstants.GAME_NAME_LONG + " client***");
             Logger.Log("Client version: " + Assembly.GetAssembly(typeof(PreStartup)).GetName().Version);
+            Logger.Log(FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion);
 
             // Log information about given startup params
             if (parameters.NoAudio)


### PR DESCRIPTION
This PR prints detailed client version ("ProductVersion") in the log, for example, `2.12.0-feat-detailed-client-version.1+9.Branch.feat-detailed-client-version.Sha.54da550909971152332380ca79fe1b732501ec3a`. Containing the git commit should be extremely helpful to minimize the mess and determine the client version if a user uses a non-release build.