### PR TITLE
Reduce default timeout to 10 seconds

### DIFF
--- a/DXMainClient/Domain/Multiplayer/CnCNet/CnCNetPlayerCountTask.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/CnCNetPlayerCountTask.cs
@@ -52,11 +52,11 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
             {
                 // Don't fetch the player count if it is explicitly disabled
                 // For example, the official CnCNet server might be unavailable/unstable in a country with Internet censorship,
-                // which causes lags in the splash screen. In the worst case, say if packets are dropped, it waits until timeouts --- 30 seconds
+                // which causes lags in the splash screen. In the worst case, say if packets are dropped, it waits until timeouts
                 if (string.IsNullOrWhiteSpace(ClientConfiguration.Instance.CnCNetPlayerCountURL))
                     return -1;
 
-                WebClient client = new WebClient();
+                WebClient client = new ExtendedWebClient();
                 Stream data = client.OpenRead(ClientConfiguration.Instance.CnCNetPlayerCountURL);
 
                 string info = string.Empty;

--- a/DXMainClient/Domain/Multiplayer/CnCNet/ExtendedWebClient.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/ExtendedWebClient.cs
@@ -8,6 +8,8 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
     /// </summary>
     class ExtendedWebClient : WebClient
     {
+        public ExtendedWebClient() : this(timeout: 10000) { }
+
         public ExtendedWebClient(int timeout)
         {
             this.timeout = timeout;

--- a/DXMainClient/Domain/Multiplayer/CnCNet/MapSharer.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/MapSharer.cs
@@ -384,9 +384,6 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
 
             using (WebClient webClient = new ExtendedWebClient(timeout: 10000))
             {
-                // TODO enable proxy support for some users
-                webClient.Proxy = null;
-
                 if (string.IsNullOrWhiteSpace(ClientConfiguration.Instance.CnCNetMapDBDownloadURL))
                 {
                     success = false;

--- a/DXMainClient/Domain/Multiplayer/CnCNet/MapSharer.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/MapSharer.cs
@@ -382,7 +382,7 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
             destinationFile.Delete();
             newFile.Delete();
 
-            using (TWebClient webClient = new TWebClient())
+            using (WebClient webClient = new ExtendedWebClient(timeout: 10000))
             {
                 // TODO enable proxy support for some users
                 webClient.Proxy = null;
@@ -455,24 +455,6 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
             public string Filename { get; set; }
             public string ContentType { get; set; }
             public Stream Stream { get; set; }
-        }
-
-        class TWebClient : WebClient
-        {
-            private int Timeout = 10000;
-
-            public TWebClient()
-            {
-                // TODO enable proxy support for some users
-                this.Proxy = null;
-            }
-
-            protected override WebRequest GetWebRequest(Uri address)
-            {
-                var webRequest = base.GetWebRequest(address);
-                webRequest.Timeout = Timeout;
-                return webRequest;
-            }
         }
     }
 }

--- a/DXMainClient/Domain/Multiplayer/CnCNet/MapSharer.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/MapSharer.cs
@@ -36,6 +36,9 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
 
         private static readonly object locker = new object();
 
+        private const int DOWNLOAD_TIMEOUT = 100000; // In milliseconds
+        private const int UPLOAD_TIMEOUT = 100000; // In milliseconds
+
         /// <summary>
         /// Adds a map into the CnCNet map upload queue.
         /// </summary>
@@ -211,6 +214,7 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
         private static byte[] UploadFiles(string address, List<FileToUpload> files, NameValueCollection values)
         {
             WebRequest request = WebRequest.Create(address);
+            request.Timeout = UPLOAD_TIMEOUT;
             request.Method = "POST";
             string boundary = "---------------------------" + DateTime.Now.Ticks.ToString("x", NumberFormatInfo.InvariantInfo);
             request.ContentType = "multipart/form-data; boundary=" + boundary;
@@ -382,7 +386,7 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
             destinationFile.Delete();
             newFile.Delete();
 
-            using (WebClient webClient = new ExtendedWebClient(timeout: 10000))
+            using (WebClient webClient = new ExtendedWebClient(DOWNLOAD_TIMEOUT))
             {
                 if (string.IsNullOrWhiteSpace(ClientConfiguration.Instance.CnCNetMapDBDownloadURL))
                 {

--- a/DXMainClient/Domain/Multiplayer/CnCNet/TunnelHandler.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/TunnelHandler.cs
@@ -148,7 +148,7 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
 
         private byte[] GetRawTunnelDataOnline()
         {
-            WebClient client = new WebClient();
+            WebClient client = new ExtendedWebClient();
             return client.DownloadData(MainClientConstants.CNCNET_TUNNEL_LIST_URL);
         }
 


### PR DESCRIPTION
The web client was created by `new WebClient()` without assigning a timeout value. It seems that the default timeout value is undocumented, and the debugger told me the default value is 100000 ms (note: 100 seconds!) No wonder why some people with poor Internet condition complained about it takes too long to wait for their clients to initialize.

This PR proposed the following changes:
- By default, the timeout value would be 10 seconds instead of 100 seconds
- As an exception, the timeout value of uploading/downloading a map is set to 100 seconds
- Remove the obsolete `TWebClient` introduced 8 years ago ([here](https://github.com/CnCNet/xna-cncnet-client/commit/d33e7c2a3a55381d8dd98dc5bc9ee491af7e6575)) since `ExtendedWebClient` was introduced 6 years ago ([here](https://github.com/CnCNet/xna-cncnet-client/commit/bb3dbc83c77f64a4864d497ec68ee10da7e246f2))
- Remove the weird statement `webClient.Proxy = null` introduced 8 years ago ([here](https://github.com/CnCNet/xna-cncnet-client/commit/d33e7c2a3a55381d8dd98dc5bc9ee491af7e6575)). Since now WebClients are initialized everywhere and no one explicitly clear the proxy setting like here, removing this statement will make the client behaves consistently -- leaving the proxy setting as system default.