### PR TITLE
Fix crash when the player themself is not in the player list

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -707,6 +707,9 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             }
 
             PlayerInfo pInfo = Players.Find(p => p.Name == ProgramConstants.PLAYERNAME);
+            if (pInfo == null)
+                return;
+
             int readyState = 0;
 
             if (chkAutoReady.Checked)


### PR DESCRIPTION
Fixes #683 

```
19.04. 19:42:40.783    KABOOOOOOM!!! Info:
19.04. 19:42:40.784    Type: System.NullReferenceException
19.04. 19:42:40.784    Message: Object reference not set to an instance of an object.
19.04. 19:42:41.122    Source: clientdx
19.04. 19:42:41.122    TargetSite.Name: RequestReadyStatus
19.04. 19:42:41.125    Stacktrace:    at DTAClient.DXGUI.Multiplayer.GameLobby.CnCNetGameLobby.RequestReadyStatus() in C:\Dev\xna-cncnet-client\DXMainClient\DXGUI\Multiplayer\GameLobby\CnCNetGameLobby.cs:line 736
   at DTAClient.DXGUI.Multiplayer.GameLobby.MultiplayerGameLobby.ChkAutoReady_CheckedChanged(Object sender, EventArgs e) in C:\Dev\xna-cncnet-client\DXMainClient\DXGUI\Multiplayer\GameLobby\MultiplayerGameLobby.cs:line 392
```