### PR TITLE
Defer loading statistics listbox until StatisticsWindow is initialized and visible

### DIFF
--- a/DXMainClient/DXGUI/Generic/StatisticsWindow.cs
+++ b/DXMainClient/DXGUI/Generic/StatisticsWindow.cs
@@ -79,6 +79,8 @@ namespace DTAClient.DXGUI.Generic
 
         private List<MultiplayerColor> mpColors;
 
+        private bool initialized = false;
+
         public override void Initialize()
         {
             sm = StatisticsManager.Instance;
@@ -94,6 +96,7 @@ namespace DTAClient.DXGUI.Generic
             Name = "StatisticsWindow";
             BackgroundTexture = AssetLoader.LoadTexture("scoreviewerbg.png");
             ClientRectangle = new Rectangle(0, 0, 700, 521);
+            VisibleChanged += StatisticsWindow_VisibleChanged;
 
             tabControl = new XNAClientTabControl(WindowManager);
             tabControl.Name = "tabControl";
@@ -415,9 +418,15 @@ namespace DTAClient.DXGUI.Generic
 
             ReadStatistics();
             ListGameModes();
-            ListGames();
 
             StatisticsManager.Instance.GameAdded += Instance_GameAdded;
+
+            initialized = true;
+        }
+
+        private void StatisticsWindow_VisibleChanged(object sender, EventArgs e)
+        {
+            ListGames();
         }
 
         private void Instance_GameAdded(object sender, EventArgs e)
@@ -613,6 +622,9 @@ namespace DTAClient.DXGUI.Generic
 
         private void ListGames()
         {
+            if (!Visible || !initialized)
+                return;
+
             lbGameList.SelectedIndex = -1;
             lbGameList.SetTopIndex(0);
 


### PR DESCRIPTION
Currently, statistics for all games are loaded into a multi-column listbox on startup and after a game is played, causing the client to lock up if there is a large game history. The XNAListbox's AddItem is the main cause of slowness which I will address with another PR later this week.

This PR defers loading the multi-col listbox until the statistics window is actually displayed.