### PR TITLE
Modify GameInformationPanel to optionally display as an invite

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameInformationPanel.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameInformationPanel.cs
@@ -4,8 +4,6 @@ using System.Diagnostics;
 using ClientCore;
 using ClientCore.Extensions;
 
-using ClientGUI;
-
 using DTAClient.Domain.Multiplayer;
 
 using Microsoft.Xna.Framework;
@@ -60,27 +58,17 @@ namespace DTAClient.DXGUI.Multiplayer
         private const int maxPreviewHeight = 150;
         private const int mapPreviewMargin = 15;
 
-        private const int buttonWidth = 75;
-        private const int buttonHeight = 30;
-
         private string[] skillLevelOptions;
-
-        private XNAClientButton btnAcceptInvite;
-        private XNAClientButton btnDeclineInvite;
-
-        public bool IsInvite { get; set; } = false;
-
-        public event Action AcceptInvite;
-        public event Action DeclineInvite;
 
         public override void Initialize()
         {
-            ClientRectangle = new Rectangle(0, 0, columnWidth * 2, IsInvite ? initialPanelHeight + buttonHeight : initialPanelHeight);
+            ClientRectangle = new Rectangle(0, 0, columnWidth * 2, initialPanelHeight);
             BackgroundTexture = AssetLoader.CreateTexture(new Color(0, 0, 0, 255), 1, 1);
             PanelBackgroundDrawMode = PanelBackgroundImageDrawMode.STRETCHED;
 
             lblGameInformation = new XNALabel(WindowManager);
             lblGameInformation.FontIndex = 1;
+            lblGameInformation.Text = "GAME INFORMATION".L10N("Client:Main:GameInfo");
 
             if (AssetLoader.AssetExists("noMapPreview.png"))
                 noMapPreviewTexture = AssetLoader.LoadTexture("noMapPreview.png");
@@ -132,23 +120,6 @@ namespace DTAClient.DXGUI.Multiplayer
                 lblPlayerNames[(lblPlayerNames.Length / 2) + i] = lblPlayerName2;
             }
 
-            // buttons for invites
-            btnAcceptInvite = new XNAClientButton(WindowManager);
-            btnAcceptInvite.Text = "Accept".L10N("Client:Main:InviteAccept");
-            btnAcceptInvite.ClientRectangle = new Rectangle(ClientRectangle.Width / 2 - buttonWidth - (columnMargin / 2), ClientRectangle.Height - buttonHeight - columnMargin, buttonWidth, buttonHeight);
-            btnAcceptInvite.LeftClick += (s, e) => AcceptInvite?.Invoke();
-            btnAcceptInvite.Visible = false;
-            btnAcceptInvite.Name = "btnAcceptInvite";
-            AddChild(btnAcceptInvite);
-
-            btnDeclineInvite = new XNAClientButton(WindowManager);
-            btnDeclineInvite.Text = "Decline".L10N("Client:Main:InviteDecline");
-            btnDeclineInvite.ClientRectangle = new Rectangle(ClientRectangle.Width / 2 + (columnMargin / 2), ClientRectangle.Height - buttonHeight - columnMargin, buttonWidth, buttonHeight);
-            btnDeclineInvite.LeftClick += (s, e) => DeclineInvite?.Invoke();
-            btnDeclineInvite.Visible = false;
-            btnDeclineInvite.Name = "btnDeclineInvite";
-            AddChild(btnDeclineInvite);
-
             AddChild(lblGameMode);
             AddChild(lblMap);
             AddChild(lblGameVersion);
@@ -158,6 +129,7 @@ namespace DTAClient.DXGUI.Multiplayer
             AddChild(lblGameInformation);
             AddChild(lblSkillLevel);
 
+            lblGameInformation.CenterOnParent();
             lblGameInformation.ClientRectangle = new Rectangle(lblGameInformation.X, 6,
                 lblGameInformation.Width, lblGameInformation.Height);
 
