### PR TITLE
Fix crash when the desktop resolution is too small

### DIFF
--- a/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
@@ -359,13 +359,6 @@ namespace DTAConfig.OptionPanels
             AddChild(ddIngameResolution);
         }
 
-        public static ScreenResolution GetBestRecommendedResolution()
-        {
-            List<ScreenResolution> recommendedResolutions = ClientConfiguration.Instance.RecommendedResolutions.Select(resolution => (ScreenResolution)resolution).ToList();
-            SortedSet<ScreenResolution> scaledRecommendedResolutions = [.. recommendedResolutions.SelectMany(resolution => resolution.GetIntegerScaledResolutions())];
-            return scaledRecommendedResolutions.Max();
-        }
-
         private void GetRenderers()
         {
             renderers = new List<DirectDrawWrapper>();

--- a/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
@@ -183,13 +183,12 @@ namespace DTAConfig.OptionPanels
 
             // Add client resolutions
             {
-                List<ScreenResolution> recommendedResolutions = ClientConfiguration.Instance.RecommendedResolutions.Select(resolution => (ScreenResolution)resolution).ToList();
-                SortedSet<ScreenResolution> scaledRecommendedResolutions = [.. recommendedResolutions.SelectMany(resolution => resolution.GetIntegerScaledResolutions())];
+                SortedSet<ScreenResolution> scaledRecommendedResolutions = ScreenResolution.GetRecommendedResolutions();
 
                 SortedSet<ScreenResolution> resolutions = [
                     .. ScreenResolution.GetFullScreenResolutions(minWidth: 800, minHeight: 600),
                     .. ScreenResolution.GetWindowedResolutions(minWidth: 800, minHeight: 600),
-                    .. scaledRecommendedResolutions
+                    .. scaledRecommendedResolutions,
                 ];
                 List<ScreenResolution> resolutionList = resolutions.ToList();
 

--- a/DTAConfig/ScreenResolution.cs
+++ b/DTAConfig/ScreenResolution.cs
@@ -188,7 +188,7 @@ namespace DTAConfig
 
         public static ScreenResolution GetBestRecommendedResolution()
         {
-            return GetRecommendedResolutions().Max() ?? SafeFullScreenResolution;
+            return GetRecommendedResolutions().DefaultIfEmpty(SafeFullScreenResolution).Max();
         }
 
     }

--- a/DTAConfig/ScreenResolution.cs
+++ b/DTAConfig/ScreenResolution.cs
@@ -63,7 +63,12 @@ namespace DTAConfig
 
         public bool Fits(ScreenResolution child) => this.Width >= child.Width && this.Height >= child.Height;
 
-        public int CompareTo(ScreenResolution? other) => (this.Width, this.Height).CompareTo(other);
+        public int CompareTo(ScreenResolution? other)
+        {
+            if (other is null)
+                return 1;
+            return (this.Width, this.Height).CompareTo((other.Width, other.Height));
+        }
 
         // Accessing GraphicsAdapter.DefaultAdapter requiring DXMainClient.GameClass has been constructed. Lazy loading prevents possible null reference issues for now.
         private static ScreenResolution? _desktopResolution = null;

--- a/DTAConfig/ScreenResolution.cs
+++ b/DTAConfig/ScreenResolution.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 
+using ClientCore;
+
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
@@ -176,5 +178,18 @@ namespace DTAConfig
 
             return windowedResolutions;
         }
+
+        public static SortedSet<ScreenResolution> GetRecommendedResolutions()
+        {
+            List<ScreenResolution> recommendedResolutions = ClientConfiguration.Instance.RecommendedResolutions.Select(resolution => (ScreenResolution)resolution).ToList();
+            SortedSet<ScreenResolution> scaledRecommendedResolutions = [.. recommendedResolutions.SelectMany(resolution => resolution.GetIntegerScaledResolutions())];
+            return scaledRecommendedResolutions;
+        }
+
+        public static ScreenResolution GetBestRecommendedResolution()
+        {
+            return GetRecommendedResolutions().Max() ?? SafeFullScreenResolution;
+        }
+
     }
 }

--- a/DTAConfig/ScreenResolution.cs
+++ b/DTAConfig/ScreenResolution.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -62,10 +63,10 @@ namespace DTAConfig
 
         public bool Fits(ScreenResolution child) => this.Width >= child.Width && this.Height >= child.Height;
 
-        public int CompareTo(ScreenResolution other) => (this.Width, this.Height).CompareTo(other);
+        public int CompareTo(ScreenResolution? other) => (this.Width, this.Height).CompareTo(other);
 
         // Accessing GraphicsAdapter.DefaultAdapter requiring DXMainClient.GameClass has been constructed. Lazy loading prevents possible null reference issues for now.
-        private static ScreenResolution _desktopResolution = null;
+        private static ScreenResolution? _desktopResolution = null;
 
         /// <summary>
         /// The resolution of primary monitor.
@@ -76,7 +77,7 @@ namespace DTAConfig
         // The default graphic profile supports resolution up to 4096x4096. The number gets even smaller in practice. Therefore, we select 3840 as the limit.
         public static ScreenResolution HiDefLimitResolution { get; } = "3840x3840";
 
