### PR TITLE
Fix potential crash when client map name is not a valid Win32 file name

### DIFF
--- a/ClientCore/Extensions/StringExtensions.cs
+++ b/ClientCore/Extensions/StringExtensions.cs
@@ -106,7 +106,7 @@ public static class StringExtensions
         }, StringComparer.InvariantCultureIgnoreCase);
 
         if (reservedFileNames.Contains(filename))
-            filename += "_map";
+            filename += "_";
 
         return filename;
     }

--- a/ClientCore/Extensions/StringExtensions.cs
+++ b/ClientCore/Extensions/StringExtensions.cs
@@ -77,4 +77,12 @@ public static class StringExtensions
         => string.IsNullOrEmpty(defaultValue)
             ? defaultValue
             : Translation.Instance.LookUp(key, defaultValue, notify);
+
+    public static string DeleteSpecialSymbols(this string defaultValue)
+    {
+        foreach (char ch in "/\\:*?<>|")
+            defaultValue = defaultValue.Replace(ch, ' ');
+
+        return defaultValue;
+    }
 }

--- a/ClientCore/Extensions/StringExtensions.cs
+++ b/ClientCore/Extensions/StringExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using ClientCore.I18N;
 
 namespace ClientCore.Extensions;
@@ -79,6 +79,7 @@ public static class StringExtensions
             : Translation.Instance.LookUp(key, defaultValue, notify);
 
     public static string DeleteSpecialSymbols(this string defaultValue)
+    public static string ToWin32FileName(this string defaultValue)
     {
         foreach (char ch in "/\\:*?<>|")
             defaultValue = defaultValue.Replace(ch, ' ');

--- a/ClientCore/Extensions/StringExtensions.cs
+++ b/ClientCore/Extensions/StringExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+
 using ClientCore.I18N;
 
 namespace ClientCore.Extensions;
@@ -86,33 +88,26 @@ public static class StringExtensions
     /// <remarks>
     /// Reference: <a href="https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file">Naming Files, Paths, and Namespaces</a>.
     /// </remarks>
-    public static string ToWin32FileName(this string defaultValue)
+    public static string ToWin32FileName(this string filename)
     {
         foreach (char ch in "/\\:*?<>|")
-            defaultValue = defaultValue.Replace(ch, ' ');
+            filename = filename.Replace(ch, ' ');
 
         // If the user is somehow using "con" or any other filename that is
         // reserved by WIN32API, it would be better to rename it.
 
-        string[] reservedFileNames = 
-        {
+        HashSet<string> reservedFileNames = new HashSet<string>(new List<string>(){
             "CON",
             "PRN",
             "AUX",
             "NUL",
             "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "COM¹", "COM²", "COM³",
             "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9", "LPT¹", "LPT²", "LPT³"
-        };
+        }, StringComparer.InvariantCultureIgnoreCase);
 
-        foreach(var reserved in reservedFileNames)
-        {
-            if (defaultValue == reserved)
-            {
-                defaultValue += "_map";
-                break;
-            }
-        }
+        if (reservedFileNames.Contains(filename))
+            filename += "_map";
 
-        return defaultValue;
+        return filename;
     }
 }

--- a/ClientCore/Extensions/StringExtensions.cs
+++ b/ClientCore/Extensions/StringExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using ClientCore.I18N;
 
 namespace ClientCore.Extensions;
@@ -78,11 +78,40 @@ public static class StringExtensions
             ? defaultValue
             : Translation.Instance.LookUp(key, defaultValue, notify);
 
-    public static string DeleteSpecialSymbols(this string defaultValue)
+    /// <summary>
+    /// Replace special characters with spaces in the filename to avoid conflicts with WIN32API.
+    /// </summary>
+    /// <param name="defaultValue">The default string value.</param>
+    /// <returns>File name without special characters or reserved combinations.</returns>
+    /// <remarks>
+    /// Reference: <a href="https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file">Naming Files, Paths, and Namespaces</a>.
+    /// </remarks>
     public static string ToWin32FileName(this string defaultValue)
     {
         foreach (char ch in "/\\:*?<>|")
             defaultValue = defaultValue.Replace(ch, ' ');
+
+        // If the user is somehow using "con" or any other filename that is
+        // reserved by WIN32API, it would be better to rename it.
+
+        string[] reservedFileNames = 
+        {
+            "CON",
+            "PRN",
+            "AUX",
+            "NUL",
+            "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "COM¹", "COM²", "COM³",
+            "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9", "LPT¹", "LPT²", "LPT³"
+        };
+
+        foreach(var reserved in reservedFileNames)
+        {
+            if (defaultValue == reserved)
+            {
+                defaultValue += "_map";
+                break;
+            }
+        }
 
         return defaultValue;
     }

