### PR TITLE
Store CurrentTunnel reference to avoid null reference

### DIFF
--- a/DXMainClient/Domain/Multiplayer/CnCNet/TunnelHandler.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/TunnelHandler.cs
@@ -131,12 +131,15 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
         {
             return Task.Factory.StartNew(() =>
             {
-                CurrentTunnel.UpdatePing();
+                var tunnel = CurrentTunnel;
+                if (tunnel == null) return;
+
+                tunnel.UpdatePing();
                 DoCurrentTunnelPinged();
 
                 if (checkTunnelList)
                 {
-                    int tunnelIndex = Tunnels.FindIndex(t => t.Address == CurrentTunnel.Address && t.Port == CurrentTunnel.Port);
+                    int tunnelIndex = Tunnels.FindIndex(t => t.Address == tunnel.Address && t.Port == tunnel.Port);
                     if (tunnelIndex > -1)
                         DoTunnelPinged(tunnelIndex);
                 }


### PR DESCRIPTION
Fix for a crash I received today when jumping through different rooms quickly.

![image](https://github.com/user-attachments/assets/eea0987f-a3c4-43c8-a6da-ec06473cb210)