@@ -218,6 +190,8 @@ namespace DTAClient.DXGUI.Multiplayer
             string localizedSkillLevel = skillLevel.L10N($"INI:ClientDefinitions:SkillLevel:{game.SkillLevel}");
             lblSkillLevel.Text = "Preferred Skill Level:".L10N("Client:Main:GameInfoSkillLevel") + " " + localizedSkillLevel;
 
+            lblGameInformation.Visible = true;
+
             if (mapLoader != null)
             {
                 mapTexture = mapLoader.GameModeMaps.Find(m => m.Map.UntranslatedName.Equals(game.Map, StringComparison.InvariantCultureIgnoreCase) && m.Map.IsPreviewTextureCached())?.Map?.LoadPreviewTexture();
@@ -232,20 +206,6 @@ namespace DTAClient.DXGUI.Multiplayer
                     disposeTextures = true;
                 }
             }
-
-            if (IsInvite)
-            {
-                lblGameInformation.Text = "GAME INVITATION".L10N("Client:Main:GameInfoInviteTitle");
-            }
-            else
-            {
-                lblGameInformation.Text = "GAME INFORMATION".L10N("Client:Main:GameInfo");
-            }
-
-            lblGameInformation.CenterOnParentHorizontally();
-            lblGameInformation.Visible = true;
-            btnAcceptInvite.Visible = IsInvite;
-            btnDeclineInvite.Visible = IsInvite;
         }
 
         public void ClearInfo()
@@ -267,8 +227,6 @@ namespace DTAClient.DXGUI.Multiplayer
                 mapTexture.Dispose();
                 mapTexture = null;
             }
-            btnAcceptInvite.Visible = false;
-            btnDeclineInvite.Visible = false;
         }
 
         public override void Draw(GameTime gameTime)
@@ -279,8 +237,6 @@ namespace DTAClient.DXGUI.Multiplayer
 
                 if (game != null && mapTexture != null)
                     RenderMapPreview();
-
-                DrawChildren(gameTime);
             }
         }
 

--- a/DXMainClient/DXGUI/Multiplayer/GameInformationPanel.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameInformationPanel.cs
@@ -4,6 +4,8 @@ using System.Diagnostics;
 using ClientCore;
 using ClientCore.Extensions;
 
+using ClientGUI;
+
 using DTAClient.Domain.Multiplayer;
 
 using Microsoft.Xna.Framework;
@@ -58,17 +60,27 @@ namespace DTAClient.DXGUI.Multiplayer
         private const int maxPreviewHeight = 150;
         private const int mapPreviewMargin = 15;
 
+        private const int buttonWidth = 75;
+        private const int buttonHeight = 30;
+
         private string[] skillLevelOptions;
+
+        private XNAClientButton btnAcceptInvite;
+        private XNAClientButton btnDeclineInvite;
+
+        public bool IsInvite { get; set; } = false;
+
+        public event Action AcceptInvite;
+        public event Action DeclineInvite;
 
         public override void Initialize()
         {
-            ClientRectangle = new Rectangle(0, 0, columnWidth * 2, initialPanelHeight);
+            ClientRectangle = new Rectangle(0, 0, columnWidth * 2, IsInvite ? initialPanelHeight + buttonHeight : initialPanelHeight);
             BackgroundTexture = AssetLoader.CreateTexture(new Color(0, 0, 0, 255), 1, 1);
             PanelBackgroundDrawMode = PanelBackgroundImageDrawMode.STRETCHED;
 
             lblGameInformation = new XNALabel(WindowManager);
             lblGameInformation.FontIndex = 1;
-            lblGameInformation.Text = "GAME INFORMATION".L10N("Client:Main:GameInfo");
 
             if (AssetLoader.AssetExists("noMapPreview.png"))
                 noMapPreviewTexture = AssetLoader.LoadTexture("noMapPreview.png");
@@ -120,6 +132,23 @@ namespace DTAClient.DXGUI.Multiplayer
                 lblPlayerNames[(lblPlayerNames.Length / 2) + i] = lblPlayerName2;
             }
 
