### PR TITLE
Refactor control names in client's code base

### DIFF
--- a/ClientGUI/DarkeningPanel.cs
+++ b/ClientGUI/DarkeningPanel.cs
@@ -21,7 +21,7 @@ namespace ClientGUI
 
         public override void Initialize()
         {
-            Name = "DarkeningPanel";
+            Name = nameof(DarkeningPanel);
 
             SetPositionAndSize();
             

--- a/ClientGUI/XNAMessageBox.cs
+++ b/ClientGUI/XNAMessageBox.cs
@@ -104,7 +104,7 @@ namespace ClientGUI
             btnOK.IdleTexture = AssetLoader.LoadTexture("75pxbtn.png");
             btnOK.HoverTexture = AssetLoader.LoadTexture("75pxbtn_c.png");
             btnOK.HoverSoundEffect = new EnhancedSoundEffect("button.wav");
-            btnOK.Name = "btnOK";
+            btnOK.Name = nameof(btnOK);
             btnOK.Text = "OK".L10N("Client:ClientGUI:ButtonOK");
             btnOK.LeftClick += BtnOK_LeftClick;
             btnOK.HotKey = Keys.Enter;
@@ -124,7 +124,7 @@ namespace ClientGUI
             btnYes.IdleTexture = AssetLoader.LoadTexture("75pxbtn.png");
             btnYes.HoverTexture = AssetLoader.LoadTexture("75pxbtn_c.png");
             btnYes.HoverSoundEffect = new EnhancedSoundEffect("button.wav");
-            btnYes.Name = "btnYes";
+            btnYes.Name = nameof(btnYes);
             btnYes.Text = "Yes".L10N("Client:ClientGUI:ButtonYes");
             btnYes.LeftClick += BtnYes_LeftClick;
             btnYes.HotKey = Keys.Y;
@@ -140,7 +140,7 @@ namespace ClientGUI
             btnNo.IdleTexture = AssetLoader.LoadTexture("75pxbtn.png");
             btnNo.HoverTexture = AssetLoader.LoadTexture("75pxbtn_c.png");
             btnNo.HoverSoundEffect = new EnhancedSoundEffect("button.wav");
-            btnNo.Name = "btnNo";
+            btnNo.Name = nameof(btnNo);
             btnNo.Text = "No".L10N("Client:ClientGUI:ButtonNo");
             btnNo.LeftClick += BtnNo_LeftClick;
             btnNo.HotKey = Keys.N;
@@ -159,7 +159,7 @@ namespace ClientGUI
             btnOK.IdleTexture = AssetLoader.LoadTexture("75pxbtn.png");
             btnOK.HoverTexture = AssetLoader.LoadTexture("75pxbtn_c.png");
             btnOK.HoverSoundEffect = new EnhancedSoundEffect("button.wav");
-            btnOK.Name = "btnOK";
+            btnOK.Name = nameof(btnOK);
             btnOK.Text = "OK".L10N("Client:ClientGUI:ButtonOK");
             btnOK.LeftClick += BtnYes_LeftClick;
             btnOK.HotKey = Keys.Enter;
@@ -175,7 +175,7 @@ namespace ClientGUI
             btnCancel.IdleTexture = AssetLoader.LoadTexture("75pxbtn.png");
             btnCancel.HoverTexture = AssetLoader.LoadTexture("75pxbtn_c.png");
             btnCancel.HoverSoundEffect = new EnhancedSoundEffect("button.wav");
-            btnCancel.Name = "btnCancel";
+            btnCancel.Name = nameof(btnCancel);
             btnCancel.Text = "Cancel".L10N("Client:ClientGUI:ButtonCancel");
             btnCancel.LeftClick += BtnCancel_LeftClick;
             btnCancel.HotKey = Keys.C;

--- a/DTAConfig/HotkeyConfigurationWindow.cs
+++ b/DTAConfig/HotkeyConfigurationWindow.cs
@@ -61,17 +61,17 @@ namespace DTAConfig
         {
             ReadGameCommands();
 
-            Name = "HotkeyConfigurationWindow";
+            Name = nameof(HotkeyConfigurationWindow);
             ClientRectangle = new Rectangle(0, 0, 600, 450);
             BackgroundTexture = AssetLoader.LoadTextureUncached("hotkeyconfigbg.png");
 
             var lblCategory = new XNALabel(WindowManager);
-            lblCategory.Name = "lblCategory";
+            lblCategory.Name = nameof(lblCategory);
             lblCategory.ClientRectangle = new Rectangle(12, 12, 0, 0);
             lblCategory.Text = "Category:".L10N("Client:DTAConfig:Category");
 
             ddCategory = new XNAClientDropDown(WindowManager);
-            ddCategory.Name = "ddCategory";
+            ddCategory.Name = nameof(ddCategory);
             ddCategory.ClientRectangle = new Rectangle(lblCategory.Right + 12,
                 lblCategory.Y - 1, 250, ddCategory.Height);
 
@@ -87,7 +87,7 @@ namespace DTAConfig
                 ddCategory.AddItem(category);
 
             lbHotkeys = new XNAMultiColumnListBox(WindowManager);
-            lbHotkeys.Name = "lbHotkeys";
+            lbHotkeys.Name = nameof(lbHotkeys);
             lbHotkeys.ClientRectangle = new Rectangle(12, ddCategory.Bottom + 12,
                 ddCategory.Right - 12, Height - ddCategory.Bottom - 59);
             lbHotkeys.PanelBackgroundDrawMode = PanelBackgroundImageDrawMode.STRETCHED;
@@ -96,83 +96,83 @@ namespace DTAConfig
             lbHotkeys.AddColumn("Shortcut".L10N("Client:DTAConfig:Shortcut"), lbHotkeys.Width - 150);
 
             hotkeyInfoPanel = new XNAPanel(WindowManager);
-            hotkeyInfoPanel.Name = "HotkeyInfoPanel";
+            hotkeyInfoPanel.Name = nameof(hotkeyInfoPanel);
             hotkeyInfoPanel.ClientRectangle = new Rectangle(lbHotkeys.Right + 12,
                 ddCategory.Y, Width - lbHotkeys.Right - 24, lbHotkeys.Height + ddCategory.Height + 12);
 
             lblCommandCaption = new XNALabel(WindowManager);
-            lblCommandCaption.Name = "lblCommandCaption";
+            lblCommandCaption.Name = nameof(lblCommandCaption);
             lblCommandCaption.FontIndex = 1;
             lblCommandCaption.ClientRectangle = new Rectangle(12, 12, 0, 0);
             lblCommandCaption.Text = "Command name".L10N("Client:DTAConfig:CommandName");
 
             lblDescription = new XNALabel(WindowManager);
-            lblDescription.Name = "lblDescription";
+            lblDescription.Name = nameof(lblDescription);
             lblDescription.ClientRectangle = new Rectangle(12, lblCommandCaption.Bottom + 12, 0, 0);
             lblDescription.Text = "Command description".L10N("Client:DTAConfig:CommandDescription");
 
             var lblCurrentHotkey = new XNALabel(WindowManager);
-            lblCurrentHotkey.Name = "lblCurrentHotkey";
+            lblCurrentHotkey.Name = nameof(lblCurrentHotkey);
             lblCurrentHotkey.ClientRectangle = new Rectangle(lblDescription.X,
                 lblDescription.Bottom + 48, 0, 0);
             lblCurrentHotkey.FontIndex = 1;
             lblCurrentHotkey.Text = "Currently assigned hotkey:".L10N("Client:DTAConfig:CurrentHotKey");
 
             lblCurrentHotkeyValue = new XNALabel(WindowManager);
-            lblCurrentHotkeyValue.Name = "lblCurrentHotkeyValue";
+            lblCurrentHotkeyValue.Name = nameof(lblCurrentHotkeyValue);
             lblCurrentHotkeyValue.ClientRectangle = new Rectangle(lblDescription.X,
                 lblCurrentHotkey.Bottom + 6, 0, 0);
             lblCurrentHotkeyValue.Text = "Current hotkey value".L10N("Client:DTAConfig:CurrentHotKeyValue");
 
             var lblNewHotkey = new XNALabel(WindowManager);
-            lblNewHotkey.Name = "lblNewHotkey";
+            lblNewHotkey.Name = nameof(lblNewHotkey);
             lblNewHotkey.ClientRectangle = new Rectangle(lblDescription.X,
                 lblCurrentHotkeyValue.Bottom + 48, 0, 0);
             lblNewHotkey.FontIndex = 1;
             lblNewHotkey.Text = "New hotkey:".L10N("Client:DTAConfig:NewHotKey");
 
             lblNewHotkeyValue = new XNALabel(WindowManager);
-            lblNewHotkeyValue.Name = "lblNewHotkeyValue";
+            lblNewHotkeyValue.Name = nameof(lblNewHotkeyValue);
             lblNewHotkeyValue.ClientRectangle = new Rectangle(lblDescription.X,
                 lblNewHotkey.Bottom + 6, 0, 0);
             lblNewHotkeyValue.Text = HOTKEY_TIP_TEXT;
 
             lblCurrentlyAssignedTo = new XNALabel(WindowManager);
-            lblCurrentlyAssignedTo.Name = "lblCurrentlyAssignedTo";
+            lblCurrentlyAssignedTo.Name = nameof(lblCurrentlyAssignedTo);
             lblCurrentlyAssignedTo.ClientRectangle = new Rectangle(lblDescription.X,
                 lblNewHotkeyValue.Bottom + 12, 0, 0);
             lblCurrentlyAssignedTo.Text = "Currently assigned to:".L10N("Client:DTAConfig:CurrentHotKeyAssign") + "\nKey";
 
             var btnAssign = new XNAClientButton(WindowManager);
-            btnAssign.Name = "btnAssign";
+            btnAssign.Name = nameof(btnAssign);
             btnAssign.ClientRectangle = new Rectangle(lblDescription.X,
                 lblCurrentlyAssignedTo.Bottom + 24, UIDesignConstants.BUTTON_WIDTH_121, UIDesignConstants.BUTTON_HEIGHT);
             btnAssign.Text = "Assign Hotkey".L10N("Client:DTAConfig:AssignHotkey");
             btnAssign.LeftClick += BtnAssign_LeftClick;
 
             btnResetKey = new XNAClientButton(WindowManager);
-            btnResetKey.Name = "btnResetKey";
+            btnResetKey.Name = nameof(btnResetKey);
             btnResetKey.ClientRectangle = new Rectangle(btnAssign.X, btnAssign.Bottom + 12, btnAssign.Width, 23);
             btnResetKey.Text = "Reset to Default".L10N("Client:DTAConfig:ResetToDefault");
             btnResetKey.LeftClick += BtnReset_LeftClick;
 
             var lblDefaultHotkey = new XNALabel(WindowManager);
-            lblDefaultHotkey.Name = "lblOriginalHotkey";
+            lblDefaultHotkey.Name = nameof(lblDefaultHotkey);
             lblDefaultHotkey.ClientRectangle = new Rectangle(lblCurrentHotkey.X, btnResetKey.Bottom + 12, 0, 0);
             lblDefaultHotkey.Text = "Default hotkey:".L10N("Client:DTAConfig:DefaultHotKey");
 
             lblDefaultHotkeyValue = new XNALabel(WindowManager);
-            lblDefaultHotkeyValue.Name = "lblDefaultHotkeyValue";
+            lblDefaultHotkeyValue.Name = nameof(lblDefaultHotkeyValue);
             lblDefaultHotkeyValue.ClientRectangle = new Rectangle(lblDefaultHotkey.Right + 12, lblDefaultHotkey.Y, 0, 0);
 
             var btnSave = new XNAClientButton(WindowManager);
-            btnSave.Name = "btnSave";
+            btnSave.Name = nameof(btnSave);
             btnSave.ClientRectangle = new Rectangle(12, lbHotkeys.Bottom + 12, UIDesignConstants.BUTTON_WIDTH_92, UIDesignConstants.BUTTON_HEIGHT);
             btnSave.Text = "Save".L10N("Client:DTAConfig:ButtonSave");
             btnSave.LeftClick += BtnSave_LeftClick;
 
             var btnResetAllKeys = new XNAClientButton(WindowManager);
-            btnResetAllKeys.Name = "btnResetAllToDefaults";
+            btnResetAllKeys.Name = nameof(btnResetAllKeys);
             btnResetAllKeys.ClientRectangle = new Rectangle(0, btnSave.Y, UIDesignConstants.BUTTON_WIDTH_121, UIDesignConstants.BUTTON_HEIGHT);
             btnResetAllKeys.Text = "Reset All Keys".L10N("Client:DTAConfig:ResetAllHotkey");
             btnResetAllKeys.LeftClick += BtnResetToDefaults_LeftClick;
@@ -180,7 +180,7 @@ namespace DTAConfig
             btnResetAllKeys.CenterOnParentHorizontally();
 
             var btnCancel = new XNAClientButton(WindowManager);
-            btnCancel.Name = "btnExit";
+            btnCancel.Name = nameof(btnCancel);
             btnCancel.ClientRectangle = new Rectangle(Width - 104, btnSave.Y, UIDesignConstants.BUTTON_WIDTH_92, UIDesignConstants.BUTTON_HEIGHT);
             btnCancel.Text = "Cancel".L10N("Client:DTAConfig:ButtonCancel");
             btnCancel.LeftClick += BtnCancel_LeftClick;

--- a/DTAConfig/OptionPanels/AudioOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/AudioOptionsPanel.cs
@@ -48,7 +48,7 @@ namespace DTAConfig.OptionPanels
         {
             base.Initialize();
 
-            Name = "AudioOptionsPanel";
+            Name = nameof(AudioOptionsPanel);
 
             var lblScoreVolume = new XNALabel(WindowManager);
             lblScoreVolume.Name = nameof(lblScoreVolume);

--- a/DTAConfig/OptionPanels/CnCNetOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/CnCNetOptionsPanel.cs
@@ -44,7 +44,7 @@ namespace DTAConfig.OptionPanels
         public override void Initialize()
         {
             base.Initialize();
-            Name = "CnCNetOptionsPanel";
+            Name = nameof(CnCNetOptionsPanel);
 
             InitOptions();
             InitGameListPanel();

--- a/DTAConfig/OptionPanels/ComponentsPanel.cs
+++ b/DTAConfig/OptionPanels/ComponentsPanel.cs
@@ -27,7 +27,7 @@ namespace DTAConfig.OptionPanels
         {
             base.Initialize();
 
-            Name = "ComponentsPanel";
+            Name = nameof(ComponentsPanel);
 
             int componentIndex = 0;
 

--- a/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/DisplayOptionsPanel.cs
@@ -66,7 +66,7 @@ namespace DTAConfig.OptionPanels
         {
             base.Initialize();
 
-            Name = "DisplayOptionsPanel";
+            Name = nameof(DisplayOptionsPanel);
 
             var lblIngameResolution = new XNALabel(WindowManager);
             lblIngameResolution.Name = nameof(lblIngameResolution);

--- a/DTAConfig/OptionPanels/GameOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/GameOptionsPanel.cs
@@ -13,7 +13,6 @@ namespace DTAConfig.OptionPanels
 {
     class GameOptionsPanel : XNAOptionsPanel
     {
-
         private const string TEXT_BACKGROUND_COLOR_TRANSPARENT = "0";
         private const string TEXT_BACKGROUND_COLOR_BLACK = "12";
         private const int MAX_SCROLL_RATE = 6;
@@ -44,7 +43,7 @@ namespace DTAConfig.OptionPanels
         {
             base.Initialize();
 
-            Name = "GameOptionsPanel";
+            Name = nameof(GameOptionsPanel);
 
             var lblScrollRate = new XNALabel(WindowManager);
             lblScrollRate.Name = nameof(lblScrollRate);

--- a/DTAConfig/OptionPanels/UpdaterOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/UpdaterOptionsPanel.cs
@@ -26,29 +26,29 @@ namespace DTAConfig.OptionPanels
         {
             base.Initialize();
 
-            Name = "UpdaterOptionsPanel";
+            Name = nameof(UpdaterOptionsPanel);
 
             var lblDescription = new XNALabel(WindowManager);
-            lblDescription.Name = "lblDescription";
+            lblDescription.Name = nameof(lblDescription);
             lblDescription.ClientRectangle = new Rectangle(12, 12, 0, 0);
             lblDescription.Text = ("To change download server priority, select a server from the list and\nuse the Move Up / Down buttons to change its priority.").L10N("Client:DTAConfig:ServerPriorityTip");
 
             lbUpdateServerList = new XNAListBox(WindowManager);
-            lbUpdateServerList.Name = "lblUpdateServerList";
+            lbUpdateServerList.Name = nameof(lbUpdateServerList);
             lbUpdateServerList.ClientRectangle = new Rectangle(lblDescription.X,
                 lblDescription.Bottom + 12, Width - 24, 100);
             lbUpdateServerList.BackgroundTexture = AssetLoader.CreateTexture(new Color(0, 0, 0, 128), 2, 2);
             lbUpdateServerList.PanelBackgroundDrawMode = PanelBackgroundImageDrawMode.STRETCHED;
 
             var btnMoveUp = new XNAClientButton(WindowManager);
-            btnMoveUp.Name = "btnMoveUp";
+            btnMoveUp.Name = nameof(btnMoveUp);
             btnMoveUp.ClientRectangle = new Rectangle(lbUpdateServerList.X,
                 lbUpdateServerList.Bottom + 12, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnMoveUp.Text = "Move Up".L10N("Client:DTAConfig:MoveUp");
             btnMoveUp.LeftClick += btnMoveUp_LeftClick;
 
             var btnMoveDown = new XNAClientButton(WindowManager);
-            btnMoveDown.Name = "btnMoveDown";
+            btnMoveDown.Name = nameof(btnMoveDown);
             btnMoveDown.ClientRectangle = new Rectangle(
                 lbUpdateServerList.Right - UIDesignConstants.BUTTON_WIDTH_133,
                 btnMoveUp.Y, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
@@ -56,13 +56,13 @@ namespace DTAConfig.OptionPanels
             btnMoveDown.LeftClick += btnMoveDown_LeftClick;
 
             chkAutoCheck = new XNAClientCheckBox(WindowManager);
-            chkAutoCheck.Name = "chkAutoCheck";
+            chkAutoCheck.Name = nameof(chkAutoCheck);
             chkAutoCheck.ClientRectangle = new Rectangle(lblDescription.X,
                 btnMoveUp.Bottom + 24, 0, 0);
             chkAutoCheck.Text = "Check for updates automatically".L10N("Client:DTAConfig:AutoCheckUpdate");
 
             btnForceUpdate = new XNAClientButton(WindowManager);
-            btnForceUpdate.Name = "btnForceUpdate";
+            btnForceUpdate.Name = nameof(btnForceUpdate);
             btnForceUpdate.ClientRectangle = new Rectangle(btnMoveDown.X, btnMoveDown.Bottom + 24, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnForceUpdate.Text = "Force Update".L10N("Client:DTAConfig:ForceUpdate");
             btnForceUpdate.LeftClick += BtnForceUpdate_LeftClick;

--- a/DTAConfig/OptionsWindow.cs
+++ b/DTAConfig/OptionsWindow.cs
@@ -34,12 +34,12 @@ namespace DTAConfig
 
         public override void Initialize()
         {
-            Name = "OptionsWindow";
+            Name = nameof(OptionsWindow);
             ClientRectangle = new Rectangle(0, 0, 576, 475);
             BackgroundTexture = AssetLoader.LoadTextureUncached("optionsbg.png");
 
             tabControl = new XNAClientTabControl(WindowManager);
-            tabControl.Name = "tabControl";
+            tabControl.Name = nameof(tabControl);
             tabControl.ClientRectangle = new Rectangle(12, 12, 0, 23);
             tabControl.FontIndex = 1;
             tabControl.ClickSound = new EnhancedSoundEffect("button.wav");
@@ -52,14 +52,14 @@ namespace DTAConfig
             tabControl.SelectedIndexChanged += TabControl_SelectedIndexChanged;
 
             var btnCancel = new XNAClientButton(WindowManager);
-            btnCancel.Name = "btnCancel";
+            btnCancel.Name = nameof(btnCancel);
             btnCancel.ClientRectangle = new Rectangle(Width - 104,
                 Height - 35, UIDesignConstants.BUTTON_WIDTH_92, UIDesignConstants.BUTTON_HEIGHT);
             btnCancel.Text = "Cancel".L10N("Client:DTAConfig:ButtonCancel");
             btnCancel.LeftClick += BtnBack_LeftClick;
 
             var btnSave = new XNAClientButton(WindowManager);
-            btnSave.Name = "btnSave";
+            btnSave.Name = nameof(btnSave);
             btnSave.ClientRectangle = new Rectangle(12, btnCancel.Y, UIDesignConstants.BUTTON_WIDTH_92, UIDesignConstants.BUTTON_HEIGHT);
             btnSave.Text = "Save".L10N("Client:DTAConfig:ButtonSave");
             btnSave.LeftClick += BtnSave_LeftClick;

--- a/DXMainClient/DXGUI/Generic/CampaignSelector.cs
+++ b/DXMainClient/DXGUI/Generic/CampaignSelector.cs
@@ -41,7 +41,7 @@ namespace DTAClient.DXGUI.Generic
         private XNATextBlock tbMissionDescription;
         private XNATrackbar trbDifficultySelector;
 
-        private CheaterScreen cheaterWindow;
+        private CheaterWindow cheaterWindow;
 
         private string[] filesToCheck = new string[]
         {
@@ -181,7 +181,7 @@ namespace DTAClient.DXGUI.Generic
 
             ReadMissionList();
 
-            cheaterWindow = new CheaterScreen(WindowManager);
+            cheaterWindow = new CheaterWindow(WindowManager);
             var dp = new DarkeningPanel(WindowManager);
             dp.AddChild(cheaterWindow);
             AddChild(dp);

--- a/DXMainClient/DXGUI/Generic/CampaignSelector.cs
+++ b/DXMainClient/DXGUI/Generic/CampaignSelector.cs
@@ -41,7 +41,7 @@ namespace DTAClient.DXGUI.Generic
         private XNATextBlock tbMissionDescription;
         private XNATrackbar trbDifficultySelector;
 
-        private CheaterWindow cheaterWindow;
+        private CheaterScreen cheaterWindow;
 
         private string[] filesToCheck = new string[]
         {
@@ -181,7 +181,7 @@ namespace DTAClient.DXGUI.Generic
 
             ReadMissionList();
 
-            cheaterWindow = new CheaterWindow(WindowManager);
+            cheaterWindow = new CheaterScreen(WindowManager);
             var dp = new DarkeningPanel(WindowManager);
             dp.AddChild(cheaterWindow);
             AddChild(dp);

--- a/DXMainClient/DXGUI/Generic/CampaignSelector.cs
+++ b/DXMainClient/DXGUI/Generic/CampaignSelector.cs
@@ -64,7 +64,7 @@ namespace DTAClient.DXGUI.Generic
             ClientRectangle = new Rectangle(0, 0, DEFAULT_WIDTH, DEFAULT_HEIGHT);
             BorderColor = UISettings.ActiveSettings.PanelBorderColor;
 
-            Name = "CampaignSelector";
+            Name = nameof(CampaignSelector);
 
             var lblSelectCampaign = new XNALabel(WindowManager);
             lblSelectCampaign.Name = nameof(lblSelectCampaign);

--- a/DXMainClient/DXGUI/Generic/CheaterScreen.cs
+++ b/DXMainClient/DXGUI/Generic/CheaterScreen.cs
@@ -7,9 +7,9 @@ using ClientCore.Extensions;
 
 namespace DTAClient.DXGUI.Generic
 {
-    public class CheaterWindow : XNAWindow
+    public class CheaterScreen : XNAWindow
     {
-        public CheaterWindow(WindowManager windowManager) : base(windowManager)
+        public CheaterScreen(WindowManager windowManager) : base(windowManager)
         {
         }
 
@@ -17,7 +17,7 @@ namespace DTAClient.DXGUI.Generic
 
         public override void Initialize()
         {
-            Name = nameof(CheaterWindow);
+            Name = nameof(CheaterScreen);
             ClientRectangle = new Rectangle(0, 0, 334, 453);
             BackgroundTexture = AssetLoader.LoadTexture("cheaterbg.png");
 

--- a/DXMainClient/DXGUI/Generic/CheaterWindow.cs
+++ b/DXMainClient/DXGUI/Generic/CheaterWindow.cs
@@ -7,9 +7,9 @@ using ClientCore.Extensions;
 
 namespace DTAClient.DXGUI.Generic
 {
-    public class CheaterScreen : XNAWindow
+    public class CheaterWindow : XNAWindow
     {
-        public CheaterScreen(WindowManager windowManager) : base(windowManager)
+        public CheaterWindow(WindowManager windowManager) : base(windowManager)
         {
         }
 
@@ -17,7 +17,7 @@ namespace DTAClient.DXGUI.Generic
 
         public override void Initialize()
         {
-            Name = nameof(CheaterScreen);
+            Name = nameof(CheaterWindow);
             ClientRectangle = new Rectangle(0, 0, 334, 453);
             BackgroundTexture = AssetLoader.LoadTexture("cheaterbg.png");
 

--- a/DXMainClient/DXGUI/Generic/CheaterWindow.cs
+++ b/DXMainClient/DXGUI/Generic/CheaterWindow.cs
@@ -17,7 +17,7 @@ namespace DTAClient.DXGUI.Generic
 
         public override void Initialize()
         {
-            Name = "CheaterScreen";
+            Name = nameof(CheaterWindow);
             ClientRectangle = new Rectangle(0, 0, 334, 453);
             BackgroundTexture = AssetLoader.LoadTexture("cheaterbg.png");
 

--- a/DXMainClient/DXGUI/Generic/CheaterWindow.cs
+++ b/DXMainClient/DXGUI/Generic/CheaterWindow.cs
@@ -17,7 +17,8 @@ namespace DTAClient.DXGUI.Generic
 
         public override void Initialize()
         {
-            Name = nameof(CheaterWindow);
+            // Retained like this to backward compatibility with old configs
+            Name = "CheaterScreen";
             ClientRectangle = new Rectangle(0, 0, 334, 453);
             BackgroundTexture = AssetLoader.LoadTexture("cheaterbg.png");
 

--- a/DXMainClient/DXGUI/Generic/ExtrasWindow.cs
+++ b/DXMainClient/DXGUI/Generic/ExtrasWindow.cs
@@ -21,7 +21,7 @@ namespace DTAClient.DXGUI.Generic
 
         public override void Initialize()
         {
-            Name = "ExtrasWindow";
+            Name = nameof(ExtrasWindow);
             ClientRectangle = new Rectangle(0, 0, 284, 190);
             BackgroundTexture = AssetLoader.LoadTexture("extrasMenu.png");
 

--- a/DXMainClient/DXGUI/Generic/GameInProgressWindow.cs
+++ b/DXMainClient/DXGUI/Generic/GameInProgressWindow.cs
@@ -50,7 +50,7 @@ namespace DTAClient.DXGUI
 
             XNAWindow window = new XNAWindow(WindowManager);
 
-            window.Name = "GameInProgressWindow";
+            window.Name = nameof(GameInProgressWindow);
             window.BackgroundTexture = AssetLoader.LoadTexture("gameinprogresswindowbg.png");
             window.ClientRectangle = new Rectangle(0, 0, 200, 100);
 

--- a/DXMainClient/DXGUI/Generic/GameLoadingWindow.cs
+++ b/DXMainClient/DXGUI/Generic/GameLoadingWindow.cs
@@ -36,7 +36,7 @@ namespace DTAClient.DXGUI.Generic
 
         public override void Initialize()
         {
-            Name = "GameLoadingWindow";
+            Name = nameof(GameLoadingWindow);
             BackgroundTexture = AssetLoader.LoadTexture("loadmissionbg.png");
 
             ClientRectangle = new Rectangle(0, 0, 600, 380);

--- a/DXMainClient/DXGUI/Generic/LoadingScreen.cs
+++ b/DXMainClient/DXGUI/Generic/LoadingScreen.cs
@@ -50,7 +50,7 @@ namespace DTAClient.DXGUI.Generic
         public override void Initialize()
         {
             ClientRectangle = new Rectangle(0, 0, 800, 600);
-            Name = "LoadingScreen";
+            Name = nameof(LoadingScreen);
             BackgroundTexture = AssetLoader.LoadTexture("loadingscreen.png");
 
             base.Initialize();

--- a/DXMainClient/DXGUI/Generic/ManualUpdateQueryWindow.cs
+++ b/DXMainClient/DXGUI/Generic/ManualUpdateQueryWindow.cs
@@ -26,7 +26,7 @@ namespace DTAClient.DXGUI.Generic
 
         public override void Initialize()
         {
-            Name = "ManualUpdateQueryWindow";
+            Name = nameof(ManualUpdateQueryWindow);
             ClientRectangle = new Rectangle(0, 0, 251, 140);
             BackgroundTexture = AssetLoader.LoadTexture("updatequerybg.png");
 

--- a/DXMainClient/DXGUI/Generic/StatisticsWindow.cs
+++ b/DXMainClient/DXGUI/Generic/StatisticsWindow.cs
@@ -93,7 +93,7 @@ namespace DTAClient.DXGUI.Generic
                 strLblAvgEconomy = "Avg. number of objects built:".L10N("Client:Main:StatisticBuildCountAvg");
             }
 
-            Name = "StatisticsWindow";
+            Name = nameof(StatisticsWindow);
             BackgroundTexture = AssetLoader.LoadTexture("scoreviewerbg.png");
             ClientRectangle = new Rectangle(0, 0, 700, 521);
             VisibleChanged += StatisticsWindow_VisibleChanged;
@@ -164,7 +164,7 @@ namespace DTAClient.DXGUI.Generic
             #region Match statistics
 
             panelGameStatistics = new XNAPanel(WindowManager);
-            panelGameStatistics.Name = "panelGameStatistics";
+            panelGameStatistics.Name = nameof(panelGameStatistics);
             panelGameStatistics.BackgroundTexture = AssetLoader.LoadTexture("scoreviewerpanelbg.png");
             panelGameStatistics.ClientRectangle = new Rectangle(10, 55, 680, 425);
 
@@ -213,7 +213,7 @@ namespace DTAClient.DXGUI.Generic
 #region Total statistics
 
             panelTotalStatistics = new XNAPanel(WindowManager);
-            panelTotalStatistics.Name = "panelTotalStatistics";
+            panelTotalStatistics.Name = nameof(panelTotalStatistics);
             panelTotalStatistics.BackgroundTexture = AssetLoader.LoadTexture("scoreviewerpanelbg.png");
             panelTotalStatistics.ClientRectangle = new Rectangle(10, 55, 680, 425);
 
@@ -226,7 +226,7 @@ namespace DTAClient.DXGUI.Generic
             AddTotalStatisticsLabel("lblGamesStarted", "Games started:".L10N("Client:Main:StatisticsGamesStarted"), new Point(TOTAL_STATS_LOCATION_X1, locationY));
 
             lblGamesStartedValue = new XNALabel(WindowManager);
-            lblGamesStartedValue.Name = "lblGamesStartedValue";
+            lblGamesStartedValue.Name = nameof(lblGamesStartedValue);
             lblGamesStartedValue.ClientRectangle = new Rectangle(TOTAL_STATS_VALUE_LOCATION_X1, locationY, 0, 0);
             lblGamesStartedValue.RemapColor = UISettings.ActiveSettings.AltColor;
             locationY += TOTAL_STATS_Y_INCREASE;
@@ -234,7 +234,7 @@ namespace DTAClient.DXGUI.Generic
             AddTotalStatisticsLabel("lblGamesFinished", "Games finished:".L10N("Client:Main:StatisticsGamesFinished"), new Point(TOTAL_STATS_LOCATION_X1, locationY));
 
             lblGamesFinishedValue = new XNALabel(WindowManager);
-            lblGamesFinishedValue.Name = "lblGamesFinishedValue";
+            lblGamesFinishedValue.Name = nameof(lblGamesFinishedValue);
             lblGamesFinishedValue.ClientRectangle = new Rectangle(TOTAL_STATS_VALUE_LOCATION_X1, locationY, 0, 0);
             lblGamesFinishedValue.RemapColor = UISettings.ActiveSettings.AltColor;
             locationY += TOTAL_STATS_Y_INCREASE;
@@ -242,7 +242,7 @@ namespace DTAClient.DXGUI.Generic
             AddTotalStatisticsLabel("lblWins", "Wins:".L10N("Client:Main:StatisticsGamesWins"), new Point(TOTAL_STATS_LOCATION_X1, locationY));
 
             lblWinsValue = new XNALabel(WindowManager);
-            lblWinsValue.Name = "lblWinsValue";
+            lblWinsValue.Name = nameof(lblWinsValue);
             lblWinsValue.ClientRectangle = new Rectangle(TOTAL_STATS_VALUE_LOCATION_X1, locationY, 0, 0);
             lblWinsValue.RemapColor = UISettings.ActiveSettings.AltColor;
             locationY += TOTAL_STATS_Y_INCREASE;
@@ -250,7 +250,7 @@ namespace DTAClient.DXGUI.Generic
             AddTotalStatisticsLabel("lblLosses", "Losses:".L10N("Client:Main:StatisticsGamesLosses"), new Point(TOTAL_STATS_LOCATION_X1, locationY));
 
             lblLossesValue = new XNALabel(WindowManager);
-            lblLossesValue.Name = "lblLossesValue";
+            lblLossesValue.Name = nameof(lblLossesValue);
             lblLossesValue.ClientRectangle = new Rectangle(TOTAL_STATS_VALUE_LOCATION_X1, locationY, 0, 0);
             lblLossesValue.RemapColor = UISettings.ActiveSettings.AltColor;
             locationY += TOTAL_STATS_Y_INCREASE;
@@ -258,7 +258,7 @@ namespace DTAClient.DXGUI.Generic
             AddTotalStatisticsLabel("lblWinLossRatio", "Win / Loss ratio:".L10N("Client:Main:StatisticsGamesWinLossRatio"), new Point(TOTAL_STATS_LOCATION_X1, locationY));
 
             lblWinLossRatioValue = new XNALabel(WindowManager);
-            lblWinLossRatioValue.Name = "lblWinLossRatioValue";
+            lblWinLossRatioValue.Name = nameof(lblWinLossRatioValue);
             lblWinLossRatioValue.ClientRectangle = new Rectangle(TOTAL_STATS_VALUE_LOCATION_X1, locationY, 0, 0);
             lblWinLossRatioValue.RemapColor = UISettings.ActiveSettings.AltColor;
             locationY += TOTAL_STATS_Y_INCREASE;
@@ -266,7 +266,7 @@ namespace DTAClient.DXGUI.Generic
             AddTotalStatisticsLabel("lblAverageGameLength", "Average game length:".L10N("Client:Main:StatisticsGamesLengthAvg"), new Point(TOTAL_STATS_LOCATION_X1, locationY));
 
             lblAverageGameLengthValue = new XNALabel(WindowManager);
-            lblAverageGameLengthValue.Name = "lblAverageGameLengthValue";
+            lblAverageGameLengthValue.Name = nameof(lblAverageGameLengthValue);
             lblAverageGameLengthValue.ClientRectangle = new Rectangle(TOTAL_STATS_VALUE_LOCATION_X1, locationY, 0, 0);
             lblAverageGameLengthValue.RemapColor = UISettings.ActiveSettings.AltColor;
             locationY += TOTAL_STATS_Y_INCREASE;
@@ -274,7 +274,7 @@ namespace DTAClient.DXGUI.Generic
             AddTotalStatisticsLabel("lblTotalTimePlayed", "Total time played:".L10N("Client:Main:StatisticsTotalTimePlayed"), new Point(TOTAL_STATS_LOCATION_X1, locationY));
 
             lblTotalTimePlayedValue = new XNALabel(WindowManager);
-            lblTotalTimePlayedValue.Name = "lblTotalTimePlayedValue";
+            lblTotalTimePlayedValue.Name = nameof(lblTotalTimePlayedValue);
             lblTotalTimePlayedValue.ClientRectangle = new Rectangle(TOTAL_STATS_VALUE_LOCATION_X1, locationY, 0, 0);
             lblTotalTimePlayedValue.RemapColor = UISettings.ActiveSettings.AltColor;
             locationY += TOTAL_STATS_Y_INCREASE;
@@ -282,7 +282,7 @@ namespace DTAClient.DXGUI.Generic
             AddTotalStatisticsLabel("lblAverageEnemyCount", "Average number of enemies:".L10N("Client:Main:StatisticsEnemiesAvg"), new Point(TOTAL_STATS_LOCATION_X1, locationY));
 
             lblAverageEnemyCountValue = new XNALabel(WindowManager);
-            lblAverageEnemyCountValue.Name = "lblAverageEnemyCountValue";
+            lblAverageEnemyCountValue.Name = nameof(lblAverageEnemyCountValue);
             lblAverageEnemyCountValue.ClientRectangle = new Rectangle(TOTAL_STATS_VALUE_LOCATION_X1, locationY, 0, 0);
             lblAverageEnemyCountValue.RemapColor = UISettings.ActiveSettings.AltColor;
             locationY += TOTAL_STATS_Y_INCREASE;
@@ -290,7 +290,7 @@ namespace DTAClient.DXGUI.Generic
             AddTotalStatisticsLabel("lblAverageAllyCount", "Average number of allies:".L10N("Client:Main:StatisticsAlliesAvg"), new Point(TOTAL_STATS_LOCATION_X1, locationY));
 
             lblAverageAllyCountValue = new XNALabel(WindowManager);
-            lblAverageAllyCountValue.Name = "lblAverageAllyCountValue";
+            lblAverageAllyCountValue.Name = nameof(lblAverageAllyCountValue);
             lblAverageAllyCountValue.ClientRectangle = new Rectangle(TOTAL_STATS_VALUE_LOCATION_X1, locationY, 0, 0);
             lblAverageAllyCountValue.RemapColor = UISettings.ActiveSettings.AltColor;
             locationY += TOTAL_STATS_Y_INCREASE;
@@ -302,7 +302,7 @@ namespace DTAClient.DXGUI.Generic
             AddTotalStatisticsLabel("lblTotalKills", "Total kills:".L10N("Client:Main:StatisticsTotalKills"), new Point(TOTAL_STATS_LOCATION_X2, locationY));
 
             lblTotalKillsValue = new XNALabel(WindowManager);
-            lblTotalKillsValue.Name = "lblTotalKillsValue";
+            lblTotalKillsValue.Name = nameof(lblTotalKillsValue);
             lblTotalKillsValue.ClientRectangle = new Rectangle(TOTAL_STATS_VALUE_LOCATION_X2, locationY, 0, 0);
             lblTotalKillsValue.RemapColor = UISettings.ActiveSettings.AltColor;
             locationY += TOTAL_STATS_Y_INCREASE;
@@ -310,7 +310,7 @@ namespace DTAClient.DXGUI.Generic
             AddTotalStatisticsLabel("lblKillsPerGame", "Kills / game:".L10N("Client:Main:StatisticsKillsPerGame"), new Point(TOTAL_STATS_LOCATION_X2, locationY));
 
             lblKillsPerGameValue = new XNALabel(WindowManager);
-            lblKillsPerGameValue.Name = "lblKillsPerGameValue";
+            lblKillsPerGameValue.Name = nameof(lblKillsPerGameValue);
             lblKillsPerGameValue.ClientRectangle = new Rectangle(TOTAL_STATS_VALUE_LOCATION_X2, locationY, 0, 0);
             lblKillsPerGameValue.RemapColor = UISettings.ActiveSettings.AltColor;
             locationY += TOTAL_STATS_Y_INCREASE;
@@ -318,7 +318,7 @@ namespace DTAClient.DXGUI.Generic
             AddTotalStatisticsLabel("lblTotalLosses", "Total losses:".L10N("Client:Main:StatisticsTotalLosses"), new Point(TOTAL_STATS_LOCATION_X2, locationY));
 
             lblTotalLossesValue = new XNALabel(WindowManager);
-            lblTotalLossesValue.Name = "lblTotalLossesValue";
+            lblTotalLossesValue.Name = nameof(lblTotalLossesValue);
             lblTotalLossesValue.ClientRectangle = new Rectangle(TOTAL_STATS_VALUE_LOCATION_X2, locationY, 0, 0);
             lblTotalLossesValue.RemapColor = UISettings.ActiveSettings.AltColor;
             locationY += TOTAL_STATS_Y_INCREASE;
@@ -326,7 +326,7 @@ namespace DTAClient.DXGUI.Generic
             AddTotalStatisticsLabel("lblLossesPerGame", "Losses / game:".L10N("Client:Main:StatisticsLossesPerGame"), new Point(TOTAL_STATS_LOCATION_X2, locationY));
 
             lblLossesPerGameValue = new XNALabel(WindowManager);
-            lblLossesPerGameValue.Name = "lblLossesPerGameValue";
+            lblLossesPerGameValue.Name = nameof(lblLossesPerGameValue);
             lblLossesPerGameValue.ClientRectangle = new Rectangle(TOTAL_STATS_VALUE_LOCATION_X2, locationY, 0, 0);
             lblLossesPerGameValue.RemapColor = UISettings.ActiveSettings.AltColor;
             locationY += TOTAL_STATS_Y_INCREASE;
@@ -334,7 +334,7 @@ namespace DTAClient.DXGUI.Generic
             AddTotalStatisticsLabel("lblKillLossRatio", "Kill / loss ratio:".L10N("Client:Main:StatisticsKillLossRatio"), new Point(TOTAL_STATS_LOCATION_X2, locationY));
 
             lblKillLossRatioValue = new XNALabel(WindowManager);
-            lblKillLossRatioValue.Name = "lblKillLossRatioValue";
+            lblKillLossRatioValue.Name = nameof(lblKillLossRatioValue);
             lblKillLossRatioValue.ClientRectangle = new Rectangle(TOTAL_STATS_VALUE_LOCATION_X2, locationY, 0, 0);
             lblKillLossRatioValue.RemapColor = UISettings.ActiveSettings.AltColor;
             locationY += TOTAL_STATS_Y_INCREASE;
@@ -342,7 +342,7 @@ namespace DTAClient.DXGUI.Generic
             AddTotalStatisticsLabel("lblTotalScore", "Total score:".L10N("Client:Main:TotalScore"), new Point(TOTAL_STATS_LOCATION_X2, locationY));
 
             lblTotalScoreValue = new XNALabel(WindowManager);
-            lblTotalScoreValue.Name = "lblTotalScoreValue";
+            lblTotalScoreValue.Name = nameof(lblTotalScoreValue);
             lblTotalScoreValue.ClientRectangle = new Rectangle(TOTAL_STATS_VALUE_LOCATION_X2, locationY, 0, 0);
             lblTotalScoreValue.RemapColor = UISettings.ActiveSettings.AltColor;
             locationY += TOTAL_STATS_Y_INCREASE;
@@ -350,7 +350,7 @@ namespace DTAClient.DXGUI.Generic
             AddTotalStatisticsLabel("lblAverageEconomy", strLblAvgEconomy, new Point(TOTAL_STATS_LOCATION_X2, locationY));
 
             lblAverageEconomyValue = new XNALabel(WindowManager);
-            lblAverageEconomyValue.Name = "lblAverageEconomyValue";
+            lblAverageEconomyValue.Name = nameof(lblAverageEconomyValue);
             lblAverageEconomyValue.ClientRectangle = new Rectangle(TOTAL_STATS_VALUE_LOCATION_X2, locationY, 0, 0);
             lblAverageEconomyValue.RemapColor = UISettings.ActiveSettings.AltColor;
             locationY += TOTAL_STATS_Y_INCREASE;
@@ -358,7 +358,7 @@ namespace DTAClient.DXGUI.Generic
             AddTotalStatisticsLabel("lblFavouriteSide", "Favourite side:".L10N("Client:Main:FavouriteSide"), new Point(TOTAL_STATS_LOCATION_X2, locationY));
 
             lblFavouriteSideValue = new XNALabel(WindowManager);
-            lblFavouriteSideValue.Name = "lblFavouriteSideValue";
+            lblFavouriteSideValue.Name = nameof(lblFavouriteSideValue);
             lblFavouriteSideValue.ClientRectangle = new Rectangle(TOTAL_STATS_VALUE_LOCATION_X2, locationY, 0, 0);
             lblFavouriteSideValue.RemapColor = UISettings.ActiveSettings.AltColor;
             locationY += TOTAL_STATS_Y_INCREASE;
@@ -366,7 +366,7 @@ namespace DTAClient.DXGUI.Generic
             AddTotalStatisticsLabel("lblAverageAILevel", "Average AI level:".L10N("Client:Main:AvgAILevel"), new Point(TOTAL_STATS_LOCATION_X2, locationY));
 
             lblAverageAILevelValue = new XNALabel(WindowManager);
-            lblAverageAILevelValue.Name = "lblAverageAILevelValue";
+            lblAverageAILevelValue.Name = nameof(lblAverageAILevelValue);
             lblAverageAILevelValue.ClientRectangle = new Rectangle(TOTAL_STATS_VALUE_LOCATION_X2, locationY, 0, 0);
             lblAverageAILevelValue.RemapColor = UISettings.ActiveSettings.AltColor;
             locationY += TOTAL_STATS_Y_INCREASE;

--- a/DXMainClient/DXGUI/Generic/TopBar.cs
+++ b/DXMainClient/DXGUI/Generic/TopBar.cs
@@ -126,7 +126,7 @@ namespace DTAClient.DXGUI.Generic
 
         public override void Initialize()
         {
-            Name = "TopBar";
+            Name = nameof(TopBar);
             ClientRectangle = new Rectangle(0, -39, WindowManager.RenderResolutionX, 39);
             PanelBackgroundDrawMode = PanelBackgroundImageDrawMode.STRETCHED;
             BackgroundTexture = AssetLoader.CreateTexture(Color.Black, 1, 1);
@@ -181,7 +181,7 @@ namespace DTAClient.DXGUI.Generic
             btnOptions.LeftClick += BtnOptions_LeftClick;
 
             lblConnectionStatus = new XNALabel(WindowManager);
-            lblConnectionStatus.Name = "lblConnectionStatus";
+            lblConnectionStatus.Name = nameof(lblConnectionStatus);
             lblConnectionStatus.FontIndex = 1;
             lblConnectionStatus.Text = "OFFLINE".L10N("Client:Main:StatusOffline");
 
@@ -197,11 +197,11 @@ namespace DTAClient.DXGUI.Generic
             if (ClientConfiguration.Instance.DisplayPlayerCountInTopBar)
             {
                 lblCnCNetStatus = new XNALabel(WindowManager);
-                lblCnCNetStatus.Name = "lblCnCNetStatus";
+                lblCnCNetStatus.Name = nameof(lblCnCNetStatus);
                 lblCnCNetStatus.FontIndex = 1;
                 lblCnCNetStatus.Text = ClientConfiguration.Instance.LocalGame.ToUpper() + " " + "PLAYERS ONLINE:".L10N("Client:Main:OnlinePlayersNumber");
                 lblCnCNetPlayerCount = new XNALabel(WindowManager);
-                lblCnCNetPlayerCount.Name = "lblCnCNetPlayerCount";
+                lblCnCNetPlayerCount.Name = nameof(lblCnCNetPlayerCount);
                 lblCnCNetPlayerCount.FontIndex = 1;
                 lblCnCNetPlayerCount.Text = "-";
                 lblCnCNetPlayerCount.ClientRectangle = new Rectangle(btnOptions.X - 50, 11, lblCnCNetPlayerCount.Width, lblCnCNetPlayerCount.Height);

--- a/DXMainClient/DXGUI/Generic/UpdateQueryWindow.cs
+++ b/DXMainClient/DXGUI/Generic/UpdateQueryWindow.cs
@@ -30,7 +30,7 @@ namespace DTAClient.DXGUI.Generic
         {
             changelogUrl = ClientConfiguration.Instance.ChangelogURL;
 
-            Name = "UpdateQueryWindow";
+            Name = nameof(UpdateQueryWindow);
             ClientRectangle = new Rectangle(0, 0, 251, 140);
             BackgroundTexture = AssetLoader.LoadTexture("updatequerybg.png");
 

--- a/DXMainClient/DXGUI/Generic/UpdateWindow.cs
+++ b/DXMainClient/DXGUI/Generic/UpdateWindow.cs
@@ -63,7 +63,7 @@ namespace DTAClient.DXGUI.Generic
 
         public override void Initialize()
         {
-            Name = "UpdateWindow";
+            Name = nameof(UpdateWindow);
             ClientRectangle = new Rectangle(0, 0, 446, 270);
             BackgroundTexture = AssetLoader.LoadTexture("updaterbg.png");
 

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLoginWindow.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLoginWindow.cs
@@ -29,12 +29,12 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
         public override void Initialize()
         {
-            Name = "CnCNetLoginWindow";
+            Name = nameof(CnCNetLoginWindow);
             ClientRectangle = new Rectangle(0, 0, 300, 220);
             BackgroundTexture = AssetLoader.LoadTextureUncached("logindialogbg.png");
 
             lblConnectToCnCNet = new XNALabel(WindowManager);
-            lblConnectToCnCNet.Name = "lblConnectToCnCNet";
+            lblConnectToCnCNet.Name = nameof(lblConnectToCnCNet);
             lblConnectToCnCNet.FontIndex = 1;
             lblConnectToCnCNet.Text = "CONNECT TO CNCNET".L10N("Client:Main:ConnectToCncNet");
 
@@ -46,48 +46,48 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 lblConnectToCnCNet.Height);
 
             tbPlayerName = new XNATextBox(WindowManager);
-            tbPlayerName.Name = "tbPlayerName";
+            tbPlayerName.Name = nameof(tbPlayerName);
             tbPlayerName.ClientRectangle = new Rectangle(Width - 132, 50, 120, 19);
             tbPlayerName.MaximumTextLength = ClientConfiguration.Instance.MaxNameLength;
             tbPlayerName.IMEDisabled = true;
             string defgame = ClientConfiguration.Instance.LocalGame;
 
             lblPlayerName = new XNALabel(WindowManager);
-            lblPlayerName.Name = "lblPlayerName";
+            lblPlayerName.Name = nameof(lblPlayerName);
             lblPlayerName.FontIndex = 1;
             lblPlayerName.Text = "PLAYER NAME:".L10N("Client:Main:PlayerName");
             lblPlayerName.ClientRectangle = new Rectangle(12, tbPlayerName.Y + 1,
                 lblPlayerName.Width, lblPlayerName.Height);
 
             chkRememberMe = new XNAClientCheckBox(WindowManager);
-            chkRememberMe.Name = "chkRememberMe";
+            chkRememberMe.Name = nameof(chkRememberMe);
             chkRememberMe.ClientRectangle = new Rectangle(12, tbPlayerName.Bottom + 12, 0, 0);
             chkRememberMe.Text = "Remember me".L10N("Client:Main:RememberMe");
             chkRememberMe.TextPadding = 7;
             chkRememberMe.CheckedChanged += ChkRememberMe_CheckedChanged;
 
             chkPersistentMode = new XNAClientCheckBox(WindowManager);
-            chkPersistentMode.Name = "chkPersistentMode";
+            chkPersistentMode.Name = nameof(chkPersistentMode);
             chkPersistentMode.ClientRectangle = new Rectangle(12, chkRememberMe.Bottom + 30, 0, 0);
             chkPersistentMode.Text = "Stay connected outside of the CnCNet lobby".L10N("Client:Main:StayConnect");
             chkPersistentMode.TextPadding = chkRememberMe.TextPadding;
             chkPersistentMode.CheckedChanged += ChkPersistentMode_CheckedChanged;
 
             chkAutoConnect = new XNAClientCheckBox(WindowManager);
-            chkAutoConnect.Name = "chkAutoConnect";
+            chkAutoConnect.Name = nameof(chkAutoConnect);
             chkAutoConnect.ClientRectangle = new Rectangle(12, chkPersistentMode.Bottom + 30, 0, 0);
             chkAutoConnect.Text = "Connect automatically on client startup".L10N("Client:Main:AutoConnect");
             chkAutoConnect.TextPadding = chkRememberMe.TextPadding;
             chkAutoConnect.AllowChecking = false;
 
             btnConnect = new XNAClientButton(WindowManager);
-            btnConnect.Name = "btnConnect";
+            btnConnect.Name = nameof(btnConnect);
             btnConnect.ClientRectangle = new Rectangle(12, Height - 35, 110, 23);
             btnConnect.Text = "Connect".L10N("Client:Main:ButtonConnect");
             btnConnect.LeftClick += BtnConnect_LeftClick;
 
             btnCancel = new XNAClientButton(WindowManager);
-            btnCancel.Name = "btnCancel";
+            btnCancel.Name = nameof(btnCancel);
             btnCancel.ClientRectangle = new Rectangle(Width - 122, btnConnect.Y, 110, 23);
             btnCancel.Text = "Cancel".L10N("Client:Main:ButtonCancel");
             btnCancel.LeftClick += BtnCancel_LeftClick;

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/GameCreationWindow.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/GameCreationWindow.cs
@@ -55,7 +55,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
             SkillLevelOptions = ClientConfiguration.Instance.SkillLevelOptions.Split(',');
 
-            Name = "GameCreationWindow";
+            Name = nameof(GameCreationWindow);
             Width = lbTunnelList.Width + UIDesignConstants.EMPTY_SPACE_SIDES * 2 +
                 UIDesignConstants.CONTROL_HORIZONTAL_MARGIN * 2;
             BackgroundTexture = AssetLoader.LoadTexture("gamecreationoptionsbg.png");
@@ -267,7 +267,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
         private void BtnDisplayAdvancedOptions_LeftClick(object sender, EventArgs e)
         {
-            Name = "GameCreationWindow_Advanced";
+            Name = nameof(GameCreationWindow) + "_Advanced";
 
             btnCreateGame.ClientRectangle = new Rectangle(btnCreateGame.X,
                 lbTunnelList.Bottom + UIDesignConstants.CONTROL_VERTICAL_MARGIN * 3,

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/PasswordRequestWindow.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/PasswordRequestWindow.cs
@@ -26,30 +26,30 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
         public override void Initialize()
         {
-            Name = "PasswordRequestWindow";
+            Name = nameof(PasswordRequestWindow);
             BackgroundTexture = AssetLoader.LoadTexture("passwordquerybg.png");
 
             var lblDescription = new XNALabel(WindowManager);
-            lblDescription.Name = "lblDescription";
+            lblDescription.Name = nameof(lblDescription);
             lblDescription.ClientRectangle = new Rectangle(12, 12, 0, 0);
             lblDescription.Text = "Please enter the password for the game and click OK.".L10N("Client:Main:EnterPasswordAndHitOK");
 
             ClientRectangle = new Rectangle(0, 0, lblDescription.Width + 24, 110);
 
             tbPassword = new XNATextBox(WindowManager);
-            tbPassword.Name = "tbPassword";
+            tbPassword.Name = nameof(tbPassword);
             tbPassword.ClientRectangle = new Rectangle(lblDescription.X,
                 lblDescription.Bottom + 12, Width - 24, 21);
 
             var btnOK = new XNAClientButton(WindowManager);
-            btnOK.Name = "btnOK";
+            btnOK.Name = nameof(btnOK);
             btnOK.ClientRectangle = new Rectangle(lblDescription.X,
                 ClientRectangle.Bottom - 35, UIDesignConstants.BUTTON_WIDTH_92, UIDesignConstants.BUTTON_HEIGHT);
             btnOK.Text = "OK".L10N("Client:Main:ButtonOK");
             btnOK.LeftClick += BtnOK_LeftClick;
 
             var btnCancel = new XNAClientButton(WindowManager);
-            btnCancel.Name = "btnCancel";
+            btnCancel.Name = nameof(btnCancel);
             btnCancel.ClientRectangle = new Rectangle(Width - 104,
                 btnOK.Y, UIDesignConstants.BUTTON_WIDTH_92, UIDesignConstants.BUTTON_HEIGHT);
             btnCancel.Text = "Cancel".L10N("Client:Main:ButtonCancel");

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/PrivateMessageNotificationBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/PrivateMessageNotificationBox.cs
@@ -43,13 +43,13 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
         public override void Initialize()
         {
-            Name = "PrivateMessageNotificationBox";
+            Name = nameof(PrivateMessageNotificationBox);
             BackgroundTexture = AssetLoader.CreateTexture(new Color(0, 0, 0, 196), 1, 1);
             ClientRectangle = new Rectangle(WindowManager.RenderResolutionX - 300, -100, 300, 100);
             PanelBackgroundDrawMode = PanelBackgroundImageDrawMode.STRETCHED;
 
             XNALabel lblHeader = new XNALabel(WindowManager);
-            lblHeader.Name = "lblHeader";
+            lblHeader.Name = nameof(lblHeader);
             lblHeader.FontIndex = 1;
             lblHeader.Text = "PRIVATE MESSAGE".L10N("Client:Main:PMHeader");
             AddChild(lblHeader);
@@ -58,11 +58,11 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 6, lblHeader.Width, lblHeader.Height);
 
             XNAPanel linePanel = new XNAPanel(WindowManager);
-            linePanel.Name = "linePanel";
+            linePanel.Name = nameof(linePanel);
             linePanel.ClientRectangle = new Rectangle(0, Height - 20, Width, 1);
 
             XNALabel lblHint = new XNALabel(WindowManager);
-            lblHint.Name = "lblHint";
+            lblHint.Name = nameof(lblHint);
             lblHint.RemapColor = UISettings.ActiveSettings.SubtleTextColor;
             lblHint.Text = "Press F4 to respond".L10N("Client:Main:F4ToRespond");
 
@@ -73,7 +73,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 lblHint.Width, lblHint.Height);
 
             gameIconPanel = new XNAPanel(WindowManager);
-            gameIconPanel.Name = "gameIconPanel";
+            gameIconPanel.Name = nameof(gameIconPanel);
             gameIconPanel.ClientRectangle = new Rectangle(12, 30, 16, 16);
             gameIconPanel.DrawBorders = false;
 
@@ -84,14 +84,14 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             gameIconPanel.BackgroundTexture = AssetLoader.TextureFromImage(dtaIcon);
 
             lblSender = new XNALabel(WindowManager);
-            lblSender.Name = "lblSender";
+            lblSender.Name = nameof(lblSender);
             lblSender.FontIndex = 1;
             lblSender.ClientRectangle = new Rectangle(gameIconPanel.Right + 3,
                 gameIconPanel.Y, 0, 0);
             lblSender.Text = "Rampastring:";
 
             lblMessage = new XNALabel(WindowManager);
-            lblMessage.Name = "lblMessage";
+            lblMessage.Name = nameof(lblMessage);
             lblMessage.ClientRectangle = new Rectangle(12, lblSender.Bottom + 6, 0, 0);
             lblMessage.RemapColor = AssetLoader.GetColorFromString(ClientConfiguration.Instance.ReceivedPMColor);
             lblMessage.Text = "This is a test message.";

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/TunnelSelectionWindow.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/TunnelSelectionWindow.cs
@@ -31,7 +31,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             if (Initialized)
                 return;
 
-            Name = "TunnelSelectionWindow";
+            Name = nameof(TunnelSelectionWindow);
 
             BackgroundTexture = AssetLoader.LoadTexture("gamecreationoptionsbg.png");
             PanelBackgroundDrawMode = PanelBackgroundImageDrawMode.STRETCHED;

--- a/DXMainClient/DXGUI/Multiplayer/GameFiltersPanel.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameFiltersPanel.cs
@@ -27,7 +27,7 @@ namespace DTAClient.DXGUI.Multiplayer
         {
             base.Initialize();
 
-            Name = "GameFiltersWindow";
+            Name = nameof(GameFiltersPanel);
             BackgroundTexture = AssetLoader.CreateTexture(new Color(0, 0, 0), Width, Height);
 
             const int gap = 12;

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CoopBriefingBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CoopBriefingBox.cs
@@ -23,7 +23,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
         public override void Initialize()
         {
-            Name = "CoopBriefingBox";
+            Name = nameof(CoopBriefingBox);
             DrawMode = ControlDrawMode.UNIQUE_RENDER_TARGET;
             ClientRectangle = new Rectangle(0, 0, 400, 300);
             PanelBackgroundDrawMode = PanelBackgroundImageDrawMode.STRETCHED;

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLaunchButton.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLaunchButton.cs
@@ -58,7 +58,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
     {
         public StarDisplay(WindowManager windowManager, Texture2D[] rankTextures) : base(windowManager)
         {
-            Name = "StarDisplay";
+            Name = nameof(StarDisplay);
             this.rankTextures = rankTextures;
             Width = rankTextures[1].Width;
             Height = rankTextures[1].Height;

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -842,7 +842,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             for (int i = MAX_PLAYER_COUNT - 1; i > -1; i--)
             {
                 var ddPlayerName = new XNAClientDropDown(WindowManager);
-                ddPlayerName.Name = "ddPlayerName" + i;
+                ddPlayerName.Name = nameof(ddPlayerName) + i;
                 ddPlayerName.ClientRectangle = new Rectangle(locationX,
                     locationY + (DROP_DOWN_HEIGHT + playerOptionVecticalMargin) * i,
                     playerNameWidth, DROP_DOWN_HEIGHT);
@@ -854,7 +854,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 ddPlayerName.Tag = true;
 
                 var ddPlayerSide = new XNAClientDropDown(WindowManager);
-                ddPlayerSide.Name = "ddPlayerSide" + i;
+                ddPlayerSide.Name = nameof(ddPlayerSide) + i;
                 ddPlayerSide.ClientRectangle = new Rectangle(
                     ddPlayerName.Right + playerOptionHorizontalMargin,
                     ddPlayerName.Y, sideWidth, DROP_DOWN_HEIGHT);
@@ -872,7 +872,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 ddPlayerSide.Tag = true;
 
                 var ddPlayerColor = new XNAClientDropDown(WindowManager);
-                ddPlayerColor.Name = "ddPlayerColor" + i;
+                ddPlayerColor.Name = nameof(ddPlayerColor) + i;
                 ddPlayerColor.ClientRectangle = new Rectangle(
                     ddPlayerSide.Right + playerOptionHorizontalMargin,
                     ddPlayerName.Y, colorWidth, DROP_DOWN_HEIGHT);
@@ -884,7 +884,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 ddPlayerColor.Tag = false;
 
                 var ddPlayerTeam = new XNAClientDropDown(WindowManager);
-                ddPlayerTeam.Name = "ddPlayerTeam" + i;
+                ddPlayerTeam.Name = nameof(ddPlayerTeam) + i;
                 ddPlayerTeam.ClientRectangle = new Rectangle(
                     ddPlayerColor.Right + playerOptionHorizontalMargin,
                     ddPlayerName.Y, teamWidth, DROP_DOWN_HEIGHT);
@@ -895,7 +895,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 ddPlayerTeam.Tag = true;
 
                 var ddPlayerStart = new XNAClientDropDown(WindowManager);
-                ddPlayerStart.Name = "ddPlayerStart" + i;
+                ddPlayerStart.Name = nameof(ddPlayerStart) + i;
                 ddPlayerStart.ClientRectangle = new Rectangle(
                     ddPlayerTeam.Right + playerOptionHorizontalMargin,
                     ddPlayerName.Y, startWidth, DROP_DOWN_HEIGHT);

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
@@ -207,18 +207,18 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         {
             string temp = lbChatMessages.Name;
 
-            lbChatMessages.Name = "lbChatMessages_Host";
+            lbChatMessages.Name = nameof(lbChatMessages) + "_Host";
             ReadINIForControl(lbChatMessages);
-            lbChatMessages.Name = "lbChatMessages_Player";
+            lbChatMessages.Name = nameof(lbChatMessages) + "_Player";
             ReadINIForControl(lbChatMessages);
             lbChatMessages.Name = temp;
             ReadINIForControl(lbChatMessages);
 
             temp = tbChatInput.Name;
 
-            tbChatInput.Name = "tbChatInput_Host";
+            tbChatInput.Name = nameof(tbChatInput) + "_Host";
             ReadINIForControl(tbChatInput);
-            tbChatInput.Name = "tbChatInput_Player";
+            tbChatInput.Name = nameof(tbChatInput) + "_Player";
             ReadINIForControl(tbChatInput);
             tbChatInput.Name = temp;
             ReadINIForControl(tbChatInput);
@@ -679,13 +679,13 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
         private void HideMapList()
         {
-            lbChatMessages.Name = "lbChatMessages_Player";
-            tbChatInput.Name = "tbChatInput_Player";
-            MapPreviewBox.Name = "MapPreviewBox";
-            lblMapName.Name = "lblMapName";
-            lblMapAuthor.Name = "lblMapAuthor";
-            lblGameMode.Name = "lblGameMode";
-            lblMapSize.Name = "lblMapSize";
+            lbChatMessages.Name = nameof(lbChatMessages) + "_Player";
+            tbChatInput.Name = nameof(tbChatInput) + "_Player";
+            MapPreviewBox.Name = nameof(MapPreviewBox);
+            lblMapName.Name = nameof(lblMapName);
+            lblMapAuthor.Name = nameof(lblMapAuthor);
+            lblGameMode.Name = nameof(lblGameMode);
+            lblMapSize.Name = nameof(lblMapSize);
 
             ReadINIForControl(btnPickRandomMap);
             ReadINIForControl(lbChatMessages);
@@ -709,13 +709,13 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
         private void ShowMapList()
         {
-            lbChatMessages.Name = "lbChatMessages_Host";
-            tbChatInput.Name = "tbChatInput_Host";
-            MapPreviewBox.Name = "MapPreviewBox";
-            lblMapName.Name = "lblMapName";
-            lblMapAuthor.Name = "lblMapAuthor";
-            lblGameMode.Name = "lblGameMode";
-            lblMapSize.Name = "lblMapSize";
+            lbChatMessages.Name = nameof(lbChatMessages) + "_Host";
+            tbChatInput.Name = nameof(tbChatInput) + "_Host";
+            MapPreviewBox.Name = nameof(MapPreviewBox);
+            lblMapName.Name = nameof(lblMapName);
+            lblMapAuthor.Name = nameof(lblMapAuthor);
+            lblGameMode.Name = nameof(lblGameMode);
+            lblMapSize.Name = nameof(lblMapSize);
 
             ddGameModeMapFilter.Enable();
             lblGameModeSelect.Enable();

--- a/DXMainClient/DXGUI/Multiplayer/LANGameCreationWindow.cs
+++ b/DXMainClient/DXGUI/Multiplayer/LANGameCreationWindow.cs
@@ -31,12 +31,12 @@ namespace DTAClient.DXGUI.Multiplayer
 
         public override void Initialize()
         {
-            Name = "LANGameCreationWindow";
+            Name = nameof(LANGameCreationWindow);
             BackgroundTexture = AssetLoader.LoadTexture("gamecreationoptionsbg.png");
             ClientRectangle = new Rectangle(0, 0, 447, 77);
 
             lblDescription = new XNALabel(WindowManager);
-            lblDescription.Name = "lblDescription";
+            lblDescription.Name = nameof(lblDescription);
             lblDescription.FontIndex = 1;
             lblDescription.Text = "SELECT SESSION TYPE".L10N("Client:Main:SelectMissionType");
 
@@ -50,7 +50,7 @@ namespace DTAClient.DXGUI.Multiplayer
                 lblDescription.Height);
 
             btnNewGame = new XNAButton(WindowManager);
-            btnNewGame.Name = "btnNewGame";
+            btnNewGame.Name = nameof(btnNewGame);
             btnNewGame.ClientRectangle = new Rectangle(12, 42, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnNewGame.IdleTexture = AssetLoader.LoadTexture("133pxbtn.png");
             btnNewGame.HoverTexture = AssetLoader.LoadTexture("133pxbtn_c.png");
@@ -60,7 +60,7 @@ namespace DTAClient.DXGUI.Multiplayer
             btnNewGame.LeftClick += BtnNewGame_LeftClick;
 
             btnLoadGame = new XNAButton(WindowManager);
-            btnLoadGame.Name = "btnLoadGame";
+            btnLoadGame.Name = nameof(btnLoadGame);
             btnLoadGame.ClientRectangle = new Rectangle(btnNewGame.Right + 12,
                 btnNewGame.Y, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnLoadGame.IdleTexture = btnNewGame.IdleTexture;
@@ -71,7 +71,7 @@ namespace DTAClient.DXGUI.Multiplayer
             btnLoadGame.LeftClick += BtnLoadGame_LeftClick;
 
             btnCancel = new XNAButton(WindowManager);
-            btnCancel.Name = "btnCancel";
+            btnCancel.Name = nameof(btnCancel);
             btnCancel.ClientRectangle = new Rectangle(btnLoadGame.Right + 12,
                 btnNewGame.Y, 133, 23);
             btnCancel.IdleTexture = btnNewGame.IdleTexture;

--- a/DXMainClient/DXGUI/Multiplayer/LANLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/LANLobby.cs
@@ -101,7 +101,7 @@ namespace DTAClient.DXGUI.Multiplayer
 
         public override void Initialize()
         {
-            Name = "LANLobby";
+            Name = nameof(LANLobby);
             BackgroundTexture = AssetLoader.LoadTexture("cncnetlobbybg.png");
             ClientRectangle = new Rectangle(0, 0, WindowManager.RenderResolutionX - 64,
                 WindowManager.RenderResolutionY - 64);
@@ -111,27 +111,27 @@ namespace DTAClient.DXGUI.Multiplayer
                 g => g.InternalName.ToUpper() == localGame.ToUpper());
 
             btnNewGame = new XNAClientButton(WindowManager);
-            btnNewGame.Name = "btnNewGame";
+            btnNewGame.Name = nameof(btnNewGame);
             btnNewGame.ClientRectangle = new Rectangle(12, Height - 35, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnNewGame.Text = "Create Game".L10N("Client:Main:CreateGame");
             btnNewGame.LeftClick += BtnNewGame_LeftClick;
 
             btnJoinGame = new XNAClientButton(WindowManager);
-            btnJoinGame.Name = "btnJoinGame";
+            btnJoinGame.Name = nameof(btnJoinGame);
             btnJoinGame.ClientRectangle = new Rectangle(btnNewGame.Right + 12,
                 btnNewGame.Y, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnJoinGame.Text = "Join Game".L10N("Client:Main:JoinGame");
             btnJoinGame.LeftClick += BtnJoinGame_LeftClick;
 
             btnMainMenu = new XNAClientButton(WindowManager);
-            btnMainMenu.Name = "btnMainMenu";
+            btnMainMenu.Name = nameof(btnMainMenu);
             btnMainMenu.ClientRectangle = new Rectangle(Width - 145,
                 btnNewGame.Y, UIDesignConstants.BUTTON_WIDTH_133, UIDesignConstants.BUTTON_HEIGHT);
             btnMainMenu.Text = "Main Menu".L10N("Client:Main:MainMenu");
             btnMainMenu.LeftClick += BtnMainMenu_LeftClick;
 
             lbGameList = new GameListBox(WindowManager, mapLoader, localGame);
-            lbGameList.Name = "lbGameList";
+            lbGameList.Name = nameof(lbGameList);
             lbGameList.ClientRectangle = new Rectangle(btnNewGame.X,
                 41, btnJoinGame.Right - btnNewGame.X,
                 btnNewGame.Y - 53);
@@ -142,7 +142,7 @@ namespace DTAClient.DXGUI.Multiplayer
             lbGameList.AllowMultiLineItems = false;
 
             lbPlayerList = new XNAListBox(WindowManager);
-            lbPlayerList.Name = "lbPlayerList";
+            lbPlayerList.Name = nameof(lbPlayerList);
             lbPlayerList.ClientRectangle = new Rectangle(Width - 202,
                 lbGameList.Y, 190,
                 lbGameList.Height);
@@ -151,7 +151,7 @@ namespace DTAClient.DXGUI.Multiplayer
             lbPlayerList.LineHeight = 16;
 
             lbChatMessages = new ChatListBox(WindowManager);
-            lbChatMessages.Name = "lbChatMessages";
+            lbChatMessages.Name = nameof(lbChatMessages);
             lbChatMessages.ClientRectangle = new Rectangle(lbGameList.Right + 12,
                 lbGameList.Y,
                 lbPlayerList.X - lbGameList.Right - 24,
@@ -161,7 +161,7 @@ namespace DTAClient.DXGUI.Multiplayer
             lbChatMessages.LineHeight = 16;
 
             tbChatInput = new XNAChatTextBox(WindowManager);
-            tbChatInput.Name = "tbChatInput";
+            tbChatInput.Name = nameof(tbChatInput);
             tbChatInput.ClientRectangle = new Rectangle(lbChatMessages.X,
                 btnNewGame.Y, lbChatMessages.Width,
                 btnNewGame.Height);
@@ -170,13 +170,13 @@ namespace DTAClient.DXGUI.Multiplayer
             tbChatInput.EnterPressed += TbChatInput_EnterPressed;
 
             lblColor = new XNALabel(WindowManager);
-            lblColor.Name = "lblColor";
+            lblColor.Name = nameof(lblColor);
             lblColor.ClientRectangle = new Rectangle(lbChatMessages.X, 14, 0, 0);
             lblColor.FontIndex = 1;
             lblColor.Text = "YOUR COLOR:".L10N("Client:Main:YourColor");
 
             ddColor = new XNAClientDropDown(WindowManager);
-            ddColor.Name = "ddColor";
+            ddColor.Name = nameof(ddColor);
             ddColor.ClientRectangle = new Rectangle(lblColor.X + 95, 12,
                 150, 21);
 

--- a/DXMainClient/Domain/Multiplayer/GameOptionPresets.cs
+++ b/DXMainClient/Domain/Multiplayer/GameOptionPresets.cs
@@ -91,7 +91,7 @@ namespace DTAClient.Domain.Multiplayer
     /// </summary>
     public class GameOptionPresets
     {
-        private const string IniFileName = "GameOptionsPresets.ini";
+        private const string IniFileName = nameof(GameOptionPresets) + ".ini";
         private const string PresetDefinitionsSectionName = "Presets";
 
         private GameOptionPresets() { }


### PR DESCRIPTION
Important fix: changed name for `CheaterWindow` from `CheaterScreen`.