### PR TITLE
Profanity filter changes

### DIFF
--- a/ClientCore/CnCNet5/NameValidator.cs
+++ b/ClientCore/CnCNet5/NameValidator.cs
@@ -13,7 +13,7 @@ namespace ClientCore.CnCNet5
         /// what is wrong with the name.</returns>
         public static string IsNameValid(string name)
         {
-            var profanityFilter = new ProfanityFilter();
+            var profanityFilter = new ProfanityFilter(new[] { "admin" });
 
             if (string.IsNullOrEmpty(name))
                 return "Please enter a name.".L10N("Client:ClientCore:EnterAName");

--- a/ClientCore/ProfanityFilter.cs
+++ b/ClientCore/ProfanityFilter.cs
@@ -11,14 +11,20 @@ namespace ClientCore
     {
         private const char CENSOR_CHAR = '*';
         private readonly Regex _combinedRegex;
-        
-        public ProfanityFilter()
-        {
+
+        /// <summary>
+        /// Creates a new profanity filter with a default set of censored words.
+        /// </summary>
+        /// <param name="extraWords">Any extra words to be considered profane.</param>
+        /// 
+        public ProfanityFilter(IEnumerable<string> extraWords = null)
+        {        
             var defaultWords = new[]
             {
-                "fuck", "shit", "cunt", "nigger", "cock",
-                "hitler", "pussy", "akbar", "allahu", "paki"
+                "fuck", "shit", "cunt", "nigger", "nigga", "niggr", "cock",
+                "hitler", "pussy", "akbar", "allahu", "paki", "twat"
             };
+            var allWords = defaultWords.Concat(extraWords ?? Enumerable.Empty<string>());
 
             //for each bad word
             //      for each letter in the bad word,
@@ -27,7 +33,7 @@ namespace ClientCore
             //          ignore hyphens/underscores/whitespace after the letter (ex: s_h_!_t)
             // join into one big, ugly pattern
 
-            var patterns = defaultWords
+            var patterns = allWords
                 .Select(word => string.Join(
                     @"[-_\s]*",  //ignore hyphens/underscores/whitespace after the letter (ex: s_h !_t)
                     word.Select(c => 
@@ -54,6 +60,11 @@ namespace ClientCore
             );
         }
 
+        /// <summary>
+        /// Checks if the text contains profanities.
+        /// </summary>
+        /// <param name="text">The text to be checked for profanities.</param>
+        /// 
         public bool IsOffensive(string text)
         {
             if (string.IsNullOrWhiteSpace(text))
@@ -62,6 +73,12 @@ namespace ClientCore
             return _combinedRegex.IsMatch(text);
         }
 
+        /// <summary>
+        /// Censors profane words with asterisks in the provided text.
+        /// </summary>
+        /// <param name="text">The text to be censored.</param>
+        /// <param name="respectSetting">Whether or not to abide by the user's chosen setting for censoring profanity.</param>
+        /// 
         public string CensorText(string text, bool respectSetting)
         {
             if (respectSetting && !UserINISettings.Instance.FilterProfanity)

--- a/ClientCore/ProfanityFilter.cs
+++ b/ClientCore/ProfanityFilter.cs
@@ -62,8 +62,13 @@ namespace ClientCore
             return _combinedRegex.IsMatch(text);
         }
 
-        public string CensorText(string text)
+        public string CensorText(string text, bool respectSetting)
         {
+            if (respectSetting && !UserINISettings.Instance.FilterProfanity)
+            {
+                return text;
+            }
+
             if (string.IsNullOrWhiteSpace(text))
                 return text;
 

--- a/ClientCore/ProfanityFilter.cs
+++ b/ClientCore/ProfanityFilter.cs
@@ -9,6 +9,7 @@ namespace ClientCore
 {
     public class ProfanityFilter
     {
+        private const char CENSOR_CHAR = '*';
         private readonly Regex _combinedRegex;
         
         public ProfanityFilter()
@@ -67,7 +68,7 @@ namespace ClientCore
                 return text;
 
             return _combinedRegex.Replace(text, match =>
-                new string('*', match.Groups[1].Length)
+                new string(CENSOR_CHAR, match.Groups[1].Length)
             );
         }
     }

--- a/ClientCore/Settings/UserINISettings.cs
+++ b/ClientCore/Settings/UserINISettings.cs
@@ -94,6 +94,7 @@ namespace ClientCore
             AutomaticCnCNetLogin = new BoolSetting(iniFile, MULTIPLAYER, "AutomaticCnCNetLogin", false);
             DiscordIntegration = new BoolSetting(iniFile, MULTIPLAYER, "DiscordIntegration", true);
             AllowGameInvitesFromFriendsOnly = new BoolSetting(iniFile, MULTIPLAYER, "AllowGameInvitesFromFriendsOnly", false);
+            FilterProfanity = new BoolSetting(iniFile, MULTIPLAYER, "FilterProfanity", true);
             NotifyOnUserListChange = new BoolSetting(iniFile, MULTIPLAYER, "NotifyOnUserListChange", true);
             DisablePrivateMessagePopups = new BoolSetting(iniFile, MULTIPLAYER, "DisablePrivateMessagePopups", false);
             AllowPrivateMessagesFromState = new IntSetting(iniFile, MULTIPLAYER, "AllowPrivateMessagesFromState", (int)AllowPrivateMessagesFromEnum.All);
@@ -195,6 +196,7 @@ namespace ClientCore
         public BoolSetting AutomaticCnCNetLogin { get; private set; }
         public BoolSetting DiscordIntegration { get; private set; }
         public BoolSetting AllowGameInvitesFromFriendsOnly { get; private set; }
+        public BoolSetting FilterProfanity { get; private set; }
 
         public BoolSetting NotifyOnUserListChange { get; private set; }
 

--- a/DTAConfig/OptionPanels/CnCNetOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/CnCNetOptionsPanel.cs
@@ -14,6 +14,16 @@ namespace DTAConfig.OptionPanels
 {
     class CnCNetOptionsPanel : XNAOptionsPanel
     {
+        private const int PADDING_X = 12;
+        private const int PADDING_Y = 14;
+        private const int DD_Y_OFFSET = 2;
+        private const int DD_HEIGHT = 22;
+        private const int DD_PM_WIDTH = 65;
+        private const int CHECKBOX_SPACING = 4;
+        private const int GROUP_SPACING_X = 22;
+        private const int LABEL_WIDTH = 200;
+        private const int LABEL_HEIGHT = 20;
+
         public CnCNetOptionsPanel(WindowManager windowManager, UserINISettings iniSettings,
             GameCollection gameCollection)
             : base(windowManager, iniSettings)
@@ -24,16 +34,13 @@ namespace DTAConfig.OptionPanels
         XNAClientCheckBox chkPingUnofficialTunnels;
         XNAClientCheckBox chkWriteInstallPathToRegistry;
         XNAClientCheckBox chkPlaySoundOnGameHosted;
-
         XNAClientCheckBox chkNotifyOnUserListChange;
-
         XNAClientCheckBox chkSkipLoginWindow;
         XNAClientCheckBox chkPersistentMode;
         XNAClientCheckBox chkConnectOnStartup;
         XNAClientCheckBox chkDiscordIntegration;
         XNAClientCheckBox chkAllowGameInvitesFromFriendsOnly;
         XNAClientCheckBox chkDisablePrivateMessagePopup;
-
         XNAClientDropDown ddAllowPrivateMessagesFrom;
 
         GameCollection gameCollection;
@@ -51,95 +58,93 @@ namespace DTAConfig.OptionPanels
 
         private void InitOptions()
         {
+            int halfWidth = (Width - (2 * PADDING_X) - GROUP_SPACING_X) / 2;
+
             // LEFT COLUMN
 
-            chkPingUnofficialTunnels = new XNAClientCheckBox(WindowManager);
-            chkPingUnofficialTunnels.Name = nameof(chkPingUnofficialTunnels);
-            chkPingUnofficialTunnels.ClientRectangle = new Rectangle(12, 12, 0, 0);
-            chkPingUnofficialTunnels.Text = "Ping unofficial CnCNet tunnels".L10N("Client:DTAConfig:PingUnofficial");
-
+            chkPingUnofficialTunnels = new XNAClientCheckBox(WindowManager)
+            {
+                Name = nameof(chkPingUnofficialTunnels),
+                ClientRectangle = new Rectangle(PADDING_X, PADDING_Y, 0, 0),
+                Text = "Ping unofficial CnCNet tunnels".L10N("Client:DTAConfig:PingUnofficial")
+            };
             AddChild(chkPingUnofficialTunnels);
 
-            chkWriteInstallPathToRegistry = new XNAClientCheckBox(WindowManager);
-            chkWriteInstallPathToRegistry.Name = nameof(chkWriteInstallPathToRegistry);
-            chkWriteInstallPathToRegistry.ClientRectangle = new Rectangle(
-                chkPingUnofficialTunnels.X,
-                chkPingUnofficialTunnels.Bottom + 12, 0, 0);
-            chkWriteInstallPathToRegistry.Text = ("Write game installation path to Windows\n" +
-                "Registry (makes it possible to join\n" +
-                 "other games' game rooms on CnCNet)").L10N("Client:DTAConfig:WriteGameRegistry");
-
+            chkWriteInstallPathToRegistry = new XNAClientCheckBox(WindowManager)
+            {
+                Name = nameof(chkWriteInstallPathToRegistry),
+                ClientRectangle = new Rectangle(PADDING_X, chkPingUnofficialTunnels.Bottom + CHECKBOX_SPACING, 0, 0),
+                Text = ("Write game installation path to Windows\n" +
+                        "Registry (makes it possible to join\n" +
+                        "other games' game rooms on CnCNet)").L10N("Client:DTAConfig:WriteGameRegistry")
+            };
             AddChild(chkWriteInstallPathToRegistry);
 
-            chkPlaySoundOnGameHosted = new XNAClientCheckBox(WindowManager);
-            chkPlaySoundOnGameHosted.Name = nameof(chkPlaySoundOnGameHosted);
-            chkPlaySoundOnGameHosted.ClientRectangle = new Rectangle(
-                chkPingUnofficialTunnels.X,
-                chkWriteInstallPathToRegistry.Bottom + 12, 0, 0);
-            chkPlaySoundOnGameHosted.Text = "Play sound when a game is hosted".L10N("Client:DTAConfig:PlaySoundGameHosted");
-
+            chkPlaySoundOnGameHosted = new XNAClientCheckBox(WindowManager)
+            {
+                Name = nameof(chkPlaySoundOnGameHosted),
+                ClientRectangle = new Rectangle(PADDING_X, chkWriteInstallPathToRegistry.Bottom + CHECKBOX_SPACING, 0, 0),
+                Text = "Play sound when a game is hosted".L10N("Client:DTAConfig:PlaySoundGameHosted")
+            };
             AddChild(chkPlaySoundOnGameHosted);
 
-            chkNotifyOnUserListChange = new XNAClientCheckBox(WindowManager);
-            chkNotifyOnUserListChange.Name = nameof(chkNotifyOnUserListChange);
-            chkNotifyOnUserListChange.ClientRectangle = new Rectangle(
-                chkPingUnofficialTunnels.X,
-                chkPlaySoundOnGameHosted.Bottom + 12, 0, 0);
-            chkNotifyOnUserListChange.Text = ("Show player join / quit messages\n" +
-                "on CnCNet lobby").L10N("Client:DTAConfig:ShowPlayerJoinQuit");
-
+            chkNotifyOnUserListChange = new XNAClientCheckBox(WindowManager)
+            {
+                Name = nameof(chkNotifyOnUserListChange),
+                ClientRectangle = new Rectangle(PADDING_X, chkPlaySoundOnGameHosted.Bottom + CHECKBOX_SPACING, 0, 0),
+                Text = ("Show player join / quit messages\n" +
+                        "on CnCNet lobby").L10N("Client:DTAConfig:ShowPlayerJoinQuit")
+            };
             AddChild(chkNotifyOnUserListChange);
 
-            chkDisablePrivateMessagePopup = new XNAClientCheckBox(WindowManager);
-            chkDisablePrivateMessagePopup.Name = nameof(chkDisablePrivateMessagePopup);
-            chkDisablePrivateMessagePopup.ClientRectangle = new Rectangle(
-                chkNotifyOnUserListChange.X,
-                chkNotifyOnUserListChange.Bottom + 8, 0, 0);
-            chkDisablePrivateMessagePopup.Text = "Disable Popups from Private Messages".L10N("Client:DTAConfig:DisablePMPopup");
-
+            chkDisablePrivateMessagePopup = new XNAClientCheckBox(WindowManager)
+            {
+                Name = nameof(chkDisablePrivateMessagePopup),
+                ClientRectangle = new Rectangle(PADDING_X, chkNotifyOnUserListChange.Bottom + CHECKBOX_SPACING, 0, 0),
+                Text = "Disable popups from Private Messages".L10N("Client:DTAConfig:DisablePMPopup")
+            };
             AddChild(chkDisablePrivateMessagePopup);
 
-            InitAllowPrivateMessagesFromDropdown();
+            InitAllowPrivateMessagesFromDropdown(PADDING_X);
 
             // RIGHT COLUMN
 
-            chkSkipLoginWindow = new XNAClientCheckBox(WindowManager);
-            chkSkipLoginWindow.Name = nameof(chkSkipLoginWindow);
-            chkSkipLoginWindow.ClientRectangle = new Rectangle(
-                276,
-                12, 0, 0);
-            chkSkipLoginWindow.Text = "Skip login dialog".L10N("Client:DTAConfig:SkipLoginDialog");
-            chkSkipLoginWindow.CheckedChanged += ChkSkipLoginWindow_CheckedChanged;
+            int rightColumnX = PADDING_X + halfWidth + GROUP_SPACING_X;
 
+            chkSkipLoginWindow = new XNAClientCheckBox(WindowManager)
+            {
+                Name = nameof(chkSkipLoginWindow),
+                ClientRectangle = new Rectangle(rightColumnX, PADDING_Y, 0, 0),
+                Text = "Skip login dialog".L10N("Client:DTAConfig:SkipLoginDialog")
+            };
+            chkSkipLoginWindow.CheckedChanged += ChkSkipLoginWindow_CheckedChanged;
             AddChild(chkSkipLoginWindow);
 
-            chkPersistentMode = new XNAClientCheckBox(WindowManager);
-            chkPersistentMode.Name = nameof(chkPersistentMode);
-            chkPersistentMode.ClientRectangle = new Rectangle(
-                chkSkipLoginWindow.X,
-                chkSkipLoginWindow.Bottom + 12, 0, 0);
-            chkPersistentMode.Text = "Stay connected outside of the CnCNet lobby".L10N("Client:DTAConfig:StayConnect");
+            chkPersistentMode = new XNAClientCheckBox(WindowManager)
+            {
+                Name = nameof(chkPersistentMode),
+                ClientRectangle = new Rectangle(rightColumnX, chkSkipLoginWindow.Bottom + CHECKBOX_SPACING, 0, 0),
+                Text = "Stay connected outside of the CnCNet lobby".L10N("Client:DTAConfig:StayConnect"),
+            };
             chkPersistentMode.CheckedChanged += ChkPersistentMode_CheckedChanged;
-
             AddChild(chkPersistentMode);
 
-            chkConnectOnStartup = new XNAClientCheckBox(WindowManager);
-            chkConnectOnStartup.Name = nameof(chkConnectOnStartup);
-            chkConnectOnStartup.ClientRectangle = new Rectangle(
-                chkSkipLoginWindow.X,
-                chkPersistentMode.Bottom + 12, 0, 0);
-            chkConnectOnStartup.Text = "Connect automatically on client startup".L10N("Client:DTAConfig:ConnectOnStart");
-            chkConnectOnStartup.AllowChecking = false;
+            chkConnectOnStartup = new XNAClientCheckBox(WindowManager)
+            {
+                Name = nameof(chkConnectOnStartup),
+                ClientRectangle = new Rectangle(rightColumnX, chkPersistentMode.Bottom + CHECKBOX_SPACING, 0, 0),
+                Text = "Connect automatically on client startup".L10N("Client:DTAConfig:ConnectOnStart"),
+                AllowChecking = false
+            };
 
             AddChild(chkConnectOnStartup);
 
-            chkDiscordIntegration = new XNAClientCheckBox(WindowManager);
-            chkDiscordIntegration.Name = nameof(chkDiscordIntegration);
-            chkDiscordIntegration.ClientRectangle = new Rectangle(
-                chkSkipLoginWindow.X,
-                chkConnectOnStartup.Bottom + 12, 0, 0);
-            chkDiscordIntegration.Text = "Show detailed game info in Discord status".L10N("Client:DTAConfig:DiscordStatus");
-
+            chkDiscordIntegration = new XNAClientCheckBox(WindowManager)
+            {
+                Name = nameof(chkDiscordIntegration),
+                ClientRectangle = new Rectangle(rightColumnX, chkConnectOnStartup.Bottom + CHECKBOX_SPACING, 0, 0),
+                Text = "Show detailed game info in Discord status".L10N("Client:DTAConfig:DiscordStatus")
+            };
             if (ClientConfiguration.Instance.DiscordIntegrationGloballyDisabled)
             {
                 chkDiscordIntegration.AllowChecking = false;
@@ -152,32 +157,32 @@ namespace DTAConfig.OptionPanels
 
             AddChild(chkDiscordIntegration);
 
-            chkAllowGameInvitesFromFriendsOnly = new XNAClientCheckBox(WindowManager);
-            chkAllowGameInvitesFromFriendsOnly.Name = nameof(chkAllowGameInvitesFromFriendsOnly);
-            chkAllowGameInvitesFromFriendsOnly.ClientRectangle = new Rectangle(
-                chkDiscordIntegration.X,
-                chkDiscordIntegration.Bottom + 12, 0, 0);
-            chkAllowGameInvitesFromFriendsOnly.Text = "Only receive game invitations from friends".L10N("Client:DTAConfig:FriendsOnly");
+            chkAllowGameInvitesFromFriendsOnly = new XNAClientCheckBox(WindowManager)
+            {
+                Name = nameof(chkAllowGameInvitesFromFriendsOnly),
+                ClientRectangle = new Rectangle(rightColumnX, chkDiscordIntegration.Bottom + CHECKBOX_SPACING, 0, 0),
+                Text = "Only receive game invitations from friends".L10N("Client:DTAConfig:FriendsOnly")
+            };
 
             AddChild(chkAllowGameInvitesFromFriendsOnly);
         }
 
-        private void InitAllowPrivateMessagesFromDropdown()
+        private void InitAllowPrivateMessagesFromDropdown(int xPosition)
         {
-            XNALabel lblAllPrivateMessagesFrom = new XNALabel(WindowManager);
-            lblAllPrivateMessagesFrom.Name = nameof(lblAllPrivateMessagesFrom);
-            lblAllPrivateMessagesFrom.Text = "Allow Private Messages From:".L10N("Client:DTAConfig:AllowPMFrom");
-            lblAllPrivateMessagesFrom.ClientRectangle = new Rectangle(
-                chkDisablePrivateMessagePopup.X,
-                chkDisablePrivateMessagePopup.Bottom + 12, 165, 0);
+            XNALabel lblAllPrivateMessagesFrom = new XNALabel(WindowManager)
+            {
+                Name = nameof(lblAllPrivateMessagesFrom),
+                Text = "Allow Private Messages from:".L10N("Client:DTAConfig:AllowPMFrom"),
+                ClientRectangle = new Rectangle(xPosition, chkDisablePrivateMessagePopup.Bottom + CHECKBOX_SPACING, LABEL_WIDTH, LABEL_HEIGHT)
+            };
 
             AddChild(lblAllPrivateMessagesFrom);
 
-            ddAllowPrivateMessagesFrom = new XNAClientDropDown(WindowManager);
-            ddAllowPrivateMessagesFrom.Name = nameof(ddAllowPrivateMessagesFrom);
-            ddAllowPrivateMessagesFrom.ClientRectangle = new Rectangle(
-                lblAllPrivateMessagesFrom.Right,
-                lblAllPrivateMessagesFrom.Y - 2, 65, 0);
+            ddAllowPrivateMessagesFrom = new XNAClientDropDown(WindowManager)
+            {
+                Name = nameof(ddAllowPrivateMessagesFrom),
+                ClientRectangle = new Rectangle(xPosition + LABEL_WIDTH, lblAllPrivateMessagesFrom.Y - DD_Y_OFFSET, DD_PM_WIDTH, DD_HEIGHT)
+            };
 
             ddAllowPrivateMessagesFrom.AddItem(new XNADropDownItem()
             {
@@ -202,21 +207,6 @@ namespace DTAConfig.OptionPanels
 
         private void InitGameListPanel()
         {
-            const int gameListPanelHeight = 185;
-            XNAPanel gameListPanel = new XNAPanel(WindowManager);
-            gameListPanel.DrawBorders = false;
-            gameListPanel.Name = nameof(gameListPanel);
-            gameListPanel.ClientRectangle = new Rectangle(0, Bottom - gameListPanelHeight, Width, gameListPanelHeight);
-
-            AddChild(gameListPanel);
-
-            var lblFollowedGames = new XNALabel(WindowManager);
-            lblFollowedGames.Name = nameof(lblFollowedGames);
-            lblFollowedGames.ClientRectangle = new Rectangle(12, 12, 0, 0);
-            lblFollowedGames.Text = "Show game rooms from the following games:".L10N("Client:DTAConfig:ShowRoomFromGame");
-
-            gameListPanel.AddChild(lblFollowedGames);
-
             // Max number of games per column
             const int maxGamesPerColumn = 4;
             // Spacing buffer between columns
@@ -227,6 +217,17 @@ namespace DTAConfig.OptionPanels
             const int gameIconWidth = 16;
             // Spacing buffer between game icon and game check box
             const int gameIconBuffer = 6;
+
+            XNAPanel gameListPanel = new XNAPanel(WindowManager);
+            gameListPanel.DrawBorders = false;
+            gameListPanel.Name = nameof(gameListPanel);
+
+            var lblFollowedGames = new XNALabel(WindowManager);
+            lblFollowedGames.Name = nameof(lblFollowedGames);
+            lblFollowedGames.ClientRectangle = new Rectangle(PADDING_X, PADDING_Y, 0, 0);
+            lblFollowedGames.Text = "Show game rooms from the following games:".L10N("Client:DTAConfig:ShowRoomFromGame");
+
+            gameListPanel.AddChild(lblFollowedGames);
 
             // List of supported games
             IEnumerable<CnCNetGame> supportedGames = gameCollection.GameList
@@ -259,14 +260,14 @@ namespace DTAConfig.OptionPanels
                 })
                 .ToMatrix(maxGamesPerColumn);
 
-
             // Calculate max widths for each column
             List<int> columnWidths = gamePanelMatrix
                 .Select(columnList => columnList.Max(gamePanel => gamePanel.Children.Last().Right + columnBuffer))
                 .ToList();
 
+            int startY = lblFollowedGames.Bottom + PADDING_X;
+
             // Reposition each game panel and then add them to the overall list panel
-            int startY = lblFollowedGames.Bottom + 12;
             for (int col = 0; col < gamePanelMatrix.Count; col++)
             {
                 List<XNAPanel> gamePanelColumn = gamePanelMatrix[col];
@@ -279,6 +280,18 @@ namespace DTAConfig.OptionPanels
                     gameListPanel.AddChild(gamePanel);
                 }
             }
+
+            // Calculate panel height based on content
+            int contentHeight = PADDING_Y +
+                               lblFollowedGames.Height +
+                               PADDING_X +
+                               (Math.Min(supportedGames.Count(), maxGamesPerColumn) * rowBuffer) -
+                               (rowBuffer - gameIconWidth) +
+                               PADDING_Y;
+
+            gameListPanel.ClientRectangle = new Rectangle(0, Height - contentHeight, Width, contentHeight);
+
+            AddChild(gameListPanel);
         }
 
         private void ChkSkipLoginWindow_CheckedChanged(object sender, EventArgs e)

--- a/DTAConfig/OptionPanels/CnCNetOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/CnCNetOptionsPanel.cs
@@ -40,6 +40,7 @@ namespace DTAConfig.OptionPanels
         XNAClientCheckBox chkConnectOnStartup;
         XNAClientCheckBox chkDiscordIntegration;
         XNAClientCheckBox chkAllowGameInvitesFromFriendsOnly;
+        XNAClientCheckBox chkFilterProfanity;
         XNAClientCheckBox chkDisablePrivateMessagePopup;
         XNAClientDropDown ddAllowPrivateMessagesFrom;
 
@@ -165,6 +166,15 @@ namespace DTAConfig.OptionPanels
             };
 
             AddChild(chkAllowGameInvitesFromFriendsOnly);
+
+            chkFilterProfanity = new XNAClientCheckBox(WindowManager)
+            {
+                Name = nameof(chkFilterProfanity),
+                ClientRectangle = new Rectangle(rightColumnX, chkAllowGameInvitesFromFriendsOnly.Bottom + CHECKBOX_SPACING, 0, 0),
+                Text = "Filter obscene language".L10N("Client:DTAConfig:FilterProfanities")
+            };
+
+            AddChild(chkFilterProfanity);
         }
 
         private void InitAllowPrivateMessagesFromDropdown(int xPosition)
@@ -334,6 +344,7 @@ namespace DTAConfig.OptionPanels
                 && IniSettings.DiscordIntegration;
 
             chkAllowGameInvitesFromFriendsOnly.Checked = IniSettings.AllowGameInvitesFromFriendsOnly;
+            chkFilterProfanity.Checked = IniSettings.FilterProfanity;
 
             string localGame = ClientConfiguration.Instance.LocalGame.ToUpperInvariant();
 
@@ -371,6 +382,7 @@ namespace DTAConfig.OptionPanels
             }
 
             IniSettings.AllowGameInvitesFromFriendsOnly.Value = chkAllowGameInvitesFromFriendsOnly.Checked;
+            IniSettings.FilterProfanity.Value = chkFilterProfanity.Checked;
 
             foreach (var chkBox in followedGameChks)
             {

--- a/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
@@ -54,12 +54,12 @@ namespace DTAClient.DXGUI.Multiplayer
             {
                 listBoxItem.Text = Renderer.GetSafeString(string.Format("[{0}] {1}",
                     message.DateTime.ToShortTimeString(),
-                    message.Message), FontIndex);
+                    message.CensoredMessage), FontIndex);
             }
             else
             {
                 listBoxItem.Text = Renderer.GetSafeString(string.Format("[{0}] {1}: {2}",
-                    message.DateTime.ToShortTimeString(), message.SenderName, message.Message), FontIndex);
+                    message.DateTime.ToShortTimeString(), message.SenderName, message.CensoredMessage), FontIndex);
             }
             
             AddItem(listBoxItem);

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
@@ -627,7 +627,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             }
 
             connectionManager.MainChannel.AddMessage(new ChatMessage(Color.White, string.Format(
-                "Cannot join game {0}, you've been banned by the game host!".L10N("Client:Main:PlayerBannedByHost"), game.RoomName)));
+                "Cannot join game {0}, you've been banned by the game host!".L10N("Client:Main:PlayerBannedByHost"), game.CensoredRoomName)));
 
             isJoiningGame = false;
             if (gameOfLastJoinAttempt != null)
