### PR TITLE
Randomize all maps when there is only one player

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -742,6 +742,11 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
         private List<Map> GetMapList(int playerCount)
         {
+            if (playerCount == 1)
+			{
+				List<Map> allMaps = GameMode?.Maps.ToList() ?? new List<Map>();
+				return allMaps;
+			}
             List<Map> mapList = (GameMode?.Maps.Where(x => x.MaxPlayers == playerCount) ?? Array.Empty<Map>()).ToList();
             if (mapList.Count < 1 && playerCount <= MAX_PLAYER_COUNT)
                 return GetMapList(playerCount + 1);

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -747,6 +747,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 				List<Map> allMaps = GameMode?.Maps.ToList() ?? new List<Map>();
 				return allMaps;
 			}
+   
             List<Map> mapList = (GameMode?.Maps.Where(x => x.MaxPlayers == playerCount) ?? Array.Empty<Map>()).ToList();
             if (mapList.Count < 1 && playerCount <= MAX_PLAYER_COUNT)
                 return GetMapList(playerCount + 1);


### PR DESCRIPTION
When the number of players is 1, the random map will be assigned to any map, regardless of the max players of the map.
Used to randomly check maps.