### PR TITLE
Add save/load to Custom Team Mappings

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/TeamStartMappingPanel.cs
+++ b/DXMainClient/DXGUI/Multiplayer/TeamStartMappingPanel.cs
@@ -13,7 +13,7 @@ namespace DTAClient.DXGUI.Multiplayer
         private readonly int _defaultTeamIndex = -1;
 
         private const int ddWidth = 35;
-        // private XNAClientDropDown ddStarts;
+
         private XNAClientDropDown ddTeams;
 
         public event EventHandler OptionsChanged;


### PR DESCRIPTION
When setting custom team mappings, the client will now save/load the values. Only applies to host or skirmish.
Also fixes an issue where for a non-host, the wrong preset would be chosen (always showed as either the first non-custom item or Custom).

Saves in UserINISettings (RA2MD.ini) like:

```
[TeamStartMappings]
fb2631acdc4728f0dd569ad57dc07edfe89cf736=A,A
a5af19e682d41fbe185a9879ec43785526203346=A,A,B,B,C,C,D,D
6cbdedbec3a190cf3675829715024e1ead54e7b6=A,A,x,A,B,x,B,B
f17d9f67057e32994a760f41a3bd1eb25d26a25c=A,A,B,A,B,B
ccff58c63db1d295480f0cc79d914c5d704b0f84=A,A,A,A,B,x,B,B
0dc540f6f57bc15da1617166b8858fb45953ef15=A,B,C,B,A,C,B,D

```

![TeamMappings](https://github.com/user-attachments/assets/102fb2b4-3371-4c91-85ee-ded91af17214)