--- a/ClientCore/Extensions/StringExtensions.cs
+++ b/ClientCore/Extensions/StringExtensions.cs
@@ -91,7 +91,7 @@ public static class StringExtensions
     public static string ToWin32FileName(this string filename)
     {
         foreach (char ch in "/\\:*?<>|")
-            filename = filename.Replace(ch, ' ');
+            filename = filename.Replace(ch, '_');
 
         // If the user is somehow using "con" or any other filename that is
         // reserved by WIN32API, it would be better to rename it.

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -1653,7 +1653,6 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         private void MapSharer_HandleMapDownloadComplete(SHA1EventArgs e)
         {
             string mapFileName = MapSharer.GetMapFileName(e.SHA1, e.MapName);
-            mapFileName = mapFileName.ToWin32FileName();
             Logger.Log("Map " + mapFileName + " downloaded, parsing.");
             string mapPath = "Maps/Custom/" + mapFileName;
             Map map = MapLoader.LoadCustomMap(mapPath, out string returnMessage);

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -1653,6 +1653,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         private void MapSharer_HandleMapDownloadComplete(SHA1EventArgs e)
         {
             string mapFileName = MapSharer.GetMapFileName(e.SHA1, e.MapName);
+            mapFileName = mapFileName.DeleteSpecialSymbols();
             Logger.Log("Map " + mapFileName + " downloaded, parsing.");
             string mapPath = "Maps/Custom/" + mapFileName;
             Map map = MapLoader.LoadCustomMap(mapPath, out string returnMessage);

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -1653,7 +1653,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         private void MapSharer_HandleMapDownloadComplete(SHA1EventArgs e)
         {
             string mapFileName = MapSharer.GetMapFileName(e.SHA1, e.MapName);
-            mapFileName = mapFileName.DeleteSpecialSymbols();
+            mapFileName = mapFileName.ToWin32FileName();
             Logger.Log("Map " + mapFileName + " downloaded, parsing.");
             string mapPath = "Maps/Custom/" + mapFileName;
             Map map = MapLoader.LoadCustomMap(mapPath, out string returnMessage);

--- a/DXMainClient/Domain/Multiplayer/CnCNet/MapSharer.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/MapSharer.cs
@@ -10,6 +10,7 @@ using Rampastring.Tools;
 using ClientCore;
 using System.IO.Compression;
 using System.Linq;
+using ClientCore.Extensions;
 
 namespace DTAClient.Domain.Multiplayer.CnCNet
 {
@@ -292,6 +293,8 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
 
         public static void DownloadMap(string sha1, string myGame, string mapName)
         {
+            mapName = mapName.DeleteSpecialSymbols();
+
             lock (locker)
             {
                 if (MapDownloadQueue.Contains(sha1))
@@ -374,7 +377,6 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
         private static string DownloadMain(string sha1, string myGame, string mapName, out bool success)
         {
             string customMapsDirectory = SafePath.CombineDirectoryPath(ProgramConstants.GamePath, "Maps", "Custom");
-
             string mapFileName = GetMapFileName(sha1, mapName);
 
             FileInfo destinationFile = SafePath.GetFile(customMapsDirectory, FormattableString.Invariant($"{mapFileName}.zip"));

--- a/DXMainClient/Domain/Multiplayer/CnCNet/MapSharer.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/MapSharer.cs
@@ -293,7 +293,7 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
 
         public static void DownloadMap(string sha1, string myGame, string mapName)
         {
-            mapName = mapName.DeleteSpecialSymbols();
+            mapName = mapName.ToWin32FileName();
 
             lock (locker)
             {

--- a/DXMainClient/Domain/Multiplayer/CnCNet/MapSharer.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/MapSharer.cs
@@ -293,8 +293,6 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
 
         public static void DownloadMap(string sha1, string myGame, string mapName)
         {
-            mapName = mapName.ToWin32FileName();
-
             lock (locker)
             {
                 if (MapDownloadQueue.Contains(sha1))
@@ -372,7 +370,7 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
         }
 
         public static string GetMapFileName(string sha1, string mapName)
-            => mapName + "_" + sha1;
+            => mapName.ToWin32FileName() + "_" + sha1;
 
         private static string DownloadMain(string sha1, string myGame, string mapName, out bool success)
         {


### PR DESCRIPTION
Fix crash when client tries to save map file with map name containing special symbols not allowed for files on NTFS.

Crash log: [ClientCrashLog_2025_05_02_23_55.txt](https://github.com/user-attachments/files/20024447/ClientCrashLog_2025_05_02_23_55.txt)

Map file to recreate crash: [14ac45ba3197c2f19a36c4269a0f263aee2ce157.zip](https://github.com/user-attachments/files/20024448/14ac45ba3197c2f19a36c4269a0f263aee2ce157.zip)
