### PR TITLE
Revert "Fix client not reaching disconnect code with unintentional disconnects. (#648)"

### DIFF
--- a/DXMainClient/Online/Connection.cs
+++ b/DXMainClient/Online/Connection.cs
@@ -242,6 +242,12 @@ namespace DTAClient.Online
                     break;
                 }
 
+                if (!serverStream.DataAvailable)
+                {
+                    Thread.Sleep(10);
+                    continue;
+                }
+
                 int bytesRead;
 
                 try


### PR DESCRIPTION
Revert commit 29c44cde3a54486e927eb7449a9b46d2c805cdc1 because it cause bug with constant reconnections to GameSurge servers.

Before:

![image](https://github.com/user-attachments/assets/bffcaa13-cdce-4869-9906-54ad66048e21)

After:

![image](https://github.com/user-attachments/assets/f9195b0f-c9a9-4126-b433-1d7bda3251b3)
