### PR TITLE
Attempt to fix game room desync by having players confirm game start

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -1429,6 +1429,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             if (IsHost)
                 channel.SendCTCPMessage("INGM " + playerIndex, QueuedMessageType.GAME_NOTIFICATION_MESSAGE, 0);
         }
+
         private void GameStartedNotification(string sender)
         {
             PlayerInfo pInfo = Players.Find(p => p.Name == sender);

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -81,6 +81,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 new StringCommandHandler(MAP_SHARING_FAIL_MESSAGE, HandleMapTransferFailMessage),
                 new StringCommandHandler(MAP_SHARING_DOWNLOAD_REQUEST, HandleMapDownloadRequest),
                 new NoParamCommandHandler(MAP_SHARING_DISABLED_MESSAGE, HandleMapSharingBlockedMessage),
+                new NoParamCommandHandler("STRTD", GameStartedNotification),
                 new NoParamCommandHandler("RETURN", ReturnNotification),
                 new IntCommandHandler("TNLPNG", HandleTunnelPing),
                 new StringCommandHandler("FHSH", FileHashNotification),
@@ -669,9 +670,6 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             {
                 Logger.Log("One player MP -- starting!");
             }
-
-            Players.ForEach(pInfo => pInfo.IsInGame = true);
-            CopyPlayerDataToUI();
 
             cncnetUserData.AddRecentPlayers(Players.Select(p => p.Name), channel.UIName);
 
@@ -1313,6 +1311,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 HandleCheatDetectedMessage(ProgramConstants.PLAYERNAME);
             }
 
+            channel.SendCTCPMessage("STRTD", QueuedMessageType.SYSTEM_MESSAGE, 20);
+
             base.StartGame();
         }
 
@@ -1428,6 +1428,15 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             if (IsHost)
                 channel.SendCTCPMessage("INGM " + playerIndex, QueuedMessageType.GAME_NOTIFICATION_MESSAGE, 0);
+        }
+        private void GameStartedNotification(string sender)
+        {
+            PlayerInfo pInfo = Players.Find(p => p.Name == sender);
+
+            if (pInfo != null)
+                pInfo.IsInGame = true;
+
+            CopyPlayerDataToUI();
         }
 
         private void ReturnNotification(string sender)

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
@@ -264,9 +264,6 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             if (fsw != null)
                 fsw.EnableRaisingEvents = true;
 
-            for (int pId = 0; pId < Players.Count; pId++)
-                Players[pId].IsInGame = true;
-
             base.StartGame();
         }
 


### PR DESCRIPTION
For #641 

This PR makes players send a message to others in the channel indicating they have started the game. This is needed to fix an issue like:

	game host marks all players as isInGame=true, sends START message to all players, and starts the game on their side
	a player leaves the lobby before they received the start message
	other players receive the person leaves message before the start message. They remove the person from their side, then they receive the start message but don't start as the room is no longer full.
	host quits out of game as no one connected
	host returns to lobby. everyone is still marked as isInGame=true. host doesn't receive any message to tell him the players aren't in the game. This means player statuses are showing incorrectly and you can't start any more games as you'll get the "player xxx is still in the game" message. All players need to rejoin the lobby.


This PR won't fix the host starting a game and no one connecting, it will only fix the glitched player state once the host returns from the game.

I've only tested this with two players and haven't confirmed it fixes the issue (need a third person), but it makes sense to me. 