### PR TITLE
Fix crash on joining a game when the channel name is occupied

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
@@ -926,8 +926,11 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             isJoiningGame = true;
             gameOfLastJoinAttempt = hg;
 
-            Channel gameChannel = connectionManager.CreateChannel(hg.RoomName, hg.ChannelName, false, true, password);
-            connectionManager.AddChannel(gameChannel);
+            if (connectionManager.FindChannel(hg.ChannelName) == null)
+            {
+                Channel gameChannel = connectionManager.CreateChannel(hg.RoomName, hg.ChannelName, false, true, password);
+                connectionManager.AddChannel(gameChannel);
+            }
 
             if (hg.IsLoadedGame)
             {


### PR DESCRIPTION
**Review required. I don't know if it's the correct solution to this issue.**

```
22.05. 04:05:24.916    KABOOOOOOM!!! Info:
22.05. 04:05:24.916    Type: System.ArgumentException
22.05. 04:05:24.917    Message: The channel already exists!
Parameter name: channel
22.05. 04:05:24.921    Source: clientdx
22.05. 04:05:24.921    TargetSite.Name: AddChannel
22.05. 04:05:24.922    Stacktrace:    at DTAClient.Online.CnCNetManager.AddChannel(Channel channel) in D:\a\xna-cncnet-client\xna-cncnet-client\DXMainClient\Online\CnCNetManager.cs:line 142
   at DTAClient.DXGUI.Multiplayer.CnCNet.CnCNetLobby._JoinGame(HostedCnCNetGame hg, String password) in D:\a\xna-cncnet-client\xna-cncnet-client\DXMainClient\DXGUI\Multiplayer\CnCNet\CnCNetLobby.cs:line 934
   at DTAClient.DXGUI.Multiplayer.CnCNet.CnCNetLobby.JoinGame(HostedCnCNetGame hg, String password, IMessageView messageView) in D:\a\xna-cncnet-client\xna-cncnet-client\DXMainClient\DXGUI\Multiplayer\CnCNet\CnCNetLobby.cs:line 921
   at DTAClient.DXGUI.Multiplayer.CnCNet.CnCNetLobby.JoinGameByIndex(Int32 gameIndex, String password) in D:\a\xna-cncnet-client\xna-cncnet-client\DXMainClient\DXGUI\Multiplayer\CnCNet\CnCNetLobby.cs:line 868
   at DTAClient.DXGUI.Multiplayer.CnCNet.CnCNetLobby.JoinSelectedGame() in D:\a\xna-cncnet-client\xna-cncnet-client\DXMainClient\DXGUI\Multiplayer\CnCNet\CnCNetLobby.cs:line 856
   at DTAClient.DXGUI.Multiplayer.CnCNet.CnCNetLobby.LbGameList_DoubleLeftClick(Object sender, EventArgs e) in D:\a\xna-cncnet-client\xna-cncnet-client\DXMainClient\DXGUI\Multiplayer\CnCNet\CnCNetLobby.cs:line 786
   at Rampastring.XNAUI.XNAControls.XNAListBox.OnDoubleLeftClick()
   at Rampastring.XNAUI.XNAControls.XNAControl.Update(GameTime gameTime)
   at Rampastring.XNAUI.XNAControls.XNAPanel.Update(GameTime gameTime)
   at Rampastring.XNAUI.XNAControls.XNAListBox.Update(GameTime gameTime)
   at DTAClient.DXGUI.Multiplayer.GameListBox.Update(GameTime gameTime) in D:\a\xna-cncnet-client\xna-cncnet-client\DXMainClient\DXGUI\Multiplayer\GameListBox.cs:line 293
   at Rampastring.XNAUI.XNAControls.XNAControl.Update(GameTime gameTime)
   at Rampastring.XNAUI.XNAControls.XNAPanel.Update(GameTime gameTime)
   at Rampastring.XNAUI.XNAControls.XNAControl.Update(GameTime gameTime)
   at Rampastring.XNAUI.XNAControls.XNAPanel.Update(GameTime gameTime)
   at ClientGUI.DarkeningPanel.Update(GameTime gameTime) in D:\a\xna-cncnet-client\xna-cncnet-client\ClientGUI\DarkeningPanel.cs:line 93
   at Rampastring.XNAUI.WindowManager.Update(GameTime gameTime)
   at Microsoft.Xna.Framework.Game.SortingFilteringCollection`1.ForEachFilteredItem[TUserData](Action`2 action, TUserData userData)
   at Microsoft.Xna.Framework.Game.DoUpdate(GameTime gameTime)
   at Microsoft.Xna.Framework.Game.Tick()
   at MonoGame.Framework.WinFormsGameWindow.TickOnIdle(Object sender, EventArgs e)
   at System.Windows.Forms.Application.ThreadContext.System.Windows.Forms.UnsafeNativeMethods.IMsoComponent.FDoIdle(Int32 grfidlef)
   at System.Windows.Forms.Application.ComponentManager.System.Windows.Forms.UnsafeNativeMethods.IMsoComponentManager.FPushMessageLoop(IntPtr dwComponentID, Int32 reason, Int32 pvLoopData)
   at System.Windows.Forms.Application.ThreadContext.RunMessageLoopInner(Int32 reason, ApplicationContext context)
   at System.Windows.Forms.Application.ThreadContext.RunMessageLoop(Int32 reason, ApplicationContext context)
   at MonoGame.Framework.WinFormsGameWindow.RunLoop()
   at Microsoft.Xna.Framework.Game.Run(GameRunBehavior runBehavior)
   at DTAClient.Startup.Execute() in D:\a\xna-cncnet-client\xna-cncnet-client\DXMainClient\Startup.cs:line 177
   at DTAClient.PreStartup.Initialize(StartupParams parameters) in D:\a\xna-cncnet-client\xna-cncnet-client\DXMainClient\PreStartup.cs:line 214
```