-        private static ScreenResolution _safeMaximumResolution = null;
+        private static ScreenResolution? _safeMaximumResolution = null;
 
         /// <summary>
         /// The resolution of primary monitor, or the maximum resolution supported by the graphic profile, whichever is smaller.
@@ -93,12 +94,12 @@ namespace DTAConfig
             }
         }
 
-        private static ScreenResolution _safeFullScreenResolution = null;
+        private static ScreenResolution? _safeFullScreenResolution = null;
 
         /// <summary>
         /// The maximum resolution supported by the graphic profile, or the largest full screen resolution supported by the primary monitor, whichever is smaller.
         /// </summary>
-        public static ScreenResolution SafeFullScreenResolution => _safeFullScreenResolution ??= GetFullScreenResolutions(minWidth: 800, minHeight: 600).Max();
+        public static ScreenResolution SafeFullScreenResolution => _safeFullScreenResolution ??= GetFullScreenResolutions(minWidth: 800, minHeight: 600).Max ?? SafeMaximumResolution;
 
         public static SortedSet<ScreenResolution> GetFullScreenResolutions(int minWidth, int minHeight) =>
             GetFullScreenResolutions(minWidth, minHeight, SafeMaximumResolution.Width, SafeMaximumResolution.Height);
@@ -186,10 +187,8 @@ namespace DTAConfig
             return scaledRecommendedResolutions;
         }
 
-        public static ScreenResolution GetBestRecommendedResolution()
-        {
-            return GetRecommendedResolutions().Max ?? SafeFullScreenResolution;
-        }
+        public static ScreenResolution GetBestRecommendedResolution() =>
+            GetRecommendedResolutions().Max ?? SafeFullScreenResolution;
 
     }
 }

--- a/DTAConfig/ScreenResolution.cs
+++ b/DTAConfig/ScreenResolution.cs
@@ -188,7 +188,7 @@ namespace DTAConfig
 
         public static ScreenResolution GetBestRecommendedResolution()
         {
-            return GetRecommendedResolutions().DefaultIfEmpty(SafeFullScreenResolution).Max();
+            return GetRecommendedResolutions().Max ?? SafeFullScreenResolution;
         }
 
     }

--- a/DXMainClient/Startup.cs
+++ b/DXMainClient/Startup.cs
@@ -134,9 +134,7 @@ namespace DTAClient
             if (!UserINISettings.Instance.BorderlessWindowedClient)
             {
                 // Find the largest recommended resolution as the default windowed resolution
-                List<ScreenResolution> recommendedResolutions = ClientConfiguration.Instance.RecommendedResolutions.Select(resolution => (ScreenResolution)resolution).ToList();
-                SortedSet<ScreenResolution> scaledRecommendedResolutions = [.. recommendedResolutions.SelectMany(resolution => resolution.GetIntegerScaledResolutions())];
-                var bestRecommendedResolution = scaledRecommendedResolutions.Max() ?? ScreenResolution.SafeFullScreenResolution;
+                var bestRecommendedResolution = ScreenResolution.GetBestRecommendedResolution();
 
                 UserINISettings.Instance.ClientResolutionX = new IntSetting(UserINISettings.Instance.SettingsIni, UserINISettings.VIDEO, "ClientResolutionX", bestRecommendedResolution.Width);
                 UserINISettings.Instance.ClientResolutionY = new IntSetting(UserINISettings.Instance.SettingsIni, UserINISettings.VIDEO, "ClientResolutionY", bestRecommendedResolution.Height);

--- a/DXMainClient/Startup.cs
+++ b/DXMainClient/Startup.cs
@@ -136,7 +136,7 @@ namespace DTAClient
                 // Find the largest recommended resolution as the default windowed resolution
                 List<ScreenResolution> recommendedResolutions = ClientConfiguration.Instance.RecommendedResolutions.Select(resolution => (ScreenResolution)resolution).ToList();
                 SortedSet<ScreenResolution> scaledRecommendedResolutions = [.. recommendedResolutions.SelectMany(resolution => resolution.GetIntegerScaledResolutions())];
-                var bestRecommendedResolution = scaledRecommendedResolutions.Max();
+                var bestRecommendedResolution = scaledRecommendedResolutions.Max() ?? ScreenResolution.SafeFullScreenResolution;
 
                 UserINISettings.Instance.ClientResolutionX = new IntSetting(UserINISettings.Instance.SettingsIni, UserINISettings.VIDEO, "ClientResolutionX", bestRecommendedResolution.Width);
                 UserINISettings.Instance.ClientResolutionY = new IntSetting(UserINISettings.Instance.SettingsIni, UserINISettings.VIDEO, "ClientResolutionY", bestRecommendedResolution.Height);


### PR DESCRIPTION
```
KABOOOOOOM!!! Info:

Type: System.NullReferenceException

Message: Message: Object reference not set to an instance of an object.

Source: clientdx

TargetSite.Name: Execute

Stacktrace:    在 DTAClient.Startup.Execute()

在 DTAClient.PreStartup.Initialize(StartupParams parameters)
```

Also removes an unused function `GetBestRecommendedResolution()` that shares the same codes.

We should indeed gradually enable `#nullable` since null reference exception is the most frequent crash type of the client.