### PR TITLE
Fix parsing error with IPv6 addresses in CnCNetTunnel

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetGameLoadingLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetGameLoadingLobby.cs
@@ -16,6 +16,7 @@ using Rampastring.XNAUI.XNAControls;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Linq;
 
 namespace DTAClient.DXGUI.Multiplayer.CnCNet
 {
@@ -567,9 +568,23 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             if (sender != hostName)
                 return;
 
-            string[] split = tunnelAddressAndPort.Split(':');
-            string tunnelAddress = split[0];
-            int tunnelPort = int.Parse(split[1]);
+            string tunnelAddress;
+            int tunnelPort;
+
+            if (tunnelAddressAndPort.Count(c => c == ':') > 1)
+            {
+                // IPv6 address
+                int lastColonIndex = tunnelAddressAndPort.LastIndexOf(':');
+                tunnelAddress = tunnelAddressAndPort.Substring(0, lastColonIndex);
+                tunnelPort = int.Parse(tunnelAddressAndPort.Substring(lastColonIndex + 1));
+            }
+            else
+            {
+                // IPv4 address or hostname
+                string[] detailedAddress = tunnelAddressAndPort.Split(':');
+                tunnelAddress = detailedAddress[0];
+                tunnelPort = int.Parse(detailedAddress[1]);
+            }
 
             CnCNetTunnel tunnel = tunnelHandler.Tunnels.Find(t => t.Address == tunnelAddress && t.Port == tunnelPort);
             if (tunnel == null)

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
@@ -1521,9 +1521,24 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 string mapName = splitMessage[7];
                 string gameMode = splitMessage[8];
 
-                string[] tunnelAddressAndPort = splitMessage[9].Split(':');
-                string tunnelAddress = tunnelAddressAndPort[0];
-                int tunnelPort = int.Parse(tunnelAddressAndPort[1]);
+                string tunnelAddressAndPort = splitMessage[9];
+                string tunnelAddress;
+                int tunnelPort;
+
+                if (tunnelAddressAndPort.Count(c => c == ':') > 1)
+                {
+                    // IPv6 address
+                    int lastColonIndex = tunnelAddressAndPort.LastIndexOf(':');
+                    tunnelAddress = tunnelAddressAndPort.Substring(0, lastColonIndex);
+                    tunnelPort = int.Parse(tunnelAddressAndPort.Substring(lastColonIndex + 1));
+                }
+                else
+                {
+                    // IPv4 address or hostname
+                    string[] detailedAddress = tunnelAddressAndPort.Split(':');
+                    tunnelAddress = detailedAddress[0];
+                    tunnelPort = int.Parse(detailedAddress[1]);
+                }
 
                 string loadedGameId = splitMessage[10];
                 int gameDifficulty = int.Parse(splitMessage[11]);

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -1566,9 +1566,23 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             if (sender != hostName)
                 return;
 
-            string[] split = tunnelAddressAndPort.Split(':');
-            string tunnelAddress = split[0];
-            int tunnelPort = int.Parse(split[1]);
+            string tunnelAddress;
+            int tunnelPort;
+
+            if (tunnelAddressAndPort.Count(c => c == ':') > 1)
+            {
+                // IPv6 address
+                int lastColonIndex = tunnelAddressAndPort.LastIndexOf(':');
+                tunnelAddress = tunnelAddressAndPort.Substring(0, lastColonIndex);
+                tunnelPort = int.Parse(tunnelAddressAndPort.Substring(lastColonIndex + 1));
+            }
+            else
+            {
+                // IPv4 address or hostname
+                string[] detailedAddress = tunnelAddressAndPort.Split(':');
+                tunnelAddress = detailedAddress[0];
+                tunnelPort = int.Parse(detailedAddress[1]);
+            }
 
             CnCNetTunnel tunnel = tunnelHandler.Tunnels.Find(t => t.Address == tunnelAddress && t.Port == tunnelPort);
             if (tunnel == null)

--- a/DXMainClient/Domain/Multiplayer/CnCNet/CnCNetTunnel.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/CnCNetTunnel.cs
@@ -41,7 +41,7 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
                 {
                     // IPv6 address
                     int lastColonIndex = address.LastIndexOf(':');
-                    host = address.Substring(0, lastColonIndex);
+                    host = "[" + address.Substring(0, lastColonIndex) + "]";
                     port = int.Parse(address.Substring(lastColonIndex + 1));
                 }
                 else
@@ -113,7 +113,16 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
                 Logger.Log($"Contacting tunnel at {Address}:{Port}");
 
                 // Do not use https here as not supported by tunnels
-                string addressString = $"http://{Address}:{Port}/request?clients={playerCount}";
+                string addressString;
+
+                if (Address.Count(c => c == ':') > 1)
+                { //IPV6
+                    addressString = $"http://{Address}:{Port}/request?clients={playerCount}";
+                }
+                else
+                { //IPV4 or hostname
+                    addressString = $"http://{Address}:{Port}/request?clients={playerCount}";
+                }
                 Logger.Log($"Downloading from {addressString}");
 
                 using (var client = new ExtendedWebClient(REQUEST_TIMEOUT))

--- a/DXMainClient/Domain/Multiplayer/CnCNet/CnCNetTunnel.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/CnCNetTunnel.cs
@@ -113,16 +113,7 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
                 Logger.Log($"Contacting tunnel at {Address}:{Port}");
 
                 // Do not use https here as not supported by tunnels
-                string addressString;
-
-                if (Address.Count(c => c == ':') > 1)
-                { //IPV6
-                    addressString = $"http://{Address}:{Port}/request?clients={playerCount}";
-                }
-                else
-                { //IPV4 or hostname
-                    addressString = $"http://{Address}:{Port}/request?clients={playerCount}";
-                }
+                string addressString = $"http://{Address}:{Port}/request?clients={playerCount}";
                 Logger.Log($"Downloading from {addressString}");
 
                 using (var client = new ExtendedWebClient(REQUEST_TIMEOUT))

--- a/DXMainClient/Domain/Multiplayer/CnCNet/CnCNetTunnel.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/CnCNetTunnel.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 
@@ -33,10 +34,26 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
                 string[] parts = str.Split(';');
 
                 string address = parts[0];
-                string[] detailedAddress = address.Split(new char[] { ':' });
-                
-                tunnel.Address = detailedAddress[0];
-                tunnel.Port = int.Parse(detailedAddress[1]);
+                string host;
+                int port;
+
+                if (address.Count(c => c == ':') > 1)
+                {
+                    // IPv6 address
+                    int lastColonIndex = address.LastIndexOf(':');
+                    host = address.Substring(0, lastColonIndex);
+                    port = int.Parse(address.Substring(lastColonIndex + 1));
+                }
+                else
+                {
+                    // IPv4 address or hostname
+                    string[] detailedAddress = address.Split(':');
+                    host = detailedAddress[0];
+                    port = int.Parse(detailedAddress[1]);
+                }
+
+                tunnel.Address = host;
+                tunnel.Port = port;
                 tunnel.Country = parts[1];
                 tunnel.CountryCode = parts[2];
                 tunnel.Name = parts[3];


### PR DESCRIPTION
I saw in my logs a parsing error when encountering tunnels with IPV6 addresses. I am assuming the fix is to parse these correctly rather than discard tunnels with IPV6 addresses (I haven't tried connecting to any so don't know if they cause errors). 


For reference, the error that was appearing in my logs:
21.01. 19:30:52.509    Fetching tunnel server info.
21.01. 19:30:52.824    Parsing tunnel information failed: System.FormatException: Input string was not in a correct format.
   at System.Number.StringToNumber(String str, NumberStyles options, NumberBuffer& number, NumberFormatInfo info, Boolean parseDecimal)
   at System.Number.ParseInt32(String s, NumberStyles style, NumberFormatInfo info)
   at DTAClient.Domain.Multiplayer.CnCNet.CnCNetTunnel.Parse(String str) in C:\Dev\xna-cncnet-client\DXMainClient\Domain\Multiplayer\CnCNet\CnCNetTunnel.cs:line 39
Parsed string: 240e:33d:343:bf80::1017:50000;China;CN;yuki;0;0;200;0;0;0;2;0