### PR TITLE
Avoid the abuse of random generator initialization

### DIFF
--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -249,7 +249,7 @@ namespace DTAClient.DXGUI
             var rng = System.Security.Cryptography.RandomNumberGenerator.Create();
             byte[] intBytes = new byte[sizeof(int)];
             rng.GetBytes(intBytes);
-            int seed = BitConverter.ToInt32(intBytes, 0) & 0x7FFFFFFF; // Ensure non-negative
+            int seed = BitConverter.ToInt32(intBytes, 0);
             return new Random(seed);
         }
 

--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -244,6 +244,15 @@ namespace DTAClient.DXGUI
                 (wm.RenderResolutionY - ls.Height) / 2, ls.Width, ls.Height);
         }
 
+        private static Random GetRandom()
+        {
+            var rng = System.Security.Cryptography.RandomNumberGenerator.Create();
+            byte[] intBytes = new byte[sizeof(int)];
+            rng.GetBytes(intBytes);
+            int seed = BitConverter.ToInt32(intBytes, 0) & 0x7FFFFFFF; // Ensure non-negative
+            return new Random(seed);
+        }
+
         private IServiceProvider BuildServiceProvider(WindowManager windowManager)
         {
             // Create host - this allows for things like DependencyInjection
@@ -261,7 +270,8 @@ namespace DTAClient.DXGUI
                             .AddSingleton<TunnelHandler>()
                             .AddSingleton<DiscordHandler>()
                             .AddSingleton<PrivateMessageHandler>()
-                            .AddSingleton<MapLoader>();
+                            .AddSingleton<MapLoader>()
+                            .AddSingleton<Random>(GetRandom());
 
                         // singleton xna controls - same instance on each request
                         services

--- a/DXMainClient/DXGUI/Generic/LoadingScreen.cs
+++ b/DXMainClient/DXGUI/Generic/LoadingScreen.cs
@@ -24,17 +24,21 @@ namespace DTAClient.DXGUI.Generic
             CnCNetManager cncnetManager,
             WindowManager windowManager,
             IServiceProvider serviceProvider,
-            MapLoader mapLoader
+            MapLoader mapLoader,
+            Random random
         ) : base(windowManager)
         {
             this.cncnetManager = cncnetManager;
             this.serviceProvider = serviceProvider;
             this.mapLoader = mapLoader;
+            this.random = random;
         }
 
         private static readonly object locker = new object();
 
         private MapLoader mapLoader;
+
+        private Random random;
 
         private PrivateMessagingPanel privateMessagingPanel;
 
@@ -87,7 +91,7 @@ namespace DTAClient.DXGUI.Generic
             if (randomTextures.Count == 0)
                 return;
 
-            BackgroundTexture = AssetLoader.LoadTexture(randomTextures[new Random().Next(randomTextures.Count)]);
+            BackgroundTexture = AssetLoader.LoadTexture(randomTextures[random.Next(randomTextures.Count)]);
         }
 
         private void InitUpdater()

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
@@ -39,7 +39,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             CnCNetGameLobby gameLobby, CnCNetGameLoadingLobby gameLoadingLobby,
             TopBar topBar, PrivateMessagingWindow pmWindow, TunnelHandler tunnelHandler,
             GameCollection gameCollection, CnCNetUserData cncnetUserData,
