### PR TITLE
Add optional parameter to [ForcedOptions] to make changes optional

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -2235,6 +2235,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             PlayerExtraOptionsPanel?.UpdateForMap(Map);
         }
+        
         private void ApplyForcedCheckBoxOptions(List<GameLobbyCheckBox> optionList,
     List<KeyValuePair<string, string>> forcedOptions)
         {
@@ -2251,7 +2252,6 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 }
             }
         }
-
 
         private void ApplyForcedDropDownOptions(List<GameLobbyDropDown> optionList,
             List<KeyValuePair<string, int>> forcedOptions)

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -2235,21 +2235,23 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             PlayerExtraOptionsPanel?.UpdateForMap(Map);
         }
-
         private void ApplyForcedCheckBoxOptions(List<GameLobbyCheckBox> optionList,
-            List<KeyValuePair<string, bool>> forcedOptions)
+    List<KeyValuePair<string, string>> forcedOptions)
         {
-            foreach (KeyValuePair<string, bool> option in forcedOptions)
+            foreach (KeyValuePair<string, string> option in forcedOptions)
             {
+                string[] optionParts = option.Value.Split(',');
                 GameLobbyCheckBox checkBox = CheckBoxes.Find(chk => chk.Name == option.Key);
                 if (checkBox != null)
                 {
-                    checkBox.Checked = option.Value;
-                    checkBox.AllowChecking = false;
+                    checkBox.Checked = bool.Parse(optionParts[0]);
+                    checkBox.AllowChecking = optionParts.Length > 1 ? bool.Parse(optionParts[1]) : false;
+
                     optionList.Remove(checkBox);
                 }
             }
         }
+
 
         private void ApplyForcedDropDownOptions(List<GameLobbyDropDown> optionList,
             List<KeyValuePair<string, int>> forcedOptions)

--- a/DXMainClient/Domain/Multiplayer/GameMode.cs
+++ b/DXMainClient/Domain/Multiplayer/GameMode.cs
@@ -71,7 +71,7 @@ namespace DTAClient.Domain.Multiplayer
 
         public List<Map> Maps = new List<Map>();
 
-        public List<KeyValuePair<string, bool>> ForcedCheckBoxValues = new List<KeyValuePair<string, bool>>();
+        public List<KeyValuePair<string, string>> ForcedCheckBoxValues = new List<KeyValuePair<string, string>>();
         public List<KeyValuePair<string, int>> ForcedDropDownValues = new List<KeyValuePair<string, int>>();
 
         private List<KeyValuePair<string, string>> ForcedSpawnIniOptions = new List<KeyValuePair<string, string>>();
@@ -126,7 +126,7 @@ namespace DTAClient.Domain.Multiplayer
                 }
                 else
                 {
-                    ForcedCheckBoxValues.Add(new KeyValuePair<string, bool>(key, Conversions.BooleanFromString(value, false)));
+                    ForcedCheckBoxValues.Add(new KeyValuePair<string, string>(key, value));
                 }
             }
         }

--- a/DXMainClient/Domain/Multiplayer/Map.cs
+++ b/DXMainClient/Domain/Multiplayer/Map.cs
@@ -256,7 +256,7 @@ namespace DTAClient.Domain.Multiplayer
         public bool ExtractCustomPreview { get; set; } = true;
 
         [JsonInclude]
-        public List<KeyValuePair<string, bool>> ForcedCheckBoxValues = new List<KeyValuePair<string, bool>>(0);
+        public List<KeyValuePair<string, string>> ForcedCheckBoxValues = new List<KeyValuePair<string, string>>(0);
 
         [JsonInclude]
         public List<KeyValuePair<string, int>> ForcedDropDownValues = new List<KeyValuePair<string, int>>(0);
@@ -664,7 +664,7 @@ namespace DTAClient.Domain.Multiplayer
                 }
                 else
                 {
-                    ForcedCheckBoxValues.Add(new KeyValuePair<string, bool>(key, Conversions.BooleanFromString(value, false)));
+                    ForcedCheckBoxValues.Add(new KeyValuePair<string, string>(key, value));
                 }
             }
         }


### PR DESCRIPTION
Currently with maps you can force options with:

[ForcedOptions]
chkNoSpy=true
chkShortGame=false
chkBalancePatch=true
...etc

Doing this will force the checkboxes to the value provided (true=ticked, false=unticked) **_and_** lock the checkbox (checkBox.AllowChecking = False).

This PR adds an optional second parameter that sets the value for checkbox.AllowChecking

So essentially it allows maps to force options, but still allows hosts to change them.


[ForcedOptions]
chkNoSpy=true,false
chkShortGame=false
chkBalancePatch=true,true
...etc

![image](https://github.com/user-attachments/assets/8eef1c3e-4a04-4158-bafb-2de7218d21e1)
