### PR TITLE
Remove default value of ClientGameType

### DIFF
--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -192,7 +192,6 @@ namespace ClientCore
         private ClientType? _ClientGameType = null;
         public ClientType ClientGameType => _ClientGameType ??= ClientTypeHelper.FromString(_ClientGameTypeString);
 
-
         public string DiscordAppId => clientDefinitionsIni.GetStringValue(SETTINGS, "DiscordAppId", string.Empty);
 
         public int SendSleep => clientDefinitionsIni.GetIntValue(SETTINGS, "SendSleep", 2500);

--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -188,7 +188,10 @@ namespace ClientCore
 
         #region Client definitions
 
-        public ClientType ClientGameType => clientDefinitionsIni.GetStringValue(SETTINGS, "ClientGameType", nameof(ClientType.TS)).ToEnum<ClientType>();
+        private string _ClientGameTypeString => clientDefinitionsIni.GetStringValue(SETTINGS, "ClientGameType", string.Empty);
+        private ClientType? _ClientGameType = null;
+        public ClientType ClientGameType => _ClientGameType ??= ClientTypeHelper.FromString(_ClientGameTypeString);
+
 
         public string DiscordAppId => clientDefinitionsIni.GetStringValue(SETTINGS, "DiscordAppId", string.Empty);
 

--- a/ClientCore/Enums/ClientTypeHelper.cs
+++ b/ClientCore/Enums/ClientTypeHelper.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace ClientCore.Enums
+{
+    public static class ClientTypeHelper
+    {
+        public static ClientType FromString(string value) => value switch
+        {
+            "TS" => ClientType.TS,
+            "YR" => ClientType.YR,
+            "Ares" => ClientType.Ares,
+            _ => throw new Exception("It seems the client configuration was not migrated to accommodate for the v2.12 changes. Please specify 'ClientGameType' in `[Settings]` section of the 'ClientDefinitions.ini' file, e.g., 'ClientGameType=Ares'."),
+        };
+    }
+}

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -208,7 +208,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             }
             catch (Exception ex)
             {
-                throw new Exception(string.Format("It seems the client configuration was not migrated to accomodate for the 'Tiberian Sun Client v6 Changes'.\n\nPlease refer to {0} for more details.\n\nError message: {1}".L10N("Client:Main:NotMigratedClientException"),
+                throw new Exception(string.Format("It seems the client configuration was not migrated to accommodate for the 'Tiberian Sun Client v6 Changes'.\n\nPlease refer to {0} for more details.\n\nError message: {1}".L10N("Client:Main:NotMigratedClientException"),
                                                   "https://github.com/CnCNet/xna-cncnet-client/blob/122b2de962afc404e203290d0618363d83c4264a/Docs/Migration-INI.md",
                                                    ex.Message));
             }

--- a/Docs/Migration-INI.md
+++ b/Docs/Migration-INI.md
@@ -10,7 +10,7 @@ It is **highly recommended** to make a complete backup of your game/mod before s
 
 Since v2.12, the client has unified different builds among game types. The game type must be defined in `ClientDefinitions.ini` now.
 
-1. Add `[Settings]->ClientGameType=YR` (defines client behaviour by game. Allowed options: TS, YR, Ares)
+- Add `[Settings]->ClientGameType=YR` (defines client behaviour by game. Allowed options: TS, YR, Ares)
 
 The way the client is launched on Unix systems has changed.
 

--- a/Docs/Migration-INI.md
+++ b/Docs/Migration-INI.md
@@ -1,6 +1,6 @@
 # Migrating from older versions - INI configuration
 
-Migrating to client version [2.11.0.0][client] from pre-2.11.0.0.
+Migrating to client version [2.11.0.0][client_2.11] or [2.12.0][client_2.12] from pre-2.11.0.0.
 
 This guide uses [YR mod base][mod_base] configuration as an example by migrating from commit [`6ce7db7`](https://github.com/Starkku/cncnet-client-mod-base/commit/6ce7db7fd753df329fb435c3aa5ba90505e5f3a2) to [`34efc04`](https://github.com/Starkku/cncnet-client-mod-base/commit/34efc0454c64e4af28e8177e63f3d9546cbbc6fb). The majority of changes also applies to non-YR client configurations.
 
@@ -8,11 +8,14 @@ It is **highly recommended** to make a complete backup of your game/mod before s
 
 ## Edit `ClientDefinitions.ini`
 
+Since v2.12, the client has unified different builds among game types. The game type must be defined in `ClientDefinitions.ini` now.
+
+1. Add `[Settings]->ClientGameType=YR` (defines client behaviour by game. Allowed options: TS, YR, Ares)
+
 The way the client is launched on Unix systems has changed.
 
 1. Add `[Settings]->UnixLauncherExe=YRLauncher.sh` (script file name can be anything)
-2. Add `[Settings]->ClientGameType=YR` (defines client behaviour by game. Allowed options: TS, YR, Ares)
-3. Create `YRLauncher.sh` in game directory:
+2. Create `YRLauncher.sh` in game directory:
 
 ```sh
 #!/bin/sh
@@ -21,7 +24,7 @@ cd "$(dirname "$0")"
 dotnet Resources/BinariesNET8/UniversalGL/clientogl.dll "$@"
 ```
 
-4. **OPTIONAL** Add these entries in `[Settings]` (fill with your required/forbidden mod files):
+3. **OPTIONAL** Add these entries in `[Settings]` (fill with your required/forbidden mod files):
 
 ```ini
 ; Comma-separated list of files required to run the game / mod that are not included in the installation.
@@ -946,5 +949,6 @@ Every file here can be placed either in `Resources` or in theme directories:
 
 You can find example assets in the [YR mod base][mod_base].
 
-[client]: https://github.com/CnCNet/xna-cncnet-client/releases/tag/2.11.0.0
+[client_2.11]: https://github.com/CnCNet/xna-cncnet-client/releases/tag/2.11.0.0
+[client_2.12]: https://github.com/CnCNet/xna-cncnet-client/releases/tag/2.12.0
 [mod_base]: https://github.com/Starkku/cncnet-client-mod-base

--- a/Docs/Migration.md
+++ b/Docs/Migration.md
@@ -47,3 +47,5 @@ Migrating from older versions
 - The [Tiberian Sun Client v6 Changes](https://github.com/CnCNet/xna-cncnet-client/pull/275) changes the license to GPLv3. This means that if your client is a private fork, you must either stop releasing the modified client or provide the modified source code to public with GPLv3 license.
 
 - `BtnSaveLoadGameOptions` in game lobbies was renamed to `btnSaveLoadGameOptions` for consistency. See [this change](https://github.com/CnCNet/cncnet-ts-client-package/commit/2ac97c68978431e94e320299e0168119f75a849f) to TSC for an example of addressing this.
+
+- Since v2.12, the client has unified different builds among game types. The game type must be defined in the `ClientDefinitions.ini` file. Please specify 'ClientGameType' in `[Settings]` section of the 'ClientDefinitions.ini' file, e.g., 'ClientGameType=Ares'.


### PR DESCRIPTION
![图片](https://github.com/user-attachments/assets/784afc1b-339e-4016-81c6-25183838f78b)

Also, minor changes are applied to the document. A placeholder of tag name `2.12.0` instead of `2.12.0.0` is used as GitVersion does not support the fourth number -- it will always be 0.