### PR TITLE
Build release via CI

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,85 @@
+name: "Release Build"
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: windows-2022
+    strategy:
+      matrix:
+        Game: 
+          - Ares
+          - TS
+          - YR
+    
+    outputs:
+      GitVersion_SemVer: ${{ steps.set_gitversion_outputs.outputs.GitVersion_SemVer }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@v4
+      with:
+        global-json-file: ./global.json
+
+    - name: Build ${{matrix.Game}}
+      run: ./Scripts/build.ps1 ${{matrix.Game}}
+      shell: pwsh
+
+    - name: Development Build Check
+      shell: pwsh
+      run: |
+        Write-Output "GitVersion_BranchName: $env:GitVersion_BranchName"
+        Write-Output "GitVersion_CommitsSinceVersionSource: $env:GitVersion_CommitsSinceVersionSource"
+        if ($env:GitVersion_CommitsSinceVersionSource -ne "0") {
+          Write-Output "::error:: This is a development build and should not be released. Do you forget creating a new tag for the release?"
+          exit 1
+        }
+
+    - uses: actions/upload-artifact@v4
+      name: Upload Artifacts
+      with:
+        name: artifacts-${{matrix.Game}}
+        path: ./Compiled/${{matrix.Game}}
+
+    - name: Set GitVersion Outputs
+      id: set_gitversion_outputs
+      shell: pwsh
+      run: |
+        echo "GitVersion_SemVer=$env:GitVersion_SemVer" >> $env:GITHUB_OUTPUT
+
+  package:
+    needs: build
+    runs-on: windows-2022
+    env:
+      ARCHIVE_NAME: ${{ format('xna-cncnet-client-artifacts-{0}.7z', needs.build.outputs.GitVersion_SemVer) }}
+
+    steps:
+    - name: Download Build Outputs
+      uses: actions/download-artifact@v4
+      with:
+        path: ./artifacts/
+
+    - name: Zip Final Artifact
+      run: 7z a -t7z -mx=9 -m0=lzma2 -md=512m -ms=on -r -- ${{ env.ARCHIVE_NAME }} ./artifacts/*
+      shell: pwsh
+
+    - uses: actions/upload-artifact@v4
+      name: Upload Final Artifact
+      with:
+        name: ${{ env.ARCHIVE_NAME }}
+        path: ${{ env.ARCHIVE_NAME }}
+        compression-level: 0
+
+    - name: Upload Files to the Release
+      uses: softprops/action-gh-release@v2
+      with:
+        append_body: true
+        files: ${{ env.ARCHIVE_NAME }}

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -4,7 +4,7 @@
   </Target>
 
   <!-- "GetVersion" target is defined in GitVersion package -->
-  <Target Name="NonReleaseBuildWarning" AfterTargets="GetVersion" BeforeTargets="CoreCompile" Condition="'$(MSBuildProjectName)' == 'DXMainClient' AND ($(GitVersion_CommitsSinceVersionSource) != 0 OR $(GitVersion_BranchName) != 'master')">
+  <Target Name="NonReleaseBuildWarning" AfterTargets="GetVersion" BeforeTargets="CoreCompile" Condition="'$(MSBuildProjectName)' == 'DXMainClient' AND ($(GitVersion_CommitsSinceVersionSource) != 0)">
     <PropertyGroup>
       <DefineConstants>$(DefineConstants);DEVELOPMENT_BUILD</DefineConstants>
     </PropertyGroup>


### PR DESCRIPTION
![01](https://github.com/user-attachments/assets/89df01d4-d259-4030-9c0b-b3fbed28c3f6)

![02](https://github.com/user-attachments/assets/6d7c6864-bcc4-4419-aa4a-c6894743d713)

Demo URLs (does not guarantee be permanent available): 

https://github.com/SadPencil/xna-cncnet-client/releases/tag/2.11.9.0

https://github.com/SadPencil/xna-cncnet-client/actions/runs/14753105526