### PR TITLE
Allow excluding private messages from players not in current channel

### DIFF
--- a/ClientCore/Enums/AllowPrivateMessagesFromEnum.cs
+++ b/ClientCore/Enums/AllowPrivateMessagesFromEnum.cs
@@ -3,7 +3,7 @@
     public enum AllowPrivateMessagesFromEnum
     {
         All = 1,
-        AllCurrentChannel = 4,
+        CurrentChannel = 4,
         Friends = 2,
         None = 3,
     }

--- a/ClientCore/Enums/AllowPrivateMessagesFromEnum.cs
+++ b/ClientCore/Enums/AllowPrivateMessagesFromEnum.cs
@@ -3,7 +3,8 @@
     public enum AllowPrivateMessagesFromEnum
     {
         All = 1,
+        AllCurrentChannel = 4,
         Friends = 2,
-        None = 3
+        None = 3,
     }
 }

--- a/DTAConfig/OptionPanels/CnCNetOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/CnCNetOptionsPanel.cs
@@ -193,19 +193,25 @@ namespace DTAConfig.OptionPanels
             ddAllowPrivateMessagesFrom.AddItem(new XNADropDownItem()
             {
                 Text = "All".L10N("Client:DTAConfig:PMAll"),
-                Tag = AllowPrivateMessagesFromEnum.All
+                Tag = AllowPrivateMessagesFromEnum.All,
+            });
+
+            ddAllowPrivateMessagesFrom.AddItem(new XNADropDownItem()
+            {
+                Text = "All (current channel only)".L10N("Client:DTAConfig:PMAllCurrentChannel"),
+                Tag = AllowPrivateMessagesFromEnum.AllCurrentChannel,
             });
 
             ddAllowPrivateMessagesFrom.AddItem(new XNADropDownItem()
             {
                 Text = "Friends".L10N("Client:DTAConfig:PMFriends"),
-                Tag = AllowPrivateMessagesFromEnum.Friends
+                Tag = AllowPrivateMessagesFromEnum.Friends,
             });
 
             ddAllowPrivateMessagesFrom.AddItem(new XNADropDownItem()
             {
                 Text = "None".L10N("Client:DTAConfig:PMNone"),
-                Tag = AllowPrivateMessagesFromEnum.None
+                Tag = AllowPrivateMessagesFromEnum.None,
             });
 
             AddChild(ddAllowPrivateMessagesFrom);

--- a/DTAConfig/OptionPanels/CnCNetOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/CnCNetOptionsPanel.cs
@@ -198,8 +198,8 @@ namespace DTAConfig.OptionPanels
 
             ddAllowPrivateMessagesFrom.AddItem(new XNADropDownItem()
             {
-                Text = "All (current channel only)".L10N("Client:DTAConfig:PMAllCurrentChannel"),
-                Tag = AllowPrivateMessagesFromEnum.AllCurrentChannel,
+                Text = "Current channel".L10N("Client:DTAConfig:PMlCurrentChannel"),
+                Tag = AllowPrivateMessagesFromEnum.CurrentChannel,
             });
 
             ddAllowPrivateMessagesFrom.AddItem(new XNADropDownItem()

--- a/DTAConfig/OptionPanels/CnCNetOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/CnCNetOptionsPanel.cs
@@ -198,7 +198,7 @@ namespace DTAConfig.OptionPanels
 
             ddAllowPrivateMessagesFrom.AddItem(new XNADropDownItem()
             {
-                Text = "Current channel".L10N("Client:DTAConfig:PMlCurrentChannel"),
+                Text = "Current channel".L10N("Client:DTAConfig:PMCurrentChannel"),
                 Tag = AllowPrivateMessagesFromEnum.CurrentChannel,
             });
 

--- a/DTAConfig/OptionPanels/CnCNetOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/CnCNetOptionsPanel.cs
@@ -188,7 +188,7 @@ namespace DTAConfig.OptionPanels
             ddAllowPrivateMessagesFrom.Name = nameof(ddAllowPrivateMessagesFrom);
             ddAllowPrivateMessagesFrom.ClientRectangle = new Rectangle(
                 lblAllPrivateMessagesFrom.Right,
-                lblAllPrivateMessagesFrom.Y - 2, 65, 0);
+                lblAllPrivateMessagesFrom.Y - 2, 110, 0);
 
             ddAllowPrivateMessagesFrom.AddItem(new XNADropDownItem()
             {

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/PrivateMessagingWindow.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/PrivateMessagingWindow.cs
@@ -454,7 +454,14 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 }
             }
 
-            if (UserINISettings.Instance.AllowPrivateMessagesFromState == (int)AllowPrivateMessagesFromEnum.Friends && !cncnetUserData.IsFriend(pmUser.IrcUser.Name))
+            bool isFriend = cncnetUserData.IsFriend(pmUser.IrcUser.Name);
+            if (UserINISettings.Instance.AllowPrivateMessagesFromState == (int)AllowPrivateMessagesFromEnum.Friends && !isFriend)
+                return;
+
+            // Exclude messages from users not in the current channel
+            if (!isFriend &&
+                UserINISettings.Instance.AllowPrivateMessagesFromState != (int)AllowPrivateMessagesFromEnum.All &&
+                connectionManager.MainChannel.Users.Find(e.Sender) == null)
                 return;
 
             ChatMessage message = new ChatMessage(e.Sender, otherUserMessageColor, DateTime.Now, e.Message);


### PR DESCRIPTION
This PR adds a new private message option, to filter out PM from players that are not in current channel.

Prevent adversaries from bothering players even if they got banned by a channel admin: https://github.com/CnCNet/xna-cncnet-client/pull/727#issuecomment-2902088148

Not enabled by default.

![图片](https://github.com/user-attachments/assets/aae76873-4c23-4aef-9b13-98ad8e81e15a)

