### PR TITLE
Fix `spawnmap.ini` encoding getting messed up

### DIFF
--- a/ClientCore/ClientCore.csproj
+++ b/ClientCore/ClientCore.csproj
@@ -11,5 +11,6 @@
     <PackageReference Include="Rampastring.XNAUI.$(Engine)" Condition="'!$(Configuration.Contains(Debug))'" />
     <PackageReference Include="Rampastring.XNAUI.$(Engine).Debug" Condition="'$(Configuration.Contains(Debug))'" />
     <PackageReference Include="System.Text.Encoding.CodePages" />
+    <PackageReference Include="Ude.NetStandard" />
   </ItemGroup>
 </Project>

--- a/ClientCore/FileHelper.cs
+++ b/ClientCore/FileHelper.cs
@@ -90,5 +90,21 @@ namespace ClientCore
                 throw new PlatformNotSupportedException();
             }
         }
+
+        public static Encoding GetEncoding(string filename)
+        {
+            Encoding encoding = Encoding.UTF8;
+
+            using (FileStream fs = File.OpenRead(filename))
+            {
+                Ude.CharsetDetector cdet = new Ude.CharsetDetector();
+                cdet.Feed(fs);
+                cdet.DataEnd();
+                if (cdet.Charset != null)
+                    encoding = Encoding.GetEncoding(cdet.Charset);
+            }
+
+            return encoding;
+        }
     }
 }

--- a/DXMainClient/Domain/Multiplayer/Map.cs
+++ b/DXMainClient/Domain/Multiplayer/Map.cs
@@ -15,6 +15,7 @@ using Point = Microsoft.Xna.Framework.Point;
 using Utilities = Rampastring.Tools.Utilities;
 using static System.Collections.Specialized.BitVector32;
 using System.Diagnostics;
+using System.Text;
 
 namespace DTAClient.Domain.Multiplayer
 {
@@ -711,11 +712,15 @@ namespace DTAClient.Domain.Multiplayer
 
         public IniFile GetMapIni()
         {
-            var mapIni = new IniFile(CompleteFilePath);
+            Encoding encoding = FileHelper.GetEncoding(CompleteFilePath);
+
+            var mapIni = new IniFile(CompleteFilePath, encoding);
 
             if (!string.IsNullOrEmpty(ExtraININame))
             {
-                var extraIni = new IniFile(SafePath.CombineFilePath(ProgramConstants.GamePath, "INI", "Map Code", ExtraININame));
+                string extraIniPath = SafePath.CombineFilePath(ProgramConstants.GamePath, "INI", "Map Code", ExtraININame);
+                encoding = FileHelper.GetEncoding(extraIniPath);
+                var extraIni = new IniFile(extraIniPath, encoding);
                 IniFile.ConsolidateIniFiles(mapIni, extraIni);
             }
 

--- a/DXMainClient/Program.cs
+++ b/DXMainClient/Program.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+using System.Text;
+
 #if !NETFRAMEWORK
 using System.Runtime.Loader;
 #endif
@@ -100,6 +102,9 @@ namespace DTAClient
 #endif
         static void Main(string[] args)
         {
+            // https://stackoverflow.com/questions/3967716/how-to-find-encoding-for-1251-codepage
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
             InitializeApplicationConfiguration();
 
             bool noAudio = false;

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,6 +32,7 @@
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="$(DotnetLibrariesVersion)" />
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+    <PackageVersion Include="Ude.NetStandard" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(MSBuildProjectName)' == 'ClientCore' Or '$(MSBuildProjectName)' == 'ClientGUI' Or '$(MSBuildProjectName)' == 'DTAConfig' Or '$(MSBuildProjectName)' == 'DXMainClient' Or '$(MSBuildProjectName)' == 'ClientUpdater'">
     <ProjectReference Include="$(MSBuildThisFileDirectory)TranslationNotifierGenerator\TranslationNotifierGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />


### PR DESCRIPTION
The bug was first discovered in 2019 when I was translating Twisted Insurrection into Russian. The bug was caused by the fact that `spawnmap.ini` is always created in UTF8 encoding, even if the original file was in a different one, for example in CP1251.

Important map code in UTF8:

![image](https://github.com/user-attachments/assets/6a5d1d20-041e-4d3b-bfcc-1c1ed2d90245)

Important map code in CP1251:

![image](https://github.com/user-attachments/assets/a4a1cdc0-c845-4972-970f-ab76d1678cd1)

Before patch:

![image](https://github.com/user-attachments/assets/77bb4adc-ca19-4270-9719-3712228c16ff)

After patch:

![image](https://github.com/user-attachments/assets/ebc23ed7-e629-4236-8e2f-c69aba5cbd89)
