### PR TITLE
Add L10N to the components in the XNAMessageBox

### DIFF
--- a/DTAConfig/OptionPanels/ComponentsPanel.cs
+++ b/DTAConfig/OptionPanels/ComponentsPanel.cs
@@ -166,7 +166,7 @@ namespace DTAConfig.OptionPanels
                         "This will take an additional {1} of disk space, and the download may take some time\n" +
                         "depending on your Internet connection speed. The size of the download is {2}.\n\n" +
                         "You will not be able to play during the download. Do you wish to continue?").L10N("Client:DTAConfig:UpdateConfirmRequiredText"),
-                        cc.GUIName, GetSizeString(cc.RemoteSize), GetSizeString(cc.Archived ? cc.RemoteArchiveSize : cc.RemoteSize)),
+                        cc.GUIName.L10N($"INI:CustomComponents:{cc.ININame}:UIName"), GetSizeString(cc.RemoteSize), GetSizeString(cc.Archived ? cc.RemoteArchiveSize : cc.RemoteSize)),
                     XNAMessageBoxButtons.YesNo);
 
                 msgBox.Tag = btn;
@@ -247,7 +247,7 @@ namespace DTAConfig.OptionPanels
                         string.Format(("Download of optional component {0} failed.\n" +
                         "See client.log for details.\n\n" +
                         "If this problem continues, please contact your mod's authors for support.").L10N("Client:DTAConfig:OptionalComponentDownloadFailedText"),
-                        cc.GUIName));
+                        cc.GUIName.L10N($"INI:CustomComponents:{cc.ININame}:UIName")));
                 }
 
                 btn.Text = "Install".L10N("Client:DTAConfig:Install") + $" ({GetSizeString(cc.RemoteSize)})";
@@ -258,7 +258,7 @@ namespace DTAConfig.OptionPanels
             else
             {
                 XNAMessageBox.Show(WindowManager, "Download Completed".L10N("Client:DTAConfig:DownloadCompleteTitle"),
-                    string.Format("Download of optional component {0} completed succesfully.".L10N("Client:DTAConfig:DownloadCompleteText"), cc.GUIName));
+                    string.Format("Download of optional component {0} completed succesfully.".L10N("Client:DTAConfig:DownloadCompleteText"), cc.GUIName.L10N($"INI:CustomComponents:{cc.ININame}:UIName")));
                 btn.Text = "Uninstall".L10N("Client:DTAConfig:Uninstall");
             }
         }


### PR DESCRIPTION
As MarkJFox mentioned, there is a bug where the client doesn't show the translated component name in the install message boxes. PR should fix this.

<details>
<summary>Before:</summary>

![image](https://github.com/user-attachments/assets/fb1acb88-e932-48c1-94bc-b6c41eda8fc5)
![image](https://github.com/user-attachments/assets/28e804a4-079f-4b3e-bc0c-d377fedce7f2)

</details>

<details>
<summary>After:</summary>

![Снимок экрана 2025-01-30 173133](https://github.com/user-attachments/assets/81a45ec5-89a1-4d9a-9e89-af9ec58519a7)
![Снимок экрана 2025-01-30 173309](https://github.com/user-attachments/assets/cf0330bb-1168-4655-9437-30025318b15c)
![Снимок экрана 2025-01-30 173426](https://github.com/user-attachments/assets/7ddcb16d-e719-45ef-809c-47dc5839aabd)

</details>