### PR TITLE
Fix concurrency issue in LoadCustomMaps by using a thread-safe collection

### DIFF
--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -164,7 +164,7 @@ namespace DTAClient.Domain.Multiplayer
 
             IEnumerable<FileInfo> mapFiles = customMapsDirectory.EnumerateFiles($"*{MAP_FILE_EXTENSION}");
             ConcurrentDictionary<string, Map> customMapCache = LoadCustomMapCache();
-            var localMapSHAs = new List<string>();
+            var localMapSHAs = new ConcurrentBag<string>();
 
             var tasks = new List<Task>();
 


### PR DESCRIPTION
Had an "IndexOutOfRangeException" today on **localMapSHAs.Add(map.SHA1);** and I think this is the fix for it. 
I don't know anything when it comes to threading so hopefully one of the propeller heads around here can verify this.