### PR TITLE
Add a hand game command to the chatbox

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -39,6 +39,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         private const string MAP_SHARING_DISABLED_MESSAGE = "MAPSDISABLED";
         private const string CHEAT_DETECTED_MESSAGE = "CD";
         private const string DICE_ROLL_MESSAGE = "DR";
+        private const string Hand_RPS_MESSAGE = "HRPS";
         private const string CHANGE_TUNNEL_SERVER_MESSAGE = "CHTNL";
 
         public CnCNetGameLobby(
@@ -85,6 +86,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 new StringCommandHandler("FHSH", FileHashNotification),
                 new StringCommandHandler("MM", CheaterNotification),
                 new StringCommandHandler(DICE_ROLL_MESSAGE, HandleDiceRollResult),
+                new StringCommandHandler(Hand_RPS_MESSAGE, HandleHandRPSResult),
                 new NoParamCommandHandler(CHEAT_DETECTED_MESSAGE, HandleCheatDetectedMessage),
                 new StringCommandHandler(CHANGE_TUNNEL_SERVER_MESSAGE, HandleTunnelServerChangeMessage)
             };
@@ -1480,7 +1482,12 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             channel.SendCTCPMessage($"{DICE_ROLL_MESSAGE} {dieSides},{resultString}", QueuedMessageType.CHAT_MESSAGE, 0);
             PrintDiceRollResult(ProgramConstants.PLAYERNAME, dieSides, results);
         }
+        protected override void BroadcastHandRPS(string results)
+        {
 
+            channel.SendCTCPMessage($"{Hand_RPS_MESSAGE} {results}", QueuedMessageType.CHAT_MESSAGE, 0);
+            PrintHandRPSResult(ProgramConstants.PLAYERNAME, results);
+        }
         #endregion
 
         protected override void HandleLockGameButtonClick()

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
@@ -40,6 +40,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         private const string LAUNCH_GAME_COMMAND = "LAUNCH";
         private const string FILE_HASH_COMMAND = "FHASH";
         private const string DICE_ROLL_COMMAND = "DR";
+        private const string HAND_RPS_COMMAND = "HRPS";
         public const string PING = "PING";
 
         public LANGameLobby(WindowManager windowManager, string iniName,
@@ -57,6 +58,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 new StringCommandHandler(PLAYER_READY_REQUEST, GameHost_HandleReadyRequest),
                 new StringCommandHandler(FILE_HASH_COMMAND, HandleFileHashCommand),
                 new StringCommandHandler(DICE_ROLL_COMMAND, Host_HandleDiceRoll),
+                new StringCommandHandler(HAND_RPS_COMMAND, Host_HandleHandRPS),
                 new NoParamCommandHandler(PING, s => { }),
             };
 
@@ -70,6 +72,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 new ClientStringCommandHandler(LAUNCH_GAME_COMMAND, HandleGameLaunchCommand),
                 new ClientStringCommandHandler(GAME_OPTIONS_COMMAND, HandleGameOptionsMessage),
                 new ClientStringCommandHandler(DICE_ROLL_COMMAND, Client_HandleDiceRoll),
+                new ClientStringCommandHandler(HAND_RPS_COMMAND, Client_HandleHandRPS),
                 new ClientNoParamCommandHandler(PING, HandlePing),
             };
 
@@ -1086,7 +1089,10 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             string resultString = string.Join(",", results);
             SendMessageToHost($"DR {dieSides},{resultString}");
         }
-
+        protected override void BroadcastHandRPS(string results)
+        {
+            SendMessageToHost($"HRPS {results}");
+        }
         private void Host_HandleDiceRoll(string sender, string result)
         {
             BroadcastMessage($"{DICE_ROLL_COMMAND} {sender}{ProgramConstants.LAN_DATA_SEPARATOR}{result}");
@@ -1100,7 +1106,19 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             HandleDiceRollResult(parts[0], parts[1]);
         }
+        private void Host_HandleHandRPS(string sender, string result)
+        {
+            BroadcastMessage($"{HAND_RPS_COMMAND} {sender}{ProgramConstants.LAN_DATA_SEPARATOR}{result}");
+        }
 
+        private void Client_HandleHandRPS(string data)
+        {
+            string[] parts = data.Split(ProgramConstants.LAN_DATA_SEPARATOR);
+            if (parts.Length != 2)
+                return;
+
+            HandleHandRPSResult(parts[0], parts[1]);
+        }
         #endregion
 
         protected override void WriteSpawnIniAdditions(IniFile iniFile)

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
@@ -48,6 +48,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 new ChatBoxCommand("RANDOMSTARTS", "Enables completely random starting locations (Tiberian Sun based games only).".L10N("Client:Main:ChatboxCommandRandomStartsHelp"), true,
                     s => SetStartingLocationClearance(s)),
                 new ChatBoxCommand("ROLL", "Roll dice, for example /roll 3d6".L10N("Client:Main:ChatboxCommandRollHelp"), false, RollDiceCommand),
+                new ChatBoxCommand("HANDRPS", "Hand game, for example /handrps".L10N("Client:Main:ChatboxCommandHandRPSHelp"), false, HandRPSCommand),
                 new ChatBoxCommand("SAVEOPTIONS", "Save game option preset so it can be loaded later".L10N("Client:Main:ChatboxCommandSaveOptionsHelp"), false, HandleGameOptionPresetSaveCommand),
                 new ChatBoxCommand("LOADOPTIONS", "Load game option preset".L10N("Client:Main:ChatboxCommandLoadOptionsHelp"), true, HandleGameOptionPresetLoadCommand)
             };
@@ -521,7 +522,14 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             BroadcastDiceRoll(dieSides, results);
         }
-
+        private void HandRPSCommand(string ent)
+        {
+            string[] handgame = { "Rock", "Paper", "Scissors" };
+            Random rand = new Random();
+            int index = rand.Next(0, handgame.Length);
+            string reuslts = " selected  " + handgame[index] + "!";
+            BroadcastHandRPS(reuslts);
+        }
         /// <summary>
         /// Handles custom map load command.
         /// </summary>
@@ -546,6 +554,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         /// <param name="dieSides">The number of sides in the dice.</param>
         /// <param name="results">The results of the dice roll.</param>
         protected abstract void BroadcastDiceRoll(int dieSides, int[] results);
+        protected abstract void BroadcastHandRPS(string result);
 
         /// <summary>
         /// Parses and lists the results of rolling dice.
@@ -581,7 +590,11 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             PrintDiceRollResult(senderName, dieSides, results);
         }
-
+        protected void HandleHandRPSResult(string senderName, string result)
+        {
+            if (string.IsNullOrEmpty(result))
+                return;
+        }
         /// <summary>
         /// Prints the result of rolling dice.
         /// </summary>
@@ -594,7 +607,11 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 senderName, results.Length, dieSides, string.Join(", ", results)
             ));
         }
-
+        protected void PrintHandRPSResult(string senderName, string result)
+        {
+            AddNotice(String.Format("{0} {1}".L10N("Client:Main:PrintHandRPSResult"),
+                senderName, result));
+        }
         protected abstract void SendChatMessage(string message);
 
         /// <summary>


### PR DESCRIPTION
Add a hand game on command to the chatbox, Players must type /handrps to randomly choose between rock, paper or scissors.
![handgame](https://github.com/user-attachments/assets/fa8074be-dbac-4cd3-af82-2cce605f4a17)