### PR TITLE
Fix issues when running 2.11.0.0+ in Wine.

### DIFF
--- a/DXMainClient/PreStartup.cs
+++ b/DXMainClient/PreStartup.cs
@@ -17,6 +17,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using ClientCore.I18N;
 using System.Globalization;
+using System.Security;
 using System.Transactions;
 
 namespace DTAClient
@@ -345,11 +346,18 @@ namespace DTAClient
                         if (ntAccount == null)
                             continue;
 
-                        if (principal.IsInRole(ntAccount.Value))
+                        try
                         {
-                            if (fsAccessRule.AccessControlType == AccessControlType.Deny)
-                                return false;
-                            isInRoleWithAccess = true;
+                            if (principal.IsInRole(ntAccount.Value))
+                            {
+                                if (fsAccessRule.AccessControlType == AccessControlType.Deny)
+                                    return false;
+                                isInRoleWithAccess = true;
+                            }
+                        }
+                        catch (SecurityException)
+                        {
+                            //IsInRole may throw when running in Wine
                         }
                     }
                 }

--- a/DXMainClient/PreStartup.cs
+++ b/DXMainClient/PreStartup.cs
@@ -357,7 +357,8 @@ namespace DTAClient
                         }
                         catch (SecurityException)
                         {
-                            //IsInRole may throw when running in Wine
+                            //IsInRole may throw for selected roles when running in Wine, keep iterating other rules 
+                            continue;
                         }
                     }
                 }

--- a/DXMainClient/Startup.cs
+++ b/DXMainClient/Startup.cs
@@ -62,6 +62,7 @@ namespace DTAClient
                 thread.Start();
             }
 
+            // Using tasks here causes crashes on Wine for some reason
             Thread onlineIdThread = new Thread(GenerateOnlineId);
             onlineIdThread.Start();
 

--- a/DXMainClient/Startup.cs
+++ b/DXMainClient/Startup.cs
@@ -62,7 +62,8 @@ namespace DTAClient
                 thread.Start();
             }
 
-            GenerateOnlineIdAsync();
+            Thread onlineIdThread = new Thread(GenerateOnlineId);
+            onlineIdThread.Start();
 
 #if ARES
             Task.Factory.StartNew(() => PruneFiles(SafePath.GetDirectory(ProgramConstants.GamePath, "debug"), DateTime.Now.AddDays(-7)));
@@ -329,7 +330,7 @@ namespace DTAClient
         /// <summary>
         /// Generate an ID for online play.
         /// </summary>
-        private static async Task GenerateOnlineIdAsync()
+        private static void GenerateOnlineId()
         {
 #if !WINFORMS
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -338,7 +339,6 @@ namespace DTAClient
 #pragma warning disable format
                 try
                 {
-                    await Task.CompletedTask;
                     ManagementObjectCollection mbsList = null;
                     ManagementObjectSearcher mbs = new ManagementObjectSearcher("Select * From Win32_processor");
                     mbsList = mbs.Get();
@@ -386,7 +386,7 @@ namespace DTAClient
             {
                 try
                 {
-                    string machineId = await File.ReadAllTextAsync("/var/lib/dbus/machine-id");
+                    string machineId = File.ReadAllText("/var/lib/dbus/machine-id");
 
                     Connection.SetId(machineId);
                 }


### PR DESCRIPTION
This PR fixes two issues occuring after upgrading YR client to 8.65+ when running in Wine (Linux).

.NET Framework 4.8 version hangs in WMIC when generating online id. Changing from async function to a manual thread (like in CheckSystemSpecifications()) solves the issue.

.NET 8 version throws SecurityException which crashes the app when checking directory permissions. Catching the exception solves the issue.

From SteamOS/Linux user perspective it is easier to keep using Windows executables, which worked up until 2.11.0.0, so it would be nice if these fixes could be merged.

Thanks.