### PR TITLE
Random loading screens

### DIFF
--- a/DXMainClient/DXGUI/Generic/LoadingScreen.cs
+++ b/DXMainClient/DXGUI/Generic/LoadingScreen.cs
@@ -5,9 +5,7 @@ using ClientCore.CnCNet5;
 using ClientGUI;
 using ClientUpdater;
 using DTAClient.Domain.Multiplayer;
-using DTAClient.DXGUI.Multiplayer;
 using DTAClient.DXGUI.Multiplayer.CnCNet;
-using DTAClient.DXGUI.Multiplayer.GameLobby;
 using DTAClient.Online;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Xna.Framework;
@@ -43,11 +41,12 @@ namespace DTAClient.DXGUI.Generic
         private readonly CnCNetManager cncnetManager;
         private readonly IServiceProvider serviceProvider;
 
+        private string[] randomTextures;
+
         public override void Initialize()
         {
             ClientRectangle = new Rectangle(0, 0, 800, 600);
             Name = "LoadingScreen";
-
             BackgroundTexture = AssetLoader.LoadTexture("loadingscreen.png");
 
             base.Initialize();
@@ -69,6 +68,18 @@ namespace DTAClient.DXGUI.Generic
                 Cursor.Visible = false;
                 visibleSpriteCursor = true;
             }
+        }
+
+        protected override void GetINIAttributes(IniFile iniFile)
+        {
+            base.GetINIAttributes(iniFile);
+
+            string tmp = iniFile.GetStringValue(Name, "RandomTextures", string.Empty);
+
+            randomTextures = tmp == string.Empty ? null : tmp.Split(',');
+
+            if (randomTextures != null)
+                BackgroundTexture = AssetLoader.LoadTexture(randomTextures[new Random().Next(randomTextures.Length)]);
         }
 
         private void InitUpdater()


### PR DESCRIPTION
## About

Reimplementation of the feature #211.

## How to use

1. Create `LoadingScreen.ini`
2. Add section `[LoadingScreen]` with key `RandomTextures` that contains filenames splited with comma `,`

Example:

```ini
; LoadingScreen.ini
[LoadingScreen]
Size=1280,720
BackgroundTexture=lsbg.png
DrawBorders=false
RandomTextures=lsbg.png,ts_legal_text.png,lstext.png
```