-            OptionsWindow optionsWindow, MapLoader mapLoader)
+            OptionsWindow optionsWindow, MapLoader mapLoader, Random random)
             : base(windowManager)
         {
             this.connectionManager = connectionManager;
@@ -52,6 +52,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             this.cncnetUserData = cncnetUserData;
             this.optionsWindow = optionsWindow;
             this.mapLoader = mapLoader;
+            this.random = random;
 
             ctcpCommandHandlers = new CommandHandlerBase[]
             {
@@ -140,6 +141,8 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
         private InvitationIndex invitationIndex;
 
         private GameFiltersPanel panelGameFilters;
+        
+        private Random random; 
 
         private void GameList_ClientRectangleUpdated(object sender, EventArgs e)
         {
@@ -1118,9 +1121,10 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
         /// <returns>A random channel name based on the currently played game.</returns>
         private string RandomizeChannelName()
         {
+            // TODO: handle the case where the randomization keeps failing for multiple (e.g., 1000) times
             while (true)
             {
-                string channelName = gameCollection.GetGameChatChannelNameFromIdentifier(localGameID) + "-game" + new Random().Next(1000000, 9999999);
+                string channelName = gameCollection.GetGameChatChannelNameFromIdentifier(localGameID) + "-game" + random.Next(1000000, 9999999);
                 int index = lbGameList.HostedGames.FindIndex(c => ((HostedCnCNetGame)c).ChannelName == channelName);
                 if (index == -1)
                     return channelName;

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
@@ -141,8 +141,8 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
         private InvitationIndex invitationIndex;
 
         private GameFiltersPanel panelGameFilters;
-        
-        private Random random; 
+
+        private Random random;
 
         private void GameList_ClientRectangleUpdated(object sender, EventArgs e)
         {
@@ -1121,14 +1121,16 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
         /// <returns>A random channel name based on the currently played game.</returns>
         private string RandomizeChannelName()
         {
-            // TODO: handle the case where the randomization keeps failing for multiple (e.g., 1000) times
-            while (true)
+            int maxTries = 10000;
+            for (int i = 0; i < maxTries; i++)
             {
                 string channelName = gameCollection.GetGameChatChannelNameFromIdentifier(localGameID) + "-game" + random.Next(1000000, 9999999);
                 int index = lbGameList.HostedGames.FindIndex(c => ((HostedCnCNetGame)c).ChannelName == channelName);
                 if (index == -1)
                     return channelName;
             }
+
+            throw new Exception(string.Format("Could not find a random channel name after {0} retries", maxTries));
         }
 
         private void Gcw_Cancelled(object sender, EventArgs e) => gameCreationPanel.Hide();

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -50,8 +50,9 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             CnCNetUserData cncnetUserData, 
             MapLoader mapLoader, 
             DiscordHandler discordHandler,
-            PrivateMessagingWindow pmWindow
-        ) : base(windowManager, "MultiplayerGameLobby", topBar, mapLoader, discordHandler, pmWindow)
+            PrivateMessagingWindow pmWindow,
+            Random random
+        ) : base(windowManager, "MultiplayerGameLobby", topBar, mapLoader, discordHandler, pmWindow, random)
         {
             this.connectionManager = connectionManager;
             localGame = ClientConfiguration.Instance.LocalGame;
@@ -59,6 +60,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             this.gameCollection = gameCollection;
             this.cncnetUserData = cncnetUserData;
             this.pmWindow = pmWindow;
+            this.random = random;
 
             ctcpCommandHandlers = new CommandHandlerBase[]
             {
@@ -143,6 +145,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         private List<string> chatCommandDownloadedMaps = new List<string>();
 
         private MapSharingConfirmationPanel mapSharingConfirmationPanel;
+
+        private Random random;
 
         /// <summary>
         /// The SHA1 of the latest selected map.
@@ -238,7 +242,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             if (isHost)
             {
-                RandomSeed = new Random().Next();
+                RandomSeed = random.Next();
                 RefreshMapSelectionUI();
                 btnChangeTunnel.Enable();
             }
@@ -1249,7 +1253,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             if (IsHost)
             {
-                RandomSeed = new Random().Next();
+                RandomSeed = random.Next();
                 OnGameOptionChanged();
                 ClearReadyStatuses();
                 CopyPlayerDataToUI();

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -55,16 +55,20 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             string iniName,
             MapLoader mapLoader,
             bool isMultiplayer,
-            DiscordHandler discordHandler
+            DiscordHandler discordHandler,
+            Random random
         ) : base(windowManager)
         {
             _iniSectionName = iniName;
             MapLoader = mapLoader;
             this.isMultiplayer = isMultiplayer;
             this.discordHandler = discordHandler;
+            this.random = random;
         }
 
         private string _iniSectionName;
+
+        private Random random;
 
         protected XNAPanel PlayerOptionsPanel;
 
@@ -747,10 +751,10 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             if (maps.Count < 1)
                 return;
 
-            int random = new Random().Next(0, maps.Count);
+            int randomValue = random.Next(0, maps.Count);
             bool isFavoriteMapsSelected = IsFavoriteMapsSelected();
-            GameModeMap = GameModeMaps.Find(gmm => (gmm.GameMode == GameMode || gmm.IsFavorite && isFavoriteMapsSelected) && gmm.Map == maps[random]);
-            Logger.Log("PickRandomMap: Rolled " + random + " out of " + maps.Count + ". Picked map: " + Map.Name);
+            GameModeMap = GameModeMaps.Find(gmm => (gmm.GameMode == GameMode || gmm.IsFavorite && isFavoriteMapsSelected) && gmm.Map == maps[randomValue]);
+            Logger.Log("PickRandomMap: Rolled " + randomValue + " out of " + maps.Count + ". Picked map: " + Map.Name);
 
             ChangeMap(GameModeMap);
             tbMapSearch.Text = string.Empty;
@@ -1333,7 +1337,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             // Randomize options
 
-            Random random = new Random(RandomSeed);
+            Random pseudoRandom = new Random(RandomSeed);
 
             for (int i = 0; i < totalPlayerCount; i++)
             {
@@ -1352,10 +1356,10 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                     disallowedSides = GetDisallowedSidesForGroup(forHumanPlayers:false);
                 }
 
-                pHouseInfo.RandomizeSide(pInfo, SideCount, random, disallowedSides, RandomSelectors, RandomSelectorCount);
+                pHouseInfo.RandomizeSide(pInfo, SideCount, pseudoRandom, disallowedSides, RandomSelectors, RandomSelectorCount);
 
-                pHouseInfo.RandomizeColor(pInfo, freeColors, MPColors, random);
-                pHouseInfo.RandomizeStart(pInfo, random, freeStartingLocations, takenStartingLocations, teamStartMappings.Any());
+                pHouseInfo.RandomizeColor(pInfo, freeColors, MPColors, pseudoRandom);
+                pHouseInfo.RandomizeStart(pInfo, pseudoRandom, freeStartingLocations, takenStartingLocations, teamStartMappings.Any());
             }
 
             return houseInfos;

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
@@ -44,8 +44,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         public const string PING = "PING";
 
         public LANGameLobby(WindowManager windowManager, string iniName,
-            TopBar topBar, LANColor[] chatColors, MapLoader mapLoader, DiscordHandler discordHandler, PrivateMessagingWindow pmWindow) :
-            base(windowManager, iniName, topBar, mapLoader, discordHandler, pmWindow)
+            TopBar topBar, LANColor[] chatColors, MapLoader mapLoader, DiscordHandler discordHandler, PrivateMessagingWindow pmWindow, Random random) :
+            base(windowManager, iniName, topBar, mapLoader, discordHandler, pmWindow, random)
         {
             this.chatColors = chatColors;
             encoding = Encoding.UTF8;
@@ -77,6 +77,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             localGame = ClientConfiguration.Instance.LocalGame;
 
             WindowManager.GameClosing += WindowManager_GameClosing;
+
+            this.random = random;
         }
 
         private void WindowManager_GameClosing(object sender, EventArgs e)
@@ -123,6 +125,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
         private string localFileHash;
 
+        private Random random;
+
         public override void Initialize()
         {
             IniNameOverride = nameof(LANGameLobby);
@@ -139,7 +143,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             if (isHost)
             {
-                RandomSeed = new Random().Next();
+                RandomSeed = random.Next();
                 Thread thread = new Thread(ListenForClients);
                 thread.Start();
 
@@ -669,7 +673,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             if (IsHost)
             {
-                RandomSeed = new Random().Next();
+                RandomSeed = random.Next();
                 OnGameOptionChanged();
                 ClearReadyStatuses();
                 CopyPlayerDataToUI();

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
@@ -28,10 +28,11 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         private const int MAX_DIE_SIDES = 100;
 
         public MultiplayerGameLobby(WindowManager windowManager, string iniName,
-            TopBar topBar, MapLoader mapLoader, DiscordHandler discordHandler, PrivateMessagingWindow pmWindow)
-            : base(windowManager, iniName, mapLoader, true, discordHandler)
+            TopBar topBar, MapLoader mapLoader, DiscordHandler discordHandler, PrivateMessagingWindow pmWindow, Random random)
+            : base(windowManager, iniName, mapLoader, true, discordHandler, random)
         {
             TopBar = topBar;
+            this.random = random;
 
             chatBoxCommands = new List<ChatBoxCommand>
             {
@@ -60,6 +61,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         protected XNAChatTextBox tbChatInput;
         protected XNAClientButton btnLockGame;
         protected XNAClientCheckBox chkAutoReady;
+
+        private Random random;
 
         protected bool IsHost = false;
 
@@ -522,7 +525,6 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             }
 
             int[] results = new int[dieCount];
-            Random random = new Random();
             for (int i = 0; i < dieCount; i++)
             {
                 results[i] = random.Next(1, dieSides + 1);

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/SkirmishLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/SkirmishLobby.cs
@@ -19,13 +19,16 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
     {
         private const string SETTINGS_PATH = "Client/SkirmishSettings.ini";
 
-        public SkirmishLobby(WindowManager windowManager, TopBar topBar, MapLoader mapLoader, DiscordHandler discordHandler)
-            : base(windowManager, "SkirmishLobby", mapLoader, false, discordHandler)
+        public SkirmishLobby(WindowManager windowManager, TopBar topBar, MapLoader mapLoader, DiscordHandler discordHandler, Random random)
+            : base(windowManager, "SkirmishLobby", mapLoader, false, discordHandler, random)
         {
             this.topBar = topBar;
+            this.random = random;
         }
 
         public event EventHandler Exited;
+
+        private Random random;
 
         TopBar topBar;
 
@@ -33,7 +36,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         {
             base.Initialize();
 
-            RandomSeed = new Random().Next();
+            RandomSeed = random.Next();
 
             //InitPlayerOptionDropdowns(128, 98, 90, 48, 55, new Point(6, 24));
             InitPlayerOptionDropdowns();
@@ -229,7 +232,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             DdGameModeMapFilter_SelectedIndexChanged(null, EventArgs.Empty); // Refresh ranks
 
-            RandomSeed = new Random().Next();
+            RandomSeed = random.Next();
         }
 
         public void Open()

--- a/DXMainClient/DXGUI/Multiplayer/LANLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/LANLobby.cs
@@ -39,15 +39,19 @@ namespace DTAClient.DXGUI.Multiplayer
             WindowManager windowManager,
             GameCollection gameCollection,
             MapLoader mapLoader,
-            DiscordHandler discordHandler
+            DiscordHandler discordHandler,
+            Random random
         ) : base(windowManager)
         {
             this.gameCollection = gameCollection;
             this.mapLoader = mapLoader;
             this.discordHandler = discordHandler;
+            this.random = random;
         }
 
         public event EventHandler Exited;
+
+        private Random random;
 
         XNAListBox lbPlayerList;
         ChatListBox lbChatMessages;
@@ -239,7 +243,7 @@ namespace DTAClient.DXGUI.Multiplayer
             gameCreationPanel.SetPositionAndSize();
 
             lanGameLobby = new LANGameLobby(WindowManager, "MultiplayerGameLobby",
-                null, chatColors, mapLoader, discordHandler, pmWindow);
+                null, chatColors, mapLoader, discordHandler, pmWindow, random);
             DarkeningPanel.AddAndInitializeWithControl(WindowManager, lanGameLobby);
             lanGameLobby.Disable();
 

--- a/DXMainClient/Online/CnCNetManager.cs
+++ b/DXMainClient/Online/CnCNetManager.cs
@@ -46,11 +46,11 @@ namespace DTAClient.Online
         public event EventHandler<UserNameIndexEventArgs> UserRemoved;
         public event EventHandler MultipleUsersAdded;
 
-        public CnCNetManager(WindowManager wm, GameCollection gc, CnCNetUserData cncNetUserData)
+        public CnCNetManager(WindowManager wm, GameCollection gc, CnCNetUserData cncNetUserData, Random random)
         {
             gameCollection = gc;
             this.cncNetUserData = cncNetUserData;
-            connection = new Connection(this);
+            connection = new Connection(this, random);
 
             this.wm = wm;
 

--- a/DXMainClient/Online/Connection.cs
+++ b/DXMainClient/Online/Connection.cs
@@ -24,12 +24,15 @@ namespace DTAClient.Online
         private const int ID_LENGTH = 9;
         private const int MAXIMUM_LATENCY = 400;
 
-        public Connection(IConnectionManager connectionManager)
+        public Connection(IConnectionManager connectionManager, Random random)
         {
             this.connectionManager = connectionManager;
+            this.Rng = random;
         }
 
         IConnectionManager connectionManager;
+
+        public Random Rng;
 
         private static IList<Server> _servers = null;
         /// <summary>
@@ -68,12 +71,6 @@ namespace DTAClient.Online
         public bool AttemptingConnection
         {
             get { return _attemptingConnection; }
-        }
-
-        Random _rng = new Random();
-        public Random Rng
-        {
-            get { return _rng; }
         }
 
         private List<QueuedMessage> MessageQueue = new List<QueuedMessage>();
@@ -904,7 +901,7 @@ namespace DTAClient.Online
         /// <param name="data">Just a dummy parameter so that this matches the delegate System.Threading.TimerCallback.</param>
         private void AutoPing(object data)
         {
-            SendMessage("PING LAG" + new Random().Next(100000, 999999));
+            SendMessage("PING LAG" + Rng.Next(100000, 999999));
         }
 
         /// <summary>


### PR DESCRIPTION
This PR uses dependency injection to provide a shared Random class whose seed is NOT generated from the system time but a reliable RNG from [System.Security.Cryptography.RandomNumberGenerator](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.randomnumbergenerator). 

This PR solves the issues below:
- Calling `new Random()` with in a short time will get an RNG with the same seed. This makes `RandomizeChannelName()` waste some times.
- Different players might have a chance to get and register the same channel if the time is close enough in `RandomizeChannelName()`