### PR TITLE
Copy built-in resources to "OutputPath" only when needed

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -90,7 +90,7 @@
     <Move SourceFiles="$(PublishDir)clientxna.pdb" DestinationFolder="$(PublishDir)../../" Condition="Exists('$(PublishDir)clientxna.pdb')" />
   </Target>
 
-  <Target Name="CopyResources" AfterTargets="Build" Condition="$(DefineConstants.Contains('DEBUG')) AND '$(MSBuildProjectName)' == 'DXMainClient' AND '$(TargetFramework)' == '' AND ! Exists('$(OutputPath)\Resources\ClientDefinitions.ini')">
+  <Target Name="CopyResources" AfterTargets="Build" Condition="$(DefineConstants.Contains('DEBUG')) AND ( '$(MSBuildProjectName)' == 'ClientCore' OR '$(MSBuildProjectName)' == 'DTAConfig' OR '$(MSBuildProjectName)' == 'DXMainClient' ) AND '$(TargetFramework)' == '' AND ! Exists('$(OutputPath)\Resources\ClientDefinitions.ini')">
     <ItemGroup>
       <ExampleClientResources Include="$(MSBuildThisFileDirectory)\DXMainClient\Resources\DTA\**\*.*" />
       <ExampleClientMaps Include="$(MSBuildThisFileDirectory)\DXMainClient\Resources\Maps\**\*.*" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -90,7 +90,7 @@
     <Move SourceFiles="$(PublishDir)clientxna.pdb" DestinationFolder="$(PublishDir)../../" Condition="Exists('$(PublishDir)clientxna.pdb')" />
   </Target>
 
-  <Target Name="CopyResources" AfterTargets="Build" Condition="$(DefineConstants.Contains('DEBUG'))">
+  <Target Name="CopyResources" AfterTargets="Build" Condition="$(DefineConstants.Contains('DEBUG')) AND '$(MSBuildProjectName)' == 'DXMainClient' AND '$(TargetFramework)' == '' AND ! Exists('$(OutputPath)\Resources\ClientDefinitions.ini')">
     <ItemGroup>
       <ExampleClientResources Include="$(MSBuildThisFileDirectory)\DXMainClient\Resources\DTA\**\*.*" />
       <ExampleClientMaps Include="$(MSBuildThisFileDirectory)\DXMainClient\Resources\Maps\**\*.*" />
@@ -99,12 +99,12 @@
       <ExampleClientSettings Include="$(MSBuildThisFileDirectory)\DXMainClient\Resources\SUN.ini" />
       <ExampleClientDefinitions Include="$(MSBuildThisFileDirectory)\DXMainClient\Resources\ClientDefinitions.ini" />
     </ItemGroup>
-    <Copy Condition="! Exists('$(OutputPath)\Resources\ClientDefinitions.ini') " SourceFiles="@(ExampleClientResources)" DestinationFolder="$(OutputPath)\Resources\%(RecursiveDir)" />
-    <Copy Condition="! Exists('$(OutputPath)\Resources\ClientDefinitions.ini') " SourceFiles="@(ExampleClientMaps)" DestinationFolder="$(OutputPath)\Maps\%(RecursiveDir)" />
-    <Copy Condition="! Exists('$(OutputPath)\Resources\ClientDefinitions.ini') " SourceFiles="@(ExampleClientIni)" DestinationFolder="$(OutputPath)\INI\%(RecursiveDir)" />
-    <Copy Condition="! Exists('$(OutputPath)\Resources\ClientDefinitions.ini') " SourceFiles="@(ExampleClientMix)" DestinationFolder="$(OutputPath)\MIX\%(RecursiveDir)" />
-    <Copy Condition="! Exists('$(OutputPath)\Resources\ClientDefinitions.ini') " SourceFiles="@(ExampleClientSettings)" DestinationFolder="$(OutputPath)" />
-    <Copy Condition="! Exists('$(OutputPath)\Resources\ClientDefinitions.ini') " SourceFiles="@(ExampleClientDefinitions)" DestinationFolder="$(OutputPath)\Resources" />
+    <Copy SourceFiles="@(ExampleClientResources)" DestinationFolder="$(OutputPath)\Resources\%(RecursiveDir)" />
+    <Copy SourceFiles="@(ExampleClientMaps)" DestinationFolder="$(OutputPath)\Maps\%(RecursiveDir)" />
+    <Copy SourceFiles="@(ExampleClientIni)" DestinationFolder="$(OutputPath)\INI\%(RecursiveDir)" />
+    <Copy SourceFiles="@(ExampleClientMix)" DestinationFolder="$(OutputPath)\MIX\%(RecursiveDir)" />
+    <Copy SourceFiles="@(ExampleClientSettings)" DestinationFolder="$(OutputPath)" />
+    <Copy SourceFiles="@(ExampleClientDefinitions)" DestinationFolder="$(OutputPath)\Resources" />
   </Target>
 
   <Target Name="CopyUpdater" AfterTargets="Build" Condition="'$(PublishDir)' != '' AND '$(MSBuildProjectName)' == 'SecondStageUpdater'">