+            // buttons for invites
+            btnAcceptInvite = new XNAClientButton(WindowManager);
+            btnAcceptInvite.Text = "Accept".L10N("Client:Main:InviteAccept");
+            btnAcceptInvite.ClientRectangle = new Rectangle(ClientRectangle.Width / 2 - buttonWidth - (columnMargin / 2), ClientRectangle.Height - buttonHeight - columnMargin, buttonWidth, buttonHeight);
+            btnAcceptInvite.LeftClick += (s, e) => AcceptInvite?.Invoke();
+            btnAcceptInvite.Visible = false;
+            btnAcceptInvite.Name = "btnAcceptInvite";
+            AddChild(btnAcceptInvite);
+
+            btnDeclineInvite = new XNAClientButton(WindowManager);
+            btnDeclineInvite.Text = "Decline".L10N("Client:Main:InviteDecline");
+            btnDeclineInvite.ClientRectangle = new Rectangle(ClientRectangle.Width / 2 + (columnMargin / 2), ClientRectangle.Height - buttonHeight - columnMargin, buttonWidth, buttonHeight);
+            btnDeclineInvite.LeftClick += (s, e) => DeclineInvite?.Invoke();
+            btnDeclineInvite.Visible = false;
+            btnDeclineInvite.Name = "btnDeclineInvite";
+            AddChild(btnDeclineInvite);
+
             AddChild(lblGameMode);
             AddChild(lblMap);
             AddChild(lblGameVersion);
@@ -129,7 +158,6 @@ namespace DTAClient.DXGUI.Multiplayer
             AddChild(lblGameInformation);
             AddChild(lblSkillLevel);
 
-            lblGameInformation.CenterOnParent();
             lblGameInformation.ClientRectangle = new Rectangle(lblGameInformation.X, 6,
                 lblGameInformation.Width, lblGameInformation.Height);
 
@@ -190,8 +218,6 @@ namespace DTAClient.DXGUI.Multiplayer
             string localizedSkillLevel = skillLevel.L10N($"INI:ClientDefinitions:SkillLevel:{game.SkillLevel}");
             lblSkillLevel.Text = "Preferred Skill Level:".L10N("Client:Main:GameInfoSkillLevel") + " " + localizedSkillLevel;
 
-            lblGameInformation.Visible = true;
-
             if (mapLoader != null)
             {
                 mapTexture = mapLoader.GameModeMaps.Find(m => m.Map.UntranslatedName.Equals(game.Map, StringComparison.InvariantCultureIgnoreCase) && m.Map.IsPreviewTextureCached())?.Map?.LoadPreviewTexture();
@@ -206,6 +232,20 @@ namespace DTAClient.DXGUI.Multiplayer
                     disposeTextures = true;
                 }
             }
+
+            if (IsInvite)
+            {
+                lblGameInformation.Text = "GAME INVITATION".L10N("Client:Main:GameInfoInviteTitle");
+            }
+            else
+            {
+                lblGameInformation.Text = "GAME INFORMATION".L10N("Client:Main:GameInfo");
+            }
+
+            lblGameInformation.CenterOnParentHorizontally();
+            lblGameInformation.Visible = true;
+            btnAcceptInvite.Visible = IsInvite;
+            btnDeclineInvite.Visible = IsInvite;
         }
 
         public void ClearInfo()
@@ -227,6 +267,8 @@ namespace DTAClient.DXGUI.Multiplayer
                 mapTexture.Dispose();
                 mapTexture = null;
             }
+            btnAcceptInvite.Visible = false;
+            btnDeclineInvite.Visible = false;
         }
 
         public override void Draw(GameTime gameTime)
@@ -237,6 +279,8 @@ namespace DTAClient.DXGUI.Multiplayer
 
                 if (game != null && mapTexture != null)
                     RenderMapPreview();
+
+                DrawChildren(gameTime);
             }
         }
 

