### PR TITLE
Fix crash when starting game with null map

### DIFF
--- a/ClientCore/Statistics/StatisticsManager.cs
+++ b/ClientCore/Statistics/StatisticsManager.cs
@@ -290,6 +290,12 @@ namespace ClientCore.Statistics
 
         public void AddMatchAndSaveDatabase(bool addMatch, MatchStatistics ms)
         {
+            if (ms == null)
+            {
+                Logger.Log("Skipping adding match to statistics because match statistics is null.");
+                return;
+            }
+
             // Skip adding stats if the game only had one player, make exception for co-op since it doesn't recognize pre-placed houses as players.
             if (ms.GetPlayerCount() <= 1 && !ms.MapIsCoop)
             {

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -1231,6 +1231,16 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         /// </summary>
         protected override void GameProcessExited()
         {
+            ResetGameState();
+        }
+
+        protected void GameStartAborted()
+        {
+            ResetGameState();
+        }
+
+        protected void ResetGameState() 
+        {
             base.GameProcessExited();
 
             channel.SendCTCPMessage("RETURN", QueuedMessageType.SYSTEM_MESSAGE, 20);
@@ -1260,7 +1270,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             if (Map == null)
             {
-                GameProcessExited();
+                GameStartAborted();
                 return;
             }
 

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -1258,6 +1258,9 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             if (sender != hostName)
                 return;
 
+            if (Map == null)
+                return;
+
             string[] parts = message.Split(';');
 
             if (parts.Length < 1)

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -1259,7 +1259,10 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 return;
 
             if (Map == null)
+            {
+                GameProcessExited();
                 return;
+            }
 
             string[] parts = message.Split(';');
 

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -1869,7 +1869,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             Logger.Log("GameProcessExited: Parsing statistics.");
 
-            matchStatistics.ParseStatistics(ProgramConstants.GamePath, ClientConfiguration.Instance.LocalGame, false);
+            matchStatistics?.ParseStatistics(ProgramConstants.GamePath, ClientConfiguration.Instance.LocalGame, false);
 
             Logger.Log("GameProcessExited: Adding match to statistics.");
 


### PR DESCRIPTION
This issue occurs when all players are marked as Ready, and the host quickly switches to a map that some players don't have before clicking Start. Players missing the map will crash.

The crash happens in `GameLobbyBase.cs` within `WriteSpawnIni` at the `if (Map.IsCoop)` check. This fix prevents the game reaching that line with a null map.

GameProcessExited is called to inform the host that the player has left the game. Without this, the host would still consider the player as IsInGame which would cause issues (I think) similar to #641.

The match statistics changes are because GameProcessExited calls them which won't work with a null map. 
If it's preferred, instead of calling GameProcessExited and making changes to match statistics, we could just call the relevant lines of GameProcessExited directly.

```
            ClearReadyStatuses();
            CopyPlayerDataToUI();
            UpdateDiscordPresence(true);
```

Not sure which is best or preferred.