### PR DESCRIPTION
Hi.

## Commit message

```
Copy built-in resources to "OutputPath" only when needed

The conditions are:

- It's being debugged;
- It's DXMainClient;
- It's cross-targeting build ('$(TargetFramework)' == ''). Don't know the whole story, just from my guess:
    - https://github.com/dotnet/msbuild/blob/b497794a81585d40ba5401acde02200f7b7d863b/src/Tasks/Microsoft.Managed.Before.targets
    - https://github.com/dotnet/msbuild/blob/b497794a81585d40ba5401acde02200f7b7d863b/src/Tasks/Microsoft.Common.CrossTargeting.targets
- No "ClientDefinitions.ini" in destination.

```

## Why

I've seen the "SUN.INI" file multiple times when playing with YR client. So today I did a search in the project root directory:

```console
$ find . -path '*/bin/*' -name 'SUN.ini'
./ClientCore/bin/Debug/YR/WindowsDX/net48/SUN.ini
./ClientCore/bin/Debug/YR/WindowsDX/net8.0-windows/SUN.ini
./ClientCore/bin/Debug/YR/WindowsDX/SUN.ini
./ClientGUI/bin/Debug/YR/WindowsDX/net48/SUN.ini
./ClientGUI/bin/Debug/YR/WindowsDX/net8.0-windows/SUN.ini
./ClientGUI/bin/Debug/YR/WindowsDX/SUN.ini
./ClientUpdater/bin/Debug/YR/WindowsDX/net48/SUN.ini
./ClientUpdater/bin/Debug/YR/WindowsDX/net8.0/SUN.ini
./ClientUpdater/bin/Debug/YR/WindowsDX/SUN.ini
./DTAConfig/bin/Debug/YR/WindowsDX/net48/SUN.ini
./DTAConfig/bin/Debug/YR/WindowsDX/net8.0-windows/SUN.ini
./DTAConfig/bin/Debug/YR/WindowsDX/SUN.ini
./DXMainClient/bin/Debug/YR/WindowsDX/net48/SUN.ini
./DXMainClient/bin/Debug/YR/WindowsDX/net8.0-windows/SUN.ini
./DXMainClient/bin/Debug/YR/WindowsDX/SUN.ini
./SecondStageUpdater/bin/Debug/YR/WindowsDX/net48/SUN.ini
./SecondStageUpdater/bin/Debug/YR/WindowsDX/net48/Updater/SUN.ini
./SecondStageUpdater/bin/Debug/YR/WindowsDX/net8.0/SUN.ini
./SecondStageUpdater/bin/Debug/YR/WindowsDX/net8.0/Updater/SUN.ini
./TranslationNotifierGenerator/bin/Debug/YR/WindowsDX/netstandard2.0/SUN.ini
./TranslationNotifierGenerator/bin/Debug/YR/WindowsDX/SUN.ini

```

Oh, they are too many, aren't they?

After doing some testing, I think we need to tweak the "CopyResources" target by adding more conditions, so I did it in this PR. 

## Change

After applying this PR, the built-in resources will be copied to the `bin\Debug\$(Game)\$(Engine)` directory, so the binary of both net8.0 and non-net8.0 will share the same game files.

## Question

I can see the duplicated `SearchResourcesDir(string startupPath)` functions in both **DXMainClient** and **ClientCore** modules:

https://github.com/CnCNet/xna-cncnet-client/blob/bae385595f48c525f1f44baf24044f337dc6cae2/ClientCore/ProgramConstants.cs#L118-L144

My question is: do we need those resources during debugging **ClientCore**? If so, I think I may need to change the condition statement.