@@ -922,11 +922,11 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
         private void _JoinGame(HostedCnCNetGame hg, string password)
         {
             connectionManager.MainChannel.AddMessage(new ChatMessage(Color.White,
-                string.Format("Attempting to join game {0} ...".L10N("Client:Main:AttemptJoin"), hg.RoomName)));
+                string.Format("Attempting to join game {0} ...".L10N("Client:Main:AttemptJoin"), hg.CensoredRoomName)));
             isJoiningGame = true;
             gameOfLastJoinAttempt = hg;
 
-            Channel gameChannel = connectionManager.CreateChannel(hg.RoomName, hg.ChannelName, false, true, password);
+            Channel gameChannel = connectionManager.CreateChannel(hg.CensoredRoomName, hg.ChannelName, false, true, password);
             connectionManager.AddChannel(gameChannel);
 
             if (hg.IsLoadedGame)

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/PrivateMessagingWindow.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/PrivateMessagingWindow.cs
@@ -841,7 +841,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             }
 
             public void AddMessage(ChatMessage message)
-                => XNAMessageBox.Show(windowManager, "Message".L10N("Client:Main:MessageTitle"), message.Message);
+                => XNAMessageBox.Show(windowManager, "Message".L10N("Client:Main:MessageTitle"), message.CensoredMessage);
         }
     }
 }

