### PR TITLE
Fix unexpected crash from background music

### DIFF
--- a/DXMainClient/DXGUI/Generic/MainMenu.cs
+++ b/DXMainClient/DXGUI/Generic/MainMenu.cs
@@ -929,20 +929,20 @@ namespace DTAClient.DXGUI.Generic
             if (!isMediaPlayerAvailable)
                 return; // SharpDX fails at music playback on Vista
 
-            if (themeSong != null && UserINISettings.Instance.PlayMainMenuMusic)
+            try
             {
-                isMusicFading = false;
-                MediaPlayer.IsRepeating = true;
-                MediaPlayer.Volume = (float)UserINISettings.Instance.ClientVolume;
-
-                try
+                if (themeSong != null && UserINISettings.Instance.PlayMainMenuMusic)
                 {
+                    isMusicFading = false;
+                    MediaPlayer.IsRepeating = true;
+                    MediaPlayer.Volume = (float)UserINISettings.Instance.ClientVolume;
+
                     MediaPlayer.Play(themeSong);
                 }
-                catch (InvalidOperationException ex)
-                {
-                    Logger.Log("Playing main menu music failed! " + ex.ToString());
-                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Log("Playing main menu music failed! " + ex.ToString());
             }
         }
 
@@ -956,15 +956,22 @@ namespace DTAClient.DXGUI.Generic
             if (!isMediaPlayerAvailable || !isMusicFading || themeSong == null)
                 return;
 
-            // Fade during 1 second
-            float step = SoundPlayer.Volume * (float)gameTime.ElapsedGameTime.TotalSeconds;
-
-            if (MediaPlayer.Volume > step)
-                MediaPlayer.Volume -= step;
-            else
+            try
             {
-                MediaPlayer.Stop();
-                isMusicFading = false;
+                // Fade during 1 second
+                float step = SoundPlayer.Volume * (float)gameTime.ElapsedGameTime.TotalSeconds;
+
+                if (MediaPlayer.Volume > step)
+                    MediaPlayer.Volume -= step;
+                else
+                {
+                    MediaPlayer.Stop();
+                    isMusicFading = false;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Log("Fading music failed! Message: " + ex.ToString());
             }
         }
 
@@ -979,17 +986,24 @@ namespace DTAClient.DXGUI.Generic
                 return;
             }
 
-            float step = MEDIA_PLAYER_VOLUME_EXIT_FADE_STEP * (float)UserINISettings.Instance.ClientVolume;
+            try
+            {
+                float step = MEDIA_PLAYER_VOLUME_EXIT_FADE_STEP * (float)UserINISettings.Instance.ClientVolume;
 
-            if (MediaPlayer.Volume > step)
-            {
-                MediaPlayer.Volume -= step;
-                AddCallback(new Action(FadeMusicExit), null);
+                if (MediaPlayer.Volume > step)
+                {
+                    MediaPlayer.Volume -= step;
+                    AddCallback(new Action(FadeMusicExit), null);
+                }
+                else
+                {
+                    MediaPlayer.Stop();
+                    ExitClient();
+                }
             }
-            else
+            catch (Exception ex)
             {
-                MediaPlayer.Stop();
-                ExitClient();
+                Logger.Log("Fading music on exit failed! Message: " + ex.ToString());
             }
         }
 


### PR DESCRIPTION
To prevent crash like this one:

(in this log file, please subtract line numbers of `MainMenu.cs` by 12 when viewing on the latest commit af7e44f1c67f32bd7bbb423ef3bf93464355b713)

```
12.03. 12:01:55.672    GameProcessLogic: Process started.
12.03. 12:01:56.402    Waiting for qres.dat or Syringe.exe to exit.
12.03. 12:11:17.215    GameProcessLogic: Process exited.
12.03. 12:11:21.195    KABOOOOOOM!!! Info:
12.03. 12:11:21.195    Type: System.Reflection.TargetInvocationException
12.03. 12:11:21.195    Message: Exception has been thrown by the target of an invocation.
12.03. 12:11:22.055    Source: mscorlib
12.03. 12:11:22.055    TargetSite.Name: InvokeMethod
12.03. 12:11:22.105    Stacktrace:    at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)
   at System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments)
   at System.Delegate.DynamicInvokeImpl(Object[] args)
   at Rampastring.XNAUI.XNAControls.XNAControl.Update(GameTime gameTime)
   at Rampastring.XNAUI.XNAControls.XNAPanel.Update(GameTime gameTime)
   at DTAClient.DXGUI.Generic.MainMenu.Update(GameTime gameTime) in DXMainClient\DXGUI\Generic\MainMenu.cs:line 925
   at Rampastring.XNAUI.WindowManager.Update(GameTime gameTime)
   at Microsoft.Xna.Framework.Game.SortingFilteringCollection`1.ForEachFilteredItem[TUserData](Action`2 action, TUserData userData)
   at Microsoft.Xna.Framework.Game.DoUpdate(GameTime gameTime)
   at Microsoft.Xna.Framework.Game.Tick()
   at MonoGame.Framework.WinFormsGameWindow.TickOnIdle(Object sender, EventArgs e)
   at System.Windows.Forms.Application.ThreadContext.System.Windows.Forms.UnsafeNativeMethods.IMsoComponent.FDoIdle(Int32 grfidlef)
   at System.Windows.Forms.Application.ComponentManager.System.Windows.Forms.UnsafeNativeMethods.IMsoComponentManager.FPushMessageLoop(IntPtr dwComponentID, Int32 reason, Int32 pvLoopData)
   at System.Windows.Forms.Application.ThreadContext.RunMessageLoopInner(Int32 reason, ApplicationContext context)
   at System.Windows.Forms.Application.ThreadContext.RunMessageLoop(Int32 reason, ApplicationContext context)
   at MonoGame.Framework.WinFormsGameWindow.RunLoop()
   at Microsoft.Xna.Framework.Game.Run(GameRunBehavior runBehavior)
   at DTAClient.Startup.Execute() in DXMainClient\Startup.cs:line 159
   at DTAClient.PreStartup.Initialize(StartupParams parameters) in DXMainClient\PreStartup.cs:line 218
12.03. 12:11:22.105    InnerException info:
12.03. 12:11:22.105    Type: SharpDX.SharpDXException
12.03. 12:11:22.105    Message: HRESULT: [0xC00D4E86], Module: [Unknown], ApiCode: [Unknown/Unknown], Message: Unknown
12.03. 12:11:22.165    Source: SharpDX
12.03. 12:11:22.165    TargetSite.Name: CheckError
12.03. 12:11:22.185    Stacktrace:    at SharpDX.Result.CheckError()
   at SharpDX.MediaFoundation.AudioStreamVolume.GetChannelCount(Int32& dwCountRef)
   at Microsoft.Xna.Framework.Media.MediaPlayer.SetChannelVolumes()
   at Microsoft.Xna.Framework.Media.MediaPlayer.set_Volume(Single value)
   at DTAClient.DXGUI.Generic.MainMenu.PlayMusic() in DXMainClient\DXGUI\Generic\MainMenu.cs:line 948
   at DTAClient.DXGUI.Generic.MainMenu.HandleGameProcessExited() in DXMainClient\DXGUI\Generic\MainMenu.cs:line 908
```