### PR TITLE
Allow user-defined network settings via NetworkDefinitions.local.ini

### DIFF
--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -21,6 +21,7 @@ namespace ClientCore
         private const string CLIENT_SETTINGS = "DTACnCNetClient.ini";
         private const string GAME_OPTIONS = "GameOptions.ini";
         private const string CLIENT_DEFS = "ClientDefinitions.ini";
+        private const string NETWORK_DEFS_LOCAL = "NetworkDefinitions.local.ini";
         private const string NETWORK_DEFS = "NetworkDefinitions.ini";
 
         private static ClientConfiguration _instance;
@@ -48,7 +49,17 @@ namespace ClientCore
 
             gameOptions_ini = new IniFile(SafePath.CombineFilePath(baseResourceDirectory.FullName, GAME_OPTIONS));
 
-            networkDefinitionsIni = new IniFile(SafePath.CombineFilePath(ProgramConstants.GetResourcePath(), NETWORK_DEFS));
+            string networkDefsPathLocal = SafePath.CombineFilePath(ProgramConstants.GetResourcePath(), NETWORK_DEFS_LOCAL);
+            if (File.Exists(networkDefsPathLocal))
+            {
+                networkDefinitionsIni = new IniFile(networkDefsPathLocal);
+                Logger.Log("Loaded network definitions from NetworkDefinitions.local.ini (user override)");
+            }
+            else
+            {
+                string networkDefsPath = SafePath.CombineFilePath(ProgramConstants.GetResourcePath(), NETWORK_DEFS);
+                networkDefinitionsIni = new IniFile(networkDefsPath);
+            }
         }
 
         /// <summary>

--- a/DXMainClient/PreStartup.cs
+++ b/DXMainClient/PreStartup.cs
@@ -88,9 +88,8 @@ namespace DTAClient
             if (!clientUserFilesDirectory.Exists)
                 clientUserFilesDirectory.Create();
 
-            MainClientConstants.Initialize();
-
             Logger.Log("***Logfile for " + MainClientConstants.GAME_NAME_LONG + " client***");
+
 
             string clientVersion = GitVersionInformation.AssemblySemVer;
 #if DEVELOPMENT_BUILD
@@ -103,6 +102,7 @@ namespace DTAClient
 #if DEVELOPMENT_BUILD
             Logger.Log("This is a development build of the client. Stability and reliability may not be fully guaranteed.");
 #endif
+            MainClientConstants.Initialize();
 
             // Log information about given startup params
             if (parameters.NoAudio)

--- a/DXMainClient/PreStartup.cs
+++ b/DXMainClient/PreStartup.cs
@@ -90,7 +90,6 @@ namespace DTAClient
 
             Logger.Log("***Logfile for " + MainClientConstants.GAME_NAME_LONG + " client***");
 
-
             string clientVersion = GitVersionInformation.AssemblySemVer;
 #if DEVELOPMENT_BUILD
             clientVersion = $"{GitVersionInformation.CommitDate} {GitVersionInformation.BranchName}@{GitVersionInformation.ShortSha}";


### PR DESCRIPTION
For #653 
Adds check for NetworkDefinitions.local.ini

The changes in PreStartup.cs are to fix the logging as the network definitions were loaded before the initial log file outputs.

So instead of:
10.02. 10:25:54.356    Loaded network definitions from NetworkDefinitions.local.ini (user override)
10.02. 10:25:54.361    ***Logfile for Yuri's Revenge client***
10.02. 10:25:54.387    Client version: 2025-02-05 develop@f11f56f
10.02. 10:25:54.387    2.11.0-beta.199+Branch.develop.Sha.f11f56f5a80f141faa998cf3566948afe5021d1c
10.02. 10:25:54.388    This is a development build of the client. Stability and reliability may not be fully guaranteed.
10.02. 10:25:54.389    Loading settings.

It will show:
10.02. 10:32:12.032    ***Logfile for CnCNet Client client***
10.02. 10:32:12.059    Client version: 2025-02-05 develop@f11f56f
10.02. 10:32:12.060    2.11.0-beta.199+Branch.develop.Sha.f11f56f5a80f141faa998cf3566948afe5021d1c
10.02. 10:32:12.068    This is a development build of the client. Stability and reliability may not be fully guaranteed.
10.02. 10:32:12.087    Loaded network definitions from NetworkDefinitions.local.ini (user override)
10.02. 10:32:12.092    Loading settings.