--- a/DXMainClient/DXGUI/Multiplayer/GameInvitePanel.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameInvitePanel.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Diagnostics;
+using System.Windows.Forms;
+
+using ClientCore;
+using ClientCore.Extensions;
+
+using ClientGUI;
+
+using DTAClient.Domain.Multiplayer;
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+using Rampastring.XNAUI;
+using Rampastring.XNAUI.XNAControls;
+
+namespace DTAClient.DXGUI.Multiplayer
+{
+    /// <summary>
+    /// A UI panel that displays information about a hosted CnCNet or LAN game.
+    /// </summary>
+    public class GameInvitePanel : XNAPanel
+    {
+        public GameInvitePanel(WindowManager windowManager, MapLoader mapLoader)
+            : base(windowManager)
+        {
+            this.mapLoader = mapLoader;
+            DrawMode = ControlDrawMode.UNIQUE_RENDER_TARGET;
+        }
+
+        private MapLoader mapLoader;
+
+        private GenericHostedGame game = null;
+
+        private const int buttonWidth = 75;
+        private const int buttonHeight = 30;
+        private const int padding = 10;
+
+        private XNALabel lblInviteHeading;
+        private XNAClientButton btnInviteAccept;
+        private XNAClientButton btnInviteDecline;
+        private GameInformationPanel panelGameInformation;
+
+        public event Action AcceptInvite;
+        public event Action DeclineInvite;
+
+        public override void Initialize()
+        {
+            panelGameInformation = new GameInformationPanel(WindowManager, mapLoader);
+            panelGameInformation.Name = nameof(panelGameInformation);
+            panelGameInformation.BackgroundTexture = AssetLoader.LoadTexture("cncnetlobbypanelbg.png");
+            panelGameInformation.DrawMode = ControlDrawMode.UNIQUE_RENDER_TARGET;
+            panelGameInformation.Initialize();
+            panelGameInformation.ClearInfo();
+            panelGameInformation.Disable();
+            panelGameInformation.InputEnabled = false;
+            panelGameInformation.Alpha = 0.5f;
+            panelGameInformation.AlphaRate = 0.5f;
+            AddChild(panelGameInformation);
+
+            lblInviteHeading = new XNALabel(WindowManager);
+            lblInviteHeading.FontIndex = 1;
+            lblInviteHeading.Text = "INVITATION TO JOIN GAME".L10N("Client:Main:InviteHeading");
+            lblInviteHeading.X = (panelGameInformation.Width / 2) - (lblInviteHeading.Width/2);
+            lblInviteHeading.Y = ((lblInviteHeading.Height + padding) / 2) - (lblInviteHeading.Height/2);
+
+            ClientRectangle = new Rectangle(0, 0, panelGameInformation.Width, padding + lblInviteHeading.Height  + panelGameInformation.Height  + padding + buttonHeight + padding);
+            BackgroundTexture = AssetLoader.CreateTexture(new Color(0, 0, 0, 255), 1, 1);
+            PanelBackgroundDrawMode = PanelBackgroundImageDrawMode.STRETCHED;
+
+            AddChild(lblInviteHeading);
+            lblInviteHeading.Visible = true;
+            panelGameInformation.Y = lblInviteHeading.Height + padding;
+
+            btnInviteAccept = new XNAClientButton(WindowManager);
+            btnInviteAccept.Text = "Accept".L10N("Client:Main:InviteAccept");
+            btnInviteAccept.ClientRectangle = new Rectangle(ClientRectangle.Width / 2 - buttonWidth - (padding / 2), panelGameInformation.Y + panelGameInformation.Height + padding, buttonWidth, buttonHeight);
+            btnInviteAccept.LeftClick += (s, e) => AcceptInvite?.Invoke();
+            btnInviteAccept.Visible = true;
+            btnInviteAccept.Name = "btnInviteAccept";
+            AddChild(btnInviteAccept);
+
+            btnInviteDecline = new XNAClientButton(WindowManager);
+            btnInviteDecline.Text = "Decline".L10N("Client:Main:InviteDecline");
+            btnInviteDecline.ClientRectangle = new Rectangle(ClientRectangle.Width / 2 + (padding / 2), btnInviteAccept.Y, buttonWidth, buttonHeight);
+            btnInviteDecline.LeftClick += (s, e) => DeclineInvite?.Invoke();
+            btnInviteDecline.Visible = true;
+            btnInviteDecline.Name = "btnInviteDecline";
+            AddChild(btnInviteDecline);
+            base.Initialize();
+        }
+
+        public void SetInfo(GenericHostedGame game)
+        {
+
+            this.game = game;
+
+            panelGameInformation.SetInfo(game);
+            panelGameInformation.Enable();
+        }
+
+        public override void Draw(GameTime gameTime)
+        {
+            if (Alpha > 0.0f)
+            {
+                base.Draw(gameTime);
+
+                DrawChildren(gameTime);
+            }
+        }
+    }
+}

