### PR TITLE
Fix readonly files can't be copied on the 2nd stage of the update

### DIFF
--- a/SecondStageUpdater/Program.cs
+++ b/SecondStageUpdater/Program.cs
@@ -143,9 +143,17 @@ internal sealed class Program
                         try
                         {
                             FileInfo copiedFile = SafePath.GetFile(baseDirectory.FullName, relativeFileName);
+                            bool isReadOnly = copiedFile.IsReadOnly;
 
                             Write($"Updating {relativeFileName}");
+
+                            if (isReadOnly)
+                                copiedFile.IsReadOnly = false;
+
                             fileInfo.CopyTo(copiedFile.FullName, true);
+
+                            if (isReadOnly)
+                                copiedFile.IsReadOnly = true;
                         }
                         catch (Exception ex)
                         {


### PR DESCRIPTION
After merging PR #590, not all cases of using links are covered, resulting in several bugs in various client-related programs, such as the [Client Launcher](https://github.com/CnCNet/dta-mg-client-launcher) (already [fixed](https://github.com/CnCNet/dta-mg-client-launcher/pull/17)) and the Second Stage Updater, because they can't replace files that have read-only property enabled.

The purpose of PR is to fix this bug for Second Stage Updater.

Example of bug:

![image](https://github.com/user-attachments/assets/82a8f29f-3e48-4e7a-912b-1a68c99be589)
