### PR TITLE
Fix incorrect hash calculation for files in nested directories

### DIFF
--- a/DXMainClient/Online/FileHashCalculator.cs
+++ b/DXMainClient/Online/FileHashCalculator.cs
@@ -151,7 +151,7 @@ namespace DTAClient.Online
             {
                 if (path.Exists)
                 {
-                    foreach (string filename in path.EnumerateFiles("*", SearchOption.AllDirectories).Select(s => Path.GetRelativePath(path.FullName, s.FullName)))
+                    foreach (string filename in path.EnumerateFiles("*", SearchOption.AllDirectories).Select(s => s.FullName.Substring(path.FullName.Length)))
                     {
                         string fileRelativePath = SafePath.CombineFilePath(path.Name, filename);
                         string fileFullPath = SafePath.CombineFilePath(path.FullName, filename);

--- a/DXMainClient/Online/FileHashCalculator.cs
+++ b/DXMainClient/Online/FileHashCalculator.cs
@@ -151,7 +151,7 @@ namespace DTAClient.Online
             {
                 if (path.Exists)
                 {
-                    foreach (string filename in path.EnumerateFiles("*", SearchOption.AllDirectories).Select(s => s.Name))
+                    foreach (string filename in path.EnumerateFiles("*", SearchOption.AllDirectories).Select(s => Path.GetRelativePath(path.FullName, s.FullName)))
                     {
                         string fileRelativePath = SafePath.CombineFilePath(path.Name, filename);
                         string fileFullPath = SafePath.CombineFilePath(path.FullName, filename);


### PR DESCRIPTION
Hey!

I'm using [cncnet-yr-client-package@`8645fa4`](https://github.com/CnCNet/cncnet-yr-client-package/tree/8645fa461c604b0f0c7545a44e9bdd475522d1f7). Today, I've gotten some "File xxx is supposed to but does not exist" messages. After debugging, I think the current implementation (#341 and #567) is a bit buggy, so I made this PR.

The correct result in the block:

| `filename` | `fileRelativePath` |
|:- |:- |
| `Allies Allowed.ini` | `Game Options\Allies Allowed.ini` |
| `No Dog Engi Eat.ini` | `Game Options\No Dog Engi Eat.ini` |
| `No Spawn Previews.ini` | `Game Options\No Spawn Previews.ini` |
| `No_France_No_Yuri.ini` | `Game Options\No_France_No_Yuri.ini` |
| `No_Spy.ini` | `Game Options\No_Spy.ini` |
| `RA2 Classic Mode.ini` | `Game Options\RA2 Classic Mode.ini` |
| `Yuri Rebalance Patch.ini` | `Game Options\Yuri Rebalance Patch.ini` |
| `AI\Brutal AI.ini` | `Game Options\AI\Brutal AI.ini` |
| `AI\Extreme AI.ini` | `Game Options\AI\Extreme AI.ini` |
| `AI\No Change.ini` | `Game Options\AI\No Change.ini` |

That inner "AI" directory is introduced in https://github.com/CnCNet/cncnet-yr-client-package/pull/389.

---

Question: I didn't find another `Path.GetRelativePath` in this project. Is it safe?