--- a/DXMainClient/DXGUI/Multiplayer/GameInvitePanel.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameInvitePanel.cs
@@ -29,7 +29,7 @@ namespace DTAClient.DXGUI.Multiplayer
             DrawMode = ControlDrawMode.UNIQUE_RENDER_TARGET;
         }
 
-        private MapLoader mapLoader;
+        private readonly MapLoader mapLoader;
 
         private GenericHostedGame game = null;
 

--- a/DXMainClient/DXGUI/Multiplayer/GameInvitePanel.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameInvitePanel.cs
@@ -65,7 +65,7 @@ namespace DTAClient.DXGUI.Multiplayer
             lblInviteHeading.X = (panelGameInformation.Width / 2) - (lblInviteHeading.Width/2);
             lblInviteHeading.Y = ((lblInviteHeading.Height + padding) / 2) - (lblInviteHeading.Height/2);
 
-            ClientRectangle = new Rectangle(0, 0, panelGameInformation.Width, padding + lblInviteHeading.Height  + panelGameInformation.Height  + padding + buttonHeight + padding);
+            ClientRectangle = new Rectangle(0, 0, panelGameInformation.Width, padding + lblInviteHeading.Height  + panelGameInformation.Height + padding + buttonHeight + padding);
             BackgroundTexture = AssetLoader.CreateTexture(new Color(0, 0, 0, 255), 1, 1);
             PanelBackgroundDrawMode = PanelBackgroundImageDrawMode.STRETCHED;
 

--- a/DXMainClient/DXGUI/Multiplayer/GameInvitePanel.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameInvitePanel.cs
@@ -33,9 +33,9 @@ namespace DTAClient.DXGUI.Multiplayer
 
         private GenericHostedGame game = null;
 
-        private const int buttonWidth = 75;
-        private const int buttonHeight = 30;
-        private const int padding = 10;
+        private const int buttonWidth = UIDesignConstants.BUTTON_WIDTH_92;
+        private const int buttonHeight = UIDesignConstants.BUTTON_HEIGHT;
+        private const int padding = 12;
 
         private XNALabel lblInviteHeading;
         private XNAClientButton btnInviteAccept;
@@ -55,30 +55,24 @@ namespace DTAClient.DXGUI.Multiplayer
             panelGameInformation.ClearInfo();
             panelGameInformation.Disable();
             panelGameInformation.InputEnabled = false;
-            panelGameInformation.Alpha = 0.5f;
-            panelGameInformation.AlphaRate = 0.5f;
+            panelGameInformation.DrawBorders = false;
             AddChild(panelGameInformation);
 
             lblInviteHeading = new XNALabel(WindowManager);
-            lblInviteHeading.FontIndex = 1;
-            lblInviteHeading.Text = "INVITATION TO JOIN GAME".L10N("Client:Main:InviteHeading");
-            lblInviteHeading.X = (panelGameInformation.Width / 2) - (lblInviteHeading.Width/2);
-            lblInviteHeading.Y = ((lblInviteHeading.Height + padding) / 2) - (lblInviteHeading.Height/2);
+            AddChild(lblInviteHeading);
 
