### PR TITLE
Fix map information labels not being updated in certain cases

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -2086,6 +2086,26 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         }
 
         /// <summary>
+        /// Updates the map information labels such as name and author.
+        /// </summary>
+        protected virtual void SetMapLabels()
+        {
+            if (GameMode == null || Map == null)
+            {
+                lblMapName.Text = "Map: Unknown".L10N("Client:Main:MapUnknown");
+                lblMapAuthor.Text = "By Unknown Author".L10N("Client:Main:AuthorByUnknown");
+                lblGameMode.Text = "Game mode: Unknown".L10N("Client:Main:GameModeUnknown");
+                lblMapSize.Text = "Size: Not available".L10N("Client:Main:MapSizeUnknown");
+                return;
+            }
+
+            lblMapName.Text = "Map:".L10N("Client:Main:Map") + " " + Renderer.GetSafeString(Map.Name, lblMapName.FontIndex);
+            lblMapAuthor.Text = "By".L10N("Client:Main:AuthorBy") + " " + Renderer.GetSafeString(Map.Author, lblMapAuthor.FontIndex);
+            lblGameMode.Text = "Game mode:".L10N("Client:Main:GameModeLabel") + " " + GameMode.UIName;
+            lblMapSize.Text = "Size:".L10N("Client:Main:MapSize") + " " + Map.GetSizeString();
+        }
+
+        /// <summary>
         /// Changes the current map and game mode.
         /// </summary>
         /// <param name="gameModeMap">The new game mode map.</param>
@@ -2095,24 +2115,14 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             _ = UpdateLaunchGameButtonStatus();
 
+            SetMapLabels();
+
             if (GameMode == null || Map == null)
             {
-                lblMapName.Text = "Map: Unknown".L10N("Client:Main:MapUnknown");
-                lblMapAuthor.Text = "By Unknown Author".L10N("Client:Main:AuthorByUnknown");
-                lblGameMode.Text = "Game mode: Unknown".L10N("Client:Main:GameModeUnknown");
-                lblMapSize.Text = "Size: Not available".L10N("Client:Main:MapSizeUnknown");
-
                 MapPreviewBox.GameModeMap = null;
-
                 OnGameOptionChanged();
-
                 return;
             }
-
-            lblMapName.Text = "Map:".L10N("Client:Main:Map") + " " + Renderer.GetSafeString(Map.Name, lblMapName.FontIndex);
-            lblMapAuthor.Text = "By".L10N("Client:Main:AuthorBy") + " " + Renderer.GetSafeString(Map.Author, lblMapAuthor.FontIndex);
-            lblGameMode.Text = "Game mode:".L10N("Client:Main:GameModeLabel") + " " + GameMode.UIName;
-            lblMapSize.Text = "Size:".L10N("Client:Main:MapSize") + " " + Map.GetSizeString();
 
             disableGameOptionUpdateBroadcast = true;
 

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
@@ -700,6 +700,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             tbMapSearch.Disable();
             btnPickRandomMap.Disable();
             btnMapSortAlphabetically.Disable();
+
+            SetMapLabels();
         }
 
         private void ShowMapList()
@@ -728,6 +730,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             ReadINIForControl(lblGameMode);
             ReadINIForControl(lblMapSize);
             ReadINIForControl(btnMapSortAlphabetically);
+
+            SetMapLabels();
         }
 
         private void MapPreviewBox_LocalStartingLocationSelected(object sender, LocalStartingLocationEventArgs e)


### PR DESCRIPTION
Fix for issue #597. When calling ShowMapList() or HideMapList() the labels are reloaded from the INI file which resets the text. The logic in ChangeMap() that updates the labels to the correct text has been extracted into a new function which is called after the INI resets and within ChangeMap().