--- a/DXMainClient/DXGUI/Multiplayer/GameListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameListBox.cs
@@ -44,6 +44,8 @@ namespace DTAClient.DXGUI.Multiplayer
 
         public List<GenericHostedGame> HostedGames = new();
 
+        private ProfanityFilter profanityFilter ;
+
         public double GameLifetime { get; set; } = 35.0;
 
         /// <summary>
@@ -144,10 +146,10 @@ namespace DTAClient.DXGUI.Multiplayer
             switch ((SortDirection)UserINISettings.Instance.SortState.Value)
             {
                 case SortDirection.Asc:
-                    sortedGames = sortedGames.ThenBy(hg => hg.RoomName);
+                    sortedGames = sortedGames.ThenBy(hg => hg.CensoredRoomName);
                     break;
                 case SortDirection.Desc:
-                    sortedGames = sortedGames.ThenByDescending(hg => hg.RoomName);
+                    sortedGames = sortedGames.ThenByDescending(hg => hg.CensoredRoomName);
                     break;
             }
 
@@ -253,12 +255,10 @@ namespace DTAClient.DXGUI.Multiplayer
             var lbItem = new XNAListBoxItem();
             lbItem.Tag = hg;
             lbItem.Text = Renderer.GetStringWithLimitedWidth(Renderer.GetSafeString(
-                hg.RoomName, FontIndex), FontIndex, maxTextWidth);
+                hg.CensoredRoomName, FontIndex), FontIndex, maxTextWidth);
 
             if (hg.Game.InternalName != localGameIdentifier.ToLower())
                 lbItem.TextColor = UISettings.ActiveSettings.TextColor;