-            ClientRectangle = new Rectangle(0, 0, panelGameInformation.Width, padding + lblInviteHeading.Height  + panelGameInformation.Height  + padding + buttonHeight + padding);
+            ClientRectangle = new Rectangle(0, 0, panelGameInformation.Width + 2, padding + lblInviteHeading.Height  + panelGameInformation.Height  + padding + buttonHeight + padding); //...+2 to account for panelGameInformation border width
             BackgroundTexture = AssetLoader.CreateTexture(new Color(0, 0, 0, 255), 1, 1);
             PanelBackgroundDrawMode = PanelBackgroundImageDrawMode.STRETCHED;
 
-            AddChild(lblInviteHeading);
-            lblInviteHeading.Visible = true;
-            panelGameInformation.Y = lblInviteHeading.Height + padding;
+            panelGameInformation.X = 1; //border width
 
             btnInviteAccept = new XNAClientButton(WindowManager);
             btnInviteAccept.Text = "Accept".L10N("Client:Main:InviteAccept");
             btnInviteAccept.ClientRectangle = new Rectangle(ClientRectangle.Width / 2 - buttonWidth - (padding / 2), panelGameInformation.Y + panelGameInformation.Height + padding, buttonWidth, buttonHeight);
             btnInviteAccept.LeftClick += (s, e) => AcceptInvite?.Invoke();
             btnInviteAccept.Visible = true;
-            btnInviteAccept.Name = "btnInviteAccept";
+            btnInviteAccept.Name = nameof(btnInviteAccept);
             AddChild(btnInviteAccept);
 
             btnInviteDecline = new XNAClientButton(WindowManager);
@@ -86,28 +80,31 @@ namespace DTAClient.DXGUI.Multiplayer
             btnInviteDecline.ClientRectangle = new Rectangle(ClientRectangle.Width / 2 + (padding / 2), btnInviteAccept.Y, buttonWidth, buttonHeight);
             btnInviteDecline.LeftClick += (s, e) => DeclineInvite?.Invoke();
             btnInviteDecline.Visible = true;
-            btnInviteDecline.Name = "btnInviteDecline";
+            btnInviteDecline.Name = nameof(btnInviteDecline);
             AddChild(btnInviteDecline);
             base.Initialize();
         }
 
         public void SetInfo(GenericHostedGame game)
         {
-
-            this.game = game;
-
-            panelGameInformation.SetInfo(game);
-            panelGameInformation.Enable();
+            if (game != null)
+            {
+                this.game = game;
+                lblInviteHeading.FontIndex = 1;
+                lblInviteHeading.Text = string.Format("{0} IS INVITING YOU TO PLAY".L10N("Client:Main:InviteHeading"), game.HostName);
+                lblInviteHeading.CenterOnParentHorizontally();
+                lblInviteHeading.Y = ((padding + lblInviteHeading.Height + padding) / 2) - (lblInviteHeading.Height / 2);
+                panelGameInformation.Y = lblInviteHeading.Y + lblInviteHeading.Height + padding;
+                panelGameInformation.SetInfo(game);
+                panelGameInformation.Enable();
+            };
         }
 
         public override void Draw(GameTime gameTime)
         {
-            if (Alpha > 0.0f)
-            {
-                base.Draw(gameTime);
+            base.Draw(gameTime);
 
-                DrawChildren(gameTime);
-            }
+            DrawChildren(gameTime);
         }
     }
 }

--- a/DXMainClient/DXGUI/Multiplayer/GameInvitePanel.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameInvitePanel.cs
@@ -93,7 +93,6 @@ namespace DTAClient.DXGUI.Multiplayer
 
         public void SetInfo(GenericHostedGame game)
         {
-
             this.game = game;
 
             panelGameInformation.SetInfo(game);


### PR DESCRIPTION
Currently when you receive an invite to join a game, you can only get information about the game host and game name. This PR modifies game invite requests to show as a GameInformationPanel instead of ChoiceNotificationBox so you get the nice map thumbnail and all the other information that is normally shown about a game.

It adds Accept/Decline buttons to the GameInformationPanel which are visible if [panel].IsInvite is set.

![image](https://github.com/user-attachments/assets/ef35c062-2ea5-419e-9e4b-75d1d2939a82)


First timer here so apologies if I am going about this incorrectly.