### PR TITLE
Add map thumbnail preview to multiplayer game lobby map list hover

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -17,6 +17,7 @@ using DTAClient.DXGUI.Multiplayer.CnCNet;
 using DTAClient.Online.EventArguments;
 using ClientCore.Extensions;
 using TextCopy;
+using System.Reflection;
 
 namespace DTAClient.DXGUI.Multiplayer.GameLobby
 {
@@ -100,6 +101,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                     UpdateDiscordPresence();
             }
         }
+
+        private MapPreviewPanel panelMapPreview;
 
         protected Map Map => GameModeMap?.Map;
         protected GameMode GameMode => GameModeMap?.GameMode;
@@ -212,6 +215,13 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                                                   "https://github.com/CnCNet/xna-cncnet-client/blob/122b2de962afc404e203290d0618363d83c4264a/Docs/Migration-INI.md",
                                                    ex.Message));
             }
+
+            panelMapPreview = new MapPreviewPanel(WindowManager, this.MapLoader);
+            panelMapPreview.Initialize();
+            panelMapPreview.ClearInfo();
+            panelMapPreview.Disable();
+            panelMapPreview.InputEnabled = false;
+            AddChild(panelMapPreview);
 
             btnLeaveGame = FindChild<XNAClientButton>(nameof(btnLeaveGame));
             btnLeaveGame.LeftClick += BtnLeaveGame_LeftClick;
@@ -715,6 +725,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             if (lbGameModeMapList.HoveredIndex < 0 || lbGameModeMapList.HoveredIndex >= lbGameModeMapList.ItemCount)
             {
                 mapListTooltip.Text = string.Empty;
+                panelMapPreview.Disable();
                 return;
             }
 
@@ -724,6 +735,25 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 mapListTooltip.Text = "Original name:".L10N("Client:Main:OriginalMapName") + " " + gmm.Map.UntranslatedName;
             else
                 mapListTooltip.Text = string.Empty;
+
+                ShowMapPreviewPanelForIndex(lbGameModeMapList.HoveredIndex);
+        }
+        private void ShowMapPreviewPanelForIndex(int index)
+        {
+            if (index < 0 || index > lbGameModeMapList.ItemCount)
+            {
+                panelMapPreview.Disable();
+                return;
+            }
+            panelMapPreview.Enable();
+            panelMapPreview.X = lbGameModeMapList.X + lbGameModeMapList.Width;
+            panelMapPreview.Y = lbGameModeMapList.Y;
+
+            XNAListBoxItem item = lbGameModeMapList.GetItem(1, index);
+
+            GameModeMap gameModeMap = (GameModeMap)item.Tag;
+
+            panelMapPreview.SetInfo(gameModeMap);
         }
 
         private void PickRandomMap()

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewPanel.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewPanel.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using ClientCore.Extensions;
+using Microsoft.Xna.Framework.Graphics.PackedVector;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+using Rampastring.XNAUI;
+using Rampastring.XNAUI.XNAControls;
+
+using DTAClient.Domain.Multiplayer;
+
+namespace DTAClient.DXGUI.Multiplayer.GameLobby
+{
+
+    /// <summary>
+    /// A UI panel that displays information about a hosted CnCNet or LAN game.
+    /// </summary>
+    public class MapPreviewPanel : XNAPanel
+    {
+        public MapPreviewPanel(WindowManager windowManager, MapLoader mapLoader)
+            : base(windowManager)
+        {
+            this.mapLoader = mapLoader;
+            DrawMode = ControlDrawMode.UNIQUE_RENDER_TARGET;
+        }
+
+        private MapLoader mapLoader;
+
+        private XNALabel lblMapPreview;
+        private XNALabel lblMapName;
+        private XNALabel lblMapMaxPlayers;
+
+        private GameModeMap map = null;
+
+        private bool disposeTextures = false;
+        private Texture2D mapTexture = null;
+        private Texture2D noMapPreviewTexture = null;
+
+        private int mapPreviewPositionY = 0;
+        private const int initialPanelHeight = 200;
+        private const int initialPanelWidth = 235;
+        private const int maxPreviewHeight = 150;
+        private const int mapPreviewMargin = 1; //border
+        private const int padding = 6;
+
+        public override void Initialize()
+        {
+            ClientRectangle = new Rectangle(0, 0, initialPanelWidth, initialPanelHeight);
+            BackgroundTexture = AssetLoader.CreateTexture(new Color(0, 0, 0, 255), 1, 1);
+            PanelBackgroundDrawMode = PanelBackgroundImageDrawMode.STRETCHED;
+
+            lblMapPreview = new XNALabel(WindowManager);
+            lblMapPreview.FontIndex = 1;
+            lblMapPreview.Text = "MAP PREVIEW".L10N("Client:Main:MapPreview");
+            AddChild(lblMapPreview);
+
+            lblMapName = new XNALabel(WindowManager);
+            lblMapName.FontIndex = 1;
+            lblMapName.Text = "";
+            AddChild(lblMapName);
+
+            lblMapMaxPlayers = new XNALabel(WindowManager);
+            lblMapMaxPlayers.FontIndex = 1;
+            lblMapMaxPlayers.Text = "";
+            AddChild(lblMapMaxPlayers);
+
+            if (AssetLoader.AssetExists("noMapPreview.png"))
+                noMapPreviewTexture = AssetLoader.LoadTexture("noMapPreview.png");
+
+            lblMapPreview.CenterOnParent();
+            lblMapPreview.ClientRectangle = new Rectangle(lblMapPreview.X, padding,
+                lblMapPreview.Width, lblMapPreview.Height);
+            lblMapName.ClientRectangle = new Rectangle(padding, lblMapPreview.Y + lblMapPreview.Height + padding,
+                lblMapName.Width, lblMapName.Height);
+            lblMapMaxPlayers.ClientRectangle = new Rectangle(padding, lblMapName.Y + lblMapName.Height + padding,
+                lblMapMaxPlayers.Width, lblMapMaxPlayers.Height);
+
+            base.Initialize();
+        }
+
+        public void SetInfo(GameModeMap map)
+        {
+            ClearInfo();
+
+            this.map = map;
+
+            lblMapPreview.Visible = true;
+            lblMapName.Text = map.Map.Name;
+            lblMapName.Visible = true;
+            lblMapMaxPlayers.Text = "Max players: ".L10N("Client:Main:MaxPlayers") + map.Map.MaxPlayers.ToString();
+            lblMapMaxPlayers.Y = lblMapName.Y + lblMapName.Height + padding;
+            lblMapMaxPlayers.Visible = true;
+
+            mapPreviewPositionY = lblMapMaxPlayers.Y + lblMapMaxPlayers.Height + padding;
+            this.Height = mapPreviewPositionY + maxPreviewHeight + padding;
+            if (mapLoader != null && map != null)
+            {
+                mapTexture = map.Map.IsPreviewTextureCached() ? map.Map.LoadPreviewTexture() : null;
+                if (mapTexture == null && noMapPreviewTexture != null)
+                {
+                    Debug.Assert(!noMapPreviewTexture.IsDisposed, "noMapPreviewTexture should not be disposed.");
+                    mapTexture = noMapPreviewTexture;
+                    disposeTextures = false;
+                }
+                else
+                {
+                    disposeTextures = true;
+                }
+            }
+        }
+
+        public void ClearInfo()
+        {
+            lblMapPreview.Visible = false;
+            lblMapName.Visible = false;
+            lblMapMaxPlayers.Visible = false;
+
+            if (mapTexture != null && disposeTextures)
+            {
+                Debug.Assert(!mapTexture.IsDisposed, "mapTexture should not be disposed.");
+                mapTexture.Dispose();
+                mapTexture = null;
+            }
+        }
+
+        public override void Draw(GameTime gameTime)
+        {
+            base.Draw(gameTime);
+
+            if (map != null && mapTexture != null)
+                RenderMapPreview();
+        }
+
+        private void RenderMapPreview()
+        {
+            // Calculate map preview area 
+            double xRatio = (ClientRectangle.Width - (mapPreviewMargin*2)) / (double)mapTexture.Width;
+            double yRatio = (ClientRectangle.Height - mapPreviewPositionY) / (double)mapTexture.Height;
+
+            double ratio = Math.Min(xRatio, yRatio); // Choose the smaller ratio for scaling
+            int textureWidth = (int)(mapTexture.Width * ratio);
+            int textureHeight = (int)(mapTexture.Height * ratio);
+
+            // Apply max height constraint
+            if (textureHeight > maxPreviewHeight)
+            {
+                ratio = maxPreviewHeight / (double)mapTexture.Height;
+                textureHeight = maxPreviewHeight;
+                textureWidth = (int)(mapTexture.Width * ratio); // Recalculate width to maintain aspect ratio
+            }
+
+            int texturePositionX = mapPreviewMargin + ((ClientRectangle.Width- (mapPreviewMargin*2)) / 2 - (textureWidth/2)); 
+            int texturePositionY = mapPreviewPositionY;
+
+            DrawTexture(
+                mapTexture,
+                new Rectangle(texturePositionX, texturePositionY, textureWidth, textureHeight),
+                Color.White
+            );
+        }
+    }
+}


### PR DESCRIPTION
Still a bit of a draft but figured I'd submit now and get some initial feedback.

- Do others want this, or just me?
- Would this be better behind a toggle? For example, right click the map list and choose "Show previews"
- Add it to skirmish map list box too?
- Is there other information that should show?

Like the other recent PR from Grant that adds map previews, this preview is only shown for maps with the texture file. The reason for this was lag on large map previews. I've never dealt with threading before - do you think it's possible to load the preview in another thread in order to have all previews working rather than those with just the texture file?

**Here it is currently:**
![XNAMapPreviewGameLobby](https://github.com/user-attachments/assets/a81c96b3-b2a1-497e-b1c5-7ba5e31052ce)