-            //else // made unnecessary by new Rampastring.XNAUI
-            //    lbItem.TextColor = UISettings.ActiveSettings.AltColor;
 
             if (hg.Incompatible || hg.Locked)
             {

--- a/DXMainClient/DXGUI/Multiplayer/LANLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/LANLobby.cs
@@ -567,7 +567,7 @@ namespace DTAClient.DXGUI.Multiplayer
                 // TODO Show warning
             }
 
-            lbChatMessages.AddMessage(string.Format("Attempting to join game {0} ...".L10N("Client:Main:AttemptJoin"), hg.RoomName));
+            lbChatMessages.AddMessage(string.Format("Attempting to join game {0} ...".L10N("Client:Main:AttemptJoin"), hg.CensoredRoomName));
 
             try
             {

--- a/DXMainClient/Domain/Multiplayer/GenericHostedGame.cs
+++ b/DXMainClient/Domain/Multiplayer/GenericHostedGame.cs
@@ -1,4 +1,5 @@
-﻿using ClientCore.CnCNet5;
+﻿using ClientCore;
+using ClientCore.CnCNet5;
 using System;
 
 namespace DTAClient.Domain.Multiplayer
@@ -9,7 +10,20 @@ namespace DTAClient.Domain.Multiplayer
     /// </summary>
     public abstract class GenericHostedGame: IEquatable<GenericHostedGame>
     {
-        public string RoomName { get; set; }
+        ProfanityFilter _profanityFilter = new ProfanityFilter();
+        private string _roomName;
+
+        public string RoomName
+        {
+            get => _roomName;
+            set
+            {
+                _roomName = value;
+                CensoredRoomName = _profanityFilter.CensorText(value, true);
+            }
+        }
+
+        public string CensoredRoomName { get; private set; }
         public bool Incompatible { get; set; }
         public bool Locked { get; set; }
         public bool IsLoadedGame { get; set; }

--- a/DXMainClient/Online/ChatMessage.cs
+++ b/DXMainClient/Online/ChatMessage.cs
@@ -1,10 +1,13 @@
-﻿using Microsoft.Xna.Framework;
+﻿using ClientCore;
+using Microsoft.Xna.Framework;
 using System;
 
 namespace DTAClient.Online
 {
     public class ChatMessage
     {
+        ProfanityFilter _profanityFilter = new ProfanityFilter();
+
         /// <summary>
         /// Creates a new ChatMessage instance.
         /// </summary>
@@ -62,7 +65,17 @@ namespace DTAClient.Online
         public string SenderIdent { get; private set; }
         public Color Color { get; private set; }
         public DateTime DateTime { get; private set; }
-        public string Message { get; private set; }
+        private string _message;
+        public string CensoredMessage { get; private set; }
+        public string Message
+        {
+            get => _message;
+            set
+            {
+                _message = value;
+                CensoredMessage = _profanityFilter.CensorText(value, true);
+            }
+        }
         public bool SenderIsAdmin { get; private set; }
 
         public bool IsUser => SenderIdent != null;


### PR DESCRIPTION
- Adds a new profanity filter.
- Adds a setting to CnCNet options panel to enable/disable word censoring (on by default - may need changing?).
- Censors words in channel names (the original, uncensored name remains accessible in code).
- Censors words in chat messages (the original, uncensored message remains accessible in code).
- Updates CnCNetOptionPanel to use constants for positioning.

The new profanity filter will filter l33tspeak variations of words, repeating characters, and basic bypass attempts. For example, these are all considered profane:

- Shit
- Sh!t
- Ss5shhhhii11tttt
- S_H_I-T
- 5_h_1_t

It's a regex based filter system. Hoping the comments make it easy to follow. On my somewhat dated laptop it can censor 10,000 medium sized strings in 200ms, and checking if a string is offensive will be quicker than that.

Censoring usernames isn't included in this PR. That's a different beast and will need more time.
The word "Admin" is now only considered profane when choosing your username. 
