### PR TITLE
Add ability for host to change game lobby name

### DIFF
--- a/ClientCore/CnCNet5/NameValidator.cs
+++ b/ClientCore/CnCNet5/NameValidator.cs
@@ -60,8 +60,41 @@ namespace ClientCore.CnCNet5
 
             if (validName.Length > ClientConfiguration.Instance.MaxNameLength)
                 return validName.Substring(0, ClientConfiguration.Instance.MaxNameLength);
-            
+
             return validName;
+        }
+
+        /// <summary>
+        /// Checks if a lobby name is valid for CnCNet.
+        /// </summary>
+        /// <param name="lobbyName">Game lobby name.</param>
+        /// <returns>Null if the lobby name is valid, otherwise a string that tells
+        /// what is wrong with the name.</returns>
+        public static string IsLobbyNameValid(string lobbyName)
+        {
+
+            if (string.IsNullOrEmpty(lobbyName))
+            {
+                return "Please enter a lobby name.".L10N("Client:Main:GameNameMissing");
+            }
+
+            char[] disallowedCharacters = { ',', ';' };
+            if (lobbyName.IndexOfAny(disallowedCharacters) != -1)
+            {
+                return "Lobby name contains disallowed characters.".L10N("Client:Main:GameNameDisallowedChars");
+            }
+
+            if (lobbyName.Length > 23)
+            {
+                return "Lobby name is too long.".L10N("Client:Main:GameNameTooLong");
+            }
+
+            if (new ProfanityFilter().IsOffensive(lobbyName))
+            {
+                return "Please enter a less offensive game name.".L10N("Client:Main:GameNameOffensiveText");
+            }
+
+            return null;
         }
     }
 }

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/GameCreationWindow.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/GameCreationWindow.cs
@@ -8,6 +8,7 @@ using Rampastring.XNAUI;
 using Rampastring.XNAUI.XNAControls;
 using System;
 using System.IO;
+using ClientCore.CnCNet5;
 
 namespace DTAClient.DXGUI.Multiplayer.CnCNet
 {
@@ -239,17 +240,14 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
         private void BtnCreateGame_LeftClick(object sender, EventArgs e)
         {
-            string gameName = tbGameName.Text.Replace(";", string.Empty);
 
-            if (string.IsNullOrEmpty(gameName))
-            {
-                return;
-            }
+            var lobbyName = tbGameName.Text;
+            var lobbyNameValid = NameValidator.IsLobbyNameValid(lobbyName);
 
-            if (new ProfanityFilter().IsOffensive(gameName))
+            if (!string.IsNullOrEmpty(lobbyNameValid))
             {
-                XNAMessageBox.Show(WindowManager, "Offensive game name".L10N("Client:Main:GameNameOffensiveTitle"),
-                    "Please enter a less offensive game name.".L10N("Client:Main:GameNameOffensiveText"));
+                XNAMessageBox.Show(WindowManager, "Invalid lobby name".L10N("Client:Main:GameNameInvalid"),
+                    lobbyNameValid);
                 return;
             }
 
@@ -259,7 +257,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             }
 
             GameCreated?.Invoke(this, 
-                new GameCreationEventArgs(gameName,int.Parse(ddMaxPlayers.SelectedItem.Text), 
+                new GameCreationEventArgs(lobbyName, int.Parse(ddMaxPlayers.SelectedItem.Text), 
                 tbPassword.Text,tunnelHandler.Tunnels[lbTunnelList.SelectedIndex],
                 ddSkillLevel.SelectedIndex)
             );

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -88,7 +88,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 new StringCommandHandler("MM", CheaterNotification),
                 new StringCommandHandler(DICE_ROLL_MESSAGE, HandleDiceRollResult),
                 new NoParamCommandHandler(CHEAT_DETECTED_MESSAGE, HandleCheatDetectedMessage),
-                new NoParamCommandHandler(LOBBY_NAME_CHANGED, HandleLobbyNameChangeMessage),
+                new StringCommandHandler(LOBBY_NAME_CHANGED, HandleLobbyNameChangeMessage),
                 new StringCommandHandler(CHANGE_TUNNEL_SERVER_MESSAGE, HandleTunnelServerChangeMessage)
             };
 
@@ -1565,8 +1565,11 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         private void HandleCheatDetectedMessage(string sender) =>
             AddNotice(string.Format("{0} has modified game files during the client session. They are likely attempting to cheat!".L10N("Client:Main:PlayerModifyFileCheat"), sender), Color.Red);
 
-        private void HandleLobbyNameChangeMessage(string sender) =>
-            AddNotice("The game host has changed the lobby name.".L10N("Client:Main:LobbyNameChanged"));
+        private void HandleLobbyNameChangeMessage(string sender, string newLobbyName)
+        {
+            AddNotice(String.Format("The game host has changed the lobby name to {0}".L10N("Client:Main:LobbyNameChanged"), newLobbyName));
+            channel.UIName = newLobbyName;
+        }
 
         private void HandleTunnelServerChangeMessage(string sender, string tunnelAddressAndPort)
         {
@@ -1909,7 +1912,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             AccelerateGameBroadcasting();
 
             //inform the players in the room
-            channel.SendCTCPMessage(LOBBY_NAME_CHANGED, QueuedMessageType.SYSTEM_MESSAGE, priority: 9);
+            channel.SendCTCPMessage(LOBBY_NAME_CHANGED + " " + lobbyName, QueuedMessageType.SYSTEM_MESSAGE, priority: 9);
             AddNotice(String.Format("Lobby name changed to {0}.".L10N("Client:Main:LobbyNameChanged"),lobbyName));
         }
 

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -1567,7 +1567,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
         private void HandleLobbyNameChangeMessage(string sender, string newLobbyName)
         {
-            AddNotice(String.Format("The game host has changed the lobby name to {0}".L10N("Client:Main:LobbyNameChanged"), newLobbyName));
+            AddNotice(String.Format("The game host has changed the lobby name to {0}".L10N("Client:Main:HostLobbyNameChanged"), newLobbyName));
             channel.UIName = newLobbyName;
         }
 

--- a/DXMainClient/Online/Channel.cs
+++ b/DXMainClient/Online/Channel.cs
@@ -63,7 +63,7 @@ namespace DTAClient.Online
 
         #region Public members
 
-        public string UIName { get; }
+        public string UIName { get; set; }
 
         public string ChannelName { get; }
 


### PR DESCRIPTION
Adds the ability for the host to change a game lobby name from within the lobby itself. The host can type:

/lobbyname <newname>

The new name is validated, then broadcast to all online players, and all players in the channel.

I've moved the lobby name validation checks to the NameValidator.cs file.
