### PR TITLE
Fix outdated TLS version support in Windows 7

### DIFF
--- a/ClientUpdater/CustomComponent.cs
+++ b/ClientUpdater/CustomComponent.cs
@@ -164,7 +164,11 @@ public class CustomComponent
 #if NETFRAMEWORK
             progressMessageHandler = new(new HttpClientHandler
             {
-                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+                SslProtocols = System.Security.Authentication.SslProtocols.Tls |
+                    System.Security.Authentication.SslProtocols.Tls11 |
+                    System.Security.Authentication.SslProtocols.Tls12 |
+                    System.Security.Authentication.SslProtocols.Tls13,
             });
 
             using var httpClient = new HttpClient(progressMessageHandler, true);

--- a/ClientUpdater/Updater.cs
+++ b/ClientUpdater/Updater.cs
@@ -645,7 +645,7 @@ public static class Updater
                     }
                     catch (Exception e)
                     {
-                        Logger.Log("Updater: Error connecting to update mirror. Error message: " + e.Message);
+                        Logger.Log("Updater: Error connecting to update mirror. Error message: " + e.ToString());
                         Logger.Log("Updater: Seeking other mirrors...");
                         currentUpdateMirrorIndex++;
 

--- a/ClientUpdater/Updater.cs
+++ b/ClientUpdater/Updater.cs
@@ -152,7 +152,11 @@ public static class Updater
 #if NETFRAMEWORK
     private static readonly ProgressMessageHandler SharedProgressMessageHandler = new(new HttpClientHandler
     {
-        AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+        AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+        SslProtocols = System.Security.Authentication.SslProtocols.Tls |
+            System.Security.Authentication.SslProtocols.Tls11 |
+            System.Security.Authentication.SslProtocols.Tls12 |
+            System.Security.Authentication.SslProtocols.Tls13,
     });
 
     private static readonly HttpClient SharedHttpClient = new(SharedProgressMessageHandler, true);


### PR DESCRIPTION
Not specifying `SslProtocols` causes Windows 7 clients can not connect to TLS 1.2/1.3-only HTTPS server.

Without this PR, windows 7:
```
22.05. 01:48:42.695    Updater: Checking for updates.
22.05. 01:48:42.697    Updater: Doing version file check.
22.05. 01:48:42.698    Updater: Checking version on the server.
22.05. 01:48:42.701    Updater: Trying to connect to update mirror https://phantom.cncguild.net/updates/
22.05. 01:49:04.482    Updater: Error connecting to update mirror. Error message: An error occurred while sending the request.
22.05. 01:49:04.482    Updater: Seeking other mirrors...
22.05. 01:49:04.483    Updater: An error occured while performing version check: Unable to connect to update servers.
22.05. 01:49:04.484    Updater: File identifiers updated.
```

this error is not logged in detail. It actually is:
```
22.05. 01:55:04.973    Updater: Checking for updates.
22.05. 01:55:04.976    Updater: Doing version file check.
22.05. 01:55:04.977    Updater: Checking version on the server.
22.05. 01:55:04.978    Updater: Trying to connect to update mirror https://phantom.cncguild.net/updates/

22.05. 01:55:26.777    Updater: Error connecting to update mirror. Error message: System.Net.Http.HttpRequestException: An error occurred while sending the request. ---> System.Net.WebException: The request was aborted: Could not create SSL/TLS secure channel.
   at System.Net.HttpWebRequest.EndGetResponse(IAsyncResult asyncResult)
   at System.Net.Http.HttpClientHandler.GetResponseCallback(IAsyncResult ar)
   --- End of inner exception stack trace ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Net.Http.Handlers.ProgressMessageHandler.<SendAsync>d__8.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   at ClientUpdater.Updater.<DoVersionCheckAsync>d__88.MoveNext() in D:\SadPencil\Documents\GitHub\xna-cncnet-client\ClientUpdater\Updater.cs:line 633
```

![图片](https://github.com/user-attachments/assets/da1bee2b-2199-4d7b-a060-ca77a8ccbe71)



