### PR TITLE
Fix options cannot be saved when a renderer is not selected

### DIFF
--- a/DTAConfig/DirectDrawWrapper.cs
+++ b/DTAConfig/DirectDrawWrapper.cs
@@ -174,8 +174,11 @@ namespace DTAConfig
             }
             else
             {
-                new FileInfo(ddrawDllTargetPath).IsReadOnly = false;
-                File.Delete(ddrawDllTargetPath);
+                if (File.Exists(ddrawDllTargetPath))
+                {
+                    new FileInfo(ddrawDllTargetPath).IsReadOnly = false;
+                    File.Delete(ddrawDllTargetPath);
+                }
             }
 
 


### PR DESCRIPTION
File.Delete() won't throw an error. But new FileInfo(path).IsReadOnly does