### PR TITLE
Fix search selecting null maps, that also caused autoready issues

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -540,6 +540,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             var isFavoriteMapsSelected = IsFavoriteMapsSelected();
             var maps = GetSortedGameModeMaps();
 
+            bool gameModeMapChanged = false;
+
             for (int i = 0; i < maps.Count; i++)
             {
                 var gameModeMap = maps[i];
@@ -587,11 +589,17 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
                 // Preserve the selected map
                 if (gameModeMap == GameModeMap)
+                {
                     mapIndex = i - skippedMapsCount;
+                    gameModeMapChanged = false;
+                }
 
                 // Preserve the selected map, even if the game mode has changed
                 if (mapIndex == -1 && (gameModeMap?.Map?.Equals(GameModeMap?.Map) ?? false))
+                {
                     mapIndex = i - skippedMapsCount;
+                    gameModeMapChanged = true;
+                }
             }
 
             if (mapIndex > -1)
@@ -602,6 +610,10 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             }
 
             lbGameModeMapList.SelectedIndexChanged += LbGameModeMapList_SelectedIndexChanged;
+
+            // Trigger the event manually to update GameModeMap
+            if (gameModeMapChanged)
+                LbGameModeMapList_SelectedIndexChanged();
         }
 
         protected abstract int GetDefaultMapRankIndex(GameModeMap gameModeMap);

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -602,8 +602,6 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             }
 
             lbGameModeMapList.SelectedIndexChanged += LbGameModeMapList_SelectedIndexChanged;
-            // Trigger the event manually to update GameModeMap
-            LbGameModeMapList_SelectedIndexChanged();
         }
 
         protected abstract int GetDefaultMapRankIndex(GameModeMap gameModeMap);


### PR DESCRIPTION
Should fix auto ready issues as described here https://github.com/CnCNet/xna-cncnet-client/issues/664

## Before


https://github.com/user-attachments/assets/f6775b85-fa4e-45cb-a2cb-e16e0ff126ef



## After (with the change applied)


https://github.com/user-attachments/assets/0977ece5-6e14-4dd0-ae4f-9df159373e1c



## Auto ready fixed

https://github.com/user-attachments/assets/8218e980-907d-4392-869b-00f9fb8efe24

