### PR TITLE
Improve `ChatListBox` link handling

### DIFF
--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -260,9 +260,9 @@ namespace ClientCore
 
         public string StatisticsLogFileName => clientDefinitionsIni.GetStringValue(SETTINGS, "StatisticsLogFileName", "DTA.LOG");
 
-        public string TrustedLinksRegExp => clientDefinitionsIni.GetStringValue(SETTINGS, "TrustedLinksRegExp", @"^((http)|(https))((://)|(://www\.))(github\.com)");
+        public string TrustedLinksRegExp => clientDefinitionsIni.GetStringValue(SETTINGS, "TrustedLinksRegExp", @"^((http)|(https))((://)|(://www\.))((github\.com)|(moddb\.com))");
         
-        public string AlwaysTrustedLinksRegExp = @"^((http)|(https))((://)|(://www\.))((cncnet\.org)|(gamesurge\.net)|(dronebl\.org)|(discord\.com/invite)|(steamcommunity\.com)|(youtube\.com)|(youtu.be))";
+        public string AlwaysTrustedLinksRegExp = @"^((http)|(https))((://)|(://www\.))((cncnet\.org)|(gamesurge\.net)|(dronebl\.org)|(discord\.com)|(steamcommunity\.com)|(youtube\.com)|(youtu.be))";
 
         public (string Name, string Path) GetThemeInfoFromIndex(int themeIndex) => clientDefinitionsIni.GetStringValue("Themes", themeIndex.ToString(), ",").Split(',').AsTuple2();
 

--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -262,7 +262,7 @@ namespace ClientCore
 
         public string[] TrustedDomains => clientDefinitionsIni.GetStringValue(SETTINGS, "TrustedDomains", string.Empty).Split(',');
 
-        public string AlwaysTrustedLinksRegExp = @"^((http)|(https))((://)|(://www\.))((cncnet\.org)|(gamesurge\.net)|(dronebl\.org)|(discord\.com)|(steamcommunity\.com)|(youtube\.com)|(youtu.be))";
+        public string AlwaysTrustedLinksRegExp = @"^((http)|(https))((://)|(://www\.))((cncnet\.org)|(mapdb\.cncnet\.org)|(gamesurge\.net)|(dronebl\.org)|(discord\.com)|(steamcommunity\.com)|(youtube\.com)|(youtu.be))";
 
         public (string Name, string Path) GetThemeInfoFromIndex(int themeIndex) => clientDefinitionsIni.GetStringValue("Themes", themeIndex.ToString(), ",").Split(',').AsTuple2();
 

--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -262,7 +262,7 @@ namespace ClientCore
 
         public string TrustedLinksRegExp => clientDefinitionsIni.GetStringValue(SETTINGS, "TrustedLinksRegExp", @"^((http)|(https))((://)|(://www\.))(github\.com)");
         
-        public string HardcodeTrustedLinksRegExp = @"^((http)|(https))((://)|(://www\.))((cncnet\.org)|(gamesurge\.net)|(dronebl\.org)|(discord\.com/invite)|(steamcommunity\.com)|(youtube\.com)|(youtu.be))";
+        public string AlwaysTrustedLinksRegExp = @"^((http)|(https))((://)|(://www\.))((cncnet\.org)|(gamesurge\.net)|(dronebl\.org)|(discord\.com/invite)|(steamcommunity\.com)|(youtube\.com)|(youtu.be))";
 
         public (string Name, string Path) GetThemeInfoFromIndex(int themeIndex) => clientDefinitionsIni.GetStringValue("Themes", themeIndex.ToString(), ",").Split(',').AsTuple2();
 

--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -262,7 +262,7 @@ namespace ClientCore
 
         public string[] TrustedDomains => clientDefinitionsIni.GetStringValue(SETTINGS, "TrustedDomains", string.Empty).Split(',');
 
-        public string[] AlwaysTrustedDomains = {"cncnet.org", "gamesurge.net", "dronebl.com", "discord.com", "youtube.com", "youtu.be"};
+        public string[] AlwaysTrustedDomains = {"cncnet.org", "gamesurge.net", "dronebl.org", "discord.com", "youtube.com", "youtu.be"};
 
         public (string Name, string Path) GetThemeInfoFromIndex(int themeIndex) => clientDefinitionsIni.GetStringValue("Themes", themeIndex.ToString(), ",").Split(',').AsTuple2();
 

--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -260,8 +260,8 @@ namespace ClientCore
 
         public string StatisticsLogFileName => clientDefinitionsIni.GetStringValue(SETTINGS, "StatisticsLogFileName", "DTA.LOG");
 
-        public string TrustedLinksRegExp => clientDefinitionsIni.GetStringValue(SETTINGS, "TrustedLinksRegExp", @"^((http)|(https))((://)|(://www\.))((github\.com)|(moddb\.com))");
-        
+        public string[] TrustedDomains => clientDefinitionsIni.GetStringValue(SETTINGS, "TrustedDomains", string.Empty).Split(',');
+
         public string AlwaysTrustedLinksRegExp = @"^((http)|(https))((://)|(://www\.))((cncnet\.org)|(gamesurge\.net)|(dronebl\.org)|(discord\.com)|(steamcommunity\.com)|(youtube\.com)|(youtu.be))";
 
         public (string Name, string Path) GetThemeInfoFromIndex(int themeIndex) => clientDefinitionsIni.GetStringValue("Themes", themeIndex.ToString(), ",").Split(',').AsTuple2();

--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -260,6 +260,8 @@ namespace ClientCore
 
         public string StatisticsLogFileName => clientDefinitionsIni.GetStringValue(SETTINGS, "StatisticsLogFileName", "DTA.LOG");
 
+        public string TrustedLinksRegExp => clientDefinitionsIni.GetStringValue(SETTINGS, "TrustedLinksRegExp", @"^((http)|(https))((://)|(://www\.))((cncnet\.org)|(discord\.com/invite)|(steamcommunity\.com)|(youtube\.com)|(youtu.be))");
+
         public (string Name, string Path) GetThemeInfoFromIndex(int themeIndex) => clientDefinitionsIni.GetStringValue("Themes", themeIndex.ToString(), ",").Split(',').AsTuple2();
 
         /// <summary>

--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -260,7 +260,9 @@ namespace ClientCore
 
         public string StatisticsLogFileName => clientDefinitionsIni.GetStringValue(SETTINGS, "StatisticsLogFileName", "DTA.LOG");
 
-        public string TrustedLinksRegExp => clientDefinitionsIni.GetStringValue(SETTINGS, "TrustedLinksRegExp", @"^((http)|(https))((://)|(://www\.))((cncnet\.org)|(gamesurge\.net)|(dronebl\.org)|(discord\.com/invite)|(steamcommunity\.com)|(youtube\.com)|(youtu.be))");
+        public string TrustedLinksRegExp => clientDefinitionsIni.GetStringValue(SETTINGS, "TrustedLinksRegExp", @"^((http)|(https))((://)|(://www\.))(github\.com)");
+        
+        public string HardcodeTrustedLinksRegExp = @"^((http)|(https))((://)|(://www\.))((cncnet\.org)|(gamesurge\.net)|(dronebl\.org)|(discord\.com/invite)|(steamcommunity\.com)|(youtube\.com)|(youtu.be))";
 
         public (string Name, string Path) GetThemeInfoFromIndex(int themeIndex) => clientDefinitionsIni.GetStringValue("Themes", themeIndex.ToString(), ",").Split(',').AsTuple2();
 

--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -262,7 +262,7 @@ namespace ClientCore
 
         public string[] TrustedDomains => clientDefinitionsIni.GetStringValue(SETTINGS, "TrustedDomains", string.Empty).Split(',');
 
-        public string AlwaysTrustedLinksRegExp = @"^((http)|(https))((://)|(://www\.))((cncnet\.org)|(mapdb\.cncnet\.org)|(gamesurge\.net)|(dronebl\.org)|(discord\.com)|(steamcommunity\.com)|(youtube\.com)|(youtu.be))";
+        public string[] AlwaysTrustedDomains = {"cncnet.org", "gamesurge.net", "dronebl.com", "discord.com", "youtube.com", "youtu.be"};
 
         public (string Name, string Path) GetThemeInfoFromIndex(int themeIndex) => clientDefinitionsIni.GetStringValue("Themes", themeIndex.ToString(), ",").Split(',').AsTuple2();
 

--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -260,7 +260,7 @@ namespace ClientCore
 
         public string StatisticsLogFileName => clientDefinitionsIni.GetStringValue(SETTINGS, "StatisticsLogFileName", "DTA.LOG");
 
-        public string TrustedLinksRegExp => clientDefinitionsIni.GetStringValue(SETTINGS, "TrustedLinksRegExp", @"^((http)|(https))((://)|(://www\.))((cncnet\.org)|(discord\.com/invite)|(steamcommunity\.com)|(youtube\.com)|(youtu.be))");
+        public string TrustedLinksRegExp => clientDefinitionsIni.GetStringValue(SETTINGS, "TrustedLinksRegExp", @"^((http)|(https))((://)|(://www\.))((cncnet\.org)|(gamesurge\.net)|(dronebl\.org)|(discord\.com/invite)|(steamcommunity\.com)|(youtube\.com)|(youtu.be))");
 
         public (string Name, string Path) GetThemeInfoFromIndex(int themeIndex) => clientDefinitionsIni.GetStringValue("Themes", themeIndex.ToString(), ",").Split(',').AsTuple2();
 

--- a/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
@@ -38,7 +38,8 @@ namespace DTAClient.DXGUI.Multiplayer
             {
                 string domain = new Uri(link).Host;
                 var trustedDomains = ClientConfiguration.Instance.TrustedDomains.Concat(ClientConfiguration.Instance.AlwaysTrustedDomains);
-                if (trustedDomains.Contains(domain) || trustedDomains.Any(trustedDomain => domain.EndsWith("." + trustedDomain)))
+                if (trustedDomains.Contains(domain, StringComparer.InvariantCultureIgnoreCase) ||
+                    trustedDomains.Any(trustedDomain => domain.EndsWith("." + trustedDomain, StringComparison.InvariantCultureIgnoreCase)))
                     isTrusted = true;
             }
             catch (Exception ex)

--- a/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
@@ -16,6 +16,8 @@ namespace DTAClient.DXGUI.Multiplayer
     /// </summary>
     public class ChatListBox : XNAListBox, IMessageView
     {
+        private Regex _regexp = new Regex(ClientConfiguration.Instance.AlwaysTrustedLinksRegExp);
+
         public ChatListBox(WindowManager windowManager) : base(windowManager)
         {
             DoubleLeftClick += ChatListBox_DoubleLeftClick;
@@ -31,8 +33,18 @@ namespace DTAClient.DXGUI.Multiplayer
             if (link == null)
                 return;
 
-            bool regExpResult = new Regex(ClientConfiguration.Instance.AlwaysTrustedLinksRegExp).Match(link).Success ||
-                new Regex(ClientConfiguration.Instance.TrustedLinksRegExp).Match(link).Success;
+            bool regExpResult = _regexp.Match(link).Success;
+
+            foreach (var elem in ClientConfiguration.Instance.TrustedDomains)
+            {
+                if (string.IsNullOrEmpty(elem))
+                    continue;
+
+                regExpResult = regExpResult || link.Contains(elem, StringComparison.CurrentCultureIgnoreCase);
+
+                if (regExpResult)
+                    break;
+            }
 
             if (regExpResult)
             {

--- a/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
@@ -37,11 +37,13 @@ namespace DTAClient.DXGUI.Multiplayer
             try
             {
                 string domain = new Uri(link).Host;
-                if (ClientConfiguration.Instance.TrustedDomains.Contains(domain) || ClientConfiguration.Instance.AlwaysTrustedDomains.Contains(domain))
+                var trustedDomains = ClientConfiguration.Instance.TrustedDomains.Concat(ClientConfiguration.Instance.AlwaysTrustedDomains);
+                if (trustedDomains.Any(trustedDomain => domain.EndsWith(trustedDomain)))
                     isTrusted = true;
             }
             catch (Exception ex)
             {
+                isTrusted = false;
                 Logger.Log($"Error in parsing the URL \"{link}\": {ex.ToString()}");
             }
 

--- a/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
@@ -31,6 +31,15 @@ namespace DTAClient.DXGUI.Multiplayer
             if (link == null)
                 return;
 
+            bool regExpResult = new Regex(ClientConfiguration.Instance.HardcodeTrustedLinksRegExp).Match(link).Success ||
+                new Regex(ClientConfiguration.Instance.TrustedLinksRegExp).Match(link).Success;
+
+            if (regExpResult)
+            {
+                ProcessLink(link);
+                return;
+            }
+
             var msgBox = new XNAMessageBox(WindowManager, 
                 "Open Link Confirmation".L10N("Client:Main:OpenLinkConfirmationTitle"),
                 """
@@ -43,15 +52,7 @@ namespace DTAClient.DXGUI.Multiplayer
                 """.L10N("Client:Main:OpenLinkConfirmationText")
                 + Environment.NewLine + Environment.NewLine + link, 
                 XNAMessageBoxButtons.YesNo);
-            
             msgBox.YesClickedAction = (msgBox) => ProcessLink(link);
-
-            if (new Regex(ClientConfiguration.Instance.TrustedLinksRegExp).Match(link).Success)
-            {
-                ProcessLink(link);
-                return;
-            }
-
             msgBox.Show();
         }
 

--- a/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
@@ -38,9 +38,8 @@ namespace DTAClient.DXGUI.Multiplayer
             {
                 string domain = new Uri(link).Host;
                 var trustedDomains = ClientConfiguration.Instance.TrustedDomains.Concat(ClientConfiguration.Instance.AlwaysTrustedDomains);
-                if (trustedDomains.Contains(domain, StringComparer.InvariantCultureIgnoreCase) ||
-                    trustedDomains.Any(trustedDomain => domain.EndsWith("." + trustedDomain, StringComparison.InvariantCultureIgnoreCase)))
-                    isTrusted = true;
+                isTrusted = trustedDomains.Contains(domain, StringComparer.InvariantCultureIgnoreCase)
+                || trustedDomains.Any(trustedDomain => domain.EndsWith("." + trustedDomain, StringComparison.InvariantCultureIgnoreCase));
             }
             catch (Exception ex)
             {

--- a/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
@@ -21,7 +21,6 @@ namespace DTAClient.DXGUI.Multiplayer
         public ChatListBox(WindowManager windowManager) : base(windowManager)
         {
             DoubleLeftClick += ChatListBox_DoubleLeftClick;
-            MiddleClick += ChatListBox_MiddleClick;
         }
         
         private void ChatListBox_DoubleLeftClick(object sender, EventArgs e)
@@ -72,18 +71,6 @@ namespace DTAClient.DXGUI.Multiplayer
         {
             if (link != null)
                 ProcessLauncher.StartShellProcess(link);
-        }
-
-        private void ChatListBox_MiddleClick(object sender, EventArgs e)
-        {
-            if (SelectedIndex < 0 || SelectedIndex >= Items.Count)
-                return;
-
-            var link = Items[SelectedIndex].Text?.GetLink();
-            if (link == null)
-                return;
-
-            ProcessLauncher.StartShellProcess(link);
         }
 
         public void AddMessage(string message)

--- a/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
@@ -34,10 +34,15 @@ namespace DTAClient.DXGUI.Multiplayer
 
             var msgBox = new XNAMessageBox(WindowManager, 
                 "Open Link Confirmation".L10N("Client:Main:OpenLinkConfirmationTitle"),
-                string.Format(("You are trying to open an unchecked link from the online chat.\n" +
-                               "CnCNet is not responsible for the content on the site to which the link leads.\n" +
-                               "Would you like to open the following link in a browser?\n\n" +
-                               "Link: {0}").L10N("Client:Main:OpenLinkConfirmationText"), link), 
+                """
+                You're about to open a link shared in chat.
+
+                Please note that this link hasn't been verified,
+                and CnCNet is not responsible for its content.
+
+                Would you like to open the following link in your browser?
+                """.L10N("Client:Main:OpenLinkConfirmationText")
+                + Environment.NewLine + Environment.NewLine + link, 
                 XNAMessageBoxButtons.YesNo);
             msgBox.YesClickedAction = OpenLinkConfirmation_YesClicked;
 

--- a/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
@@ -31,7 +31,7 @@ namespace DTAClient.DXGUI.Multiplayer
             if (link == null)
                 return;
 
-            bool regExpResult = new Regex(ClientConfiguration.Instance.HardcodeTrustedLinksRegExp).Match(link).Success ||
+            bool regExpResult = new Regex(ClientConfiguration.Instance.AlwaysTrustedLinksRegExp).Match(link).Success ||
                 new Regex(ClientConfiguration.Instance.TrustedLinksRegExp).Match(link).Success;
 
             if (regExpResult)

--- a/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
@@ -3,6 +3,7 @@ using Rampastring.XNAUI;
 using DTAClient.Online;
 using Microsoft.Xna.Framework;
 using System;
+using System.Text.RegularExpressions;
 using ClientCore;
 using ClientCore.Extensions;
 using ClientGUI;
@@ -38,14 +39,27 @@ namespace DTAClient.DXGUI.Multiplayer
                                "Would you like to open the following link in a browser?\n\n" +
                                "Link: {0}").L10N("Client:Main:OpenLinkConfirmationText"), link), 
                 XNAMessageBoxButtons.YesNo);
-            msgBox.Show();
             msgBox.YesClickedAction = OpenLinkConfirmation_YesClicked;
+
+            if (new Regex(ClientConfiguration.Instance.TrustedLinksRegExp).Match(link).Success)
+            {
+                ProcessLink();
+                return;
+            }
+
+            msgBox.Show();
         }
 
         private void OpenLinkConfirmation_YesClicked(XNAMessageBox messageBox)
+            => ProcessLink();
+
+        private void ProcessLink()
         {
-            ProcessLauncher.StartShellProcess(link);
-            link = null;
+            if (link != null)
+            {
+                ProcessLauncher.StartShellProcess(link);
+                link = null;
+            }
         }
 
         private void ChatListBox_MiddleClick(object sender, EventArgs e)

--- a/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
@@ -33,7 +33,10 @@ namespace DTAClient.DXGUI.Multiplayer
 
             var msgBox = new XNAMessageBox(WindowManager, 
                 "Open Link Confirmation".L10N("Client:Main:OpenLinkConfirmationTitle"),
-                string.Format("Would you like to view the following website in a browser?\n{0}".L10N("Client:Main:OpenLinkConfirmationText"), link), 
+                string.Format(("You are trying to open an unchecked link from the online chat.\n" +
+                               "CnCNet is not responsible for the content on the site to which the link leads.\n" +
+                               "Would you like to open the following link in a browser?\n\n" +
+                               "Link: {0}").L10N("Client:Main:OpenLinkConfirmationText"), link), 
                 XNAMessageBoxButtons.YesNo);
             msgBox.Show();
             msgBox.YesClickedAction = OpenLinkConfirmation_YesClicked;

--- a/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
@@ -38,7 +38,7 @@ namespace DTAClient.DXGUI.Multiplayer
             {
                 string domain = new Uri(link).Host;
                 var trustedDomains = ClientConfiguration.Instance.TrustedDomains.Concat(ClientConfiguration.Instance.AlwaysTrustedDomains);
-                if (trustedDomains.Any(trustedDomain => domain.EndsWith(trustedDomain)))
+                if (trustedDomains.Contains(domain) || trustedDomains.Any(trustedDomain => domain.EndsWith("." + trustedDomain)))
                     isTrusted = true;
             }
             catch (Exception ex)

--- a/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
@@ -7,6 +7,7 @@ using System.Text.RegularExpressions;
 using ClientCore;
 using ClientCore.Extensions;
 using ClientGUI;
+using System.Linq;
 
 namespace DTAClient.DXGUI.Multiplayer
 {
@@ -33,24 +34,14 @@ namespace DTAClient.DXGUI.Multiplayer
                 return;
 
             bool result = false;
+            string linkDomain = domainExtractRegExp.Match(link).Groups[0].Value;
 
-            foreach (var elem in ClientConfiguration.Instance.AlwaysTrustedDomains)
+            foreach (var elem in ClientConfiguration.Instance.TrustedDomains.ToList().Concat(ClientConfiguration.Instance.AlwaysTrustedDomains))
             {
                 if (string.IsNullOrEmpty(elem))
                     continue;
 
-                result = result || link.Contains(elem, StringComparison.CurrentCultureIgnoreCase);
-
-                if (result)
-                    break;
-            }
-
-            foreach (var elem in ClientConfiguration.Instance.TrustedDomains)
-            {
-                if (string.IsNullOrEmpty(elem))
-                    continue;
-
-                result = result || domainExtractRegExp.Match(link).Groups[0].Value.Contains(elem, StringComparison.CurrentCultureIgnoreCase);
+                result = result || linkDomain.Contains(elem, StringComparison.CurrentCultureIgnoreCase);
 
                 if (result)
                     break;

--- a/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
@@ -39,7 +39,7 @@ namespace DTAClient.DXGUI.Multiplayer
                 string domain = new Uri(link).Host;
                 var trustedDomains = ClientConfiguration.Instance.TrustedDomains.Concat(ClientConfiguration.Instance.AlwaysTrustedDomains);
                 isTrusted = trustedDomains.Contains(domain, StringComparer.InvariantCultureIgnoreCase)
-                || trustedDomains.Any(trustedDomain => domain.EndsWith("." + trustedDomain, StringComparison.InvariantCultureIgnoreCase));
+                    || trustedDomains.Any(trustedDomain => domain.EndsWith("." + trustedDomain, StringComparison.InvariantCultureIgnoreCase));
             }
             catch (Exception ex)
             {

--- a/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
@@ -5,6 +5,7 @@ using Microsoft.Xna.Framework;
 using System;
 using ClientCore;
 using ClientCore.Extensions;
+using ClientGUI;
 
 namespace DTAClient.DXGUI.Multiplayer
 {
@@ -14,9 +15,11 @@ namespace DTAClient.DXGUI.Multiplayer
     /// </summary>
     public class ChatListBox : XNAListBox, IMessageView
     {
+        private string? link = null;
         public ChatListBox(WindowManager windowManager) : base(windowManager)
         {
             DoubleLeftClick += ChatListBox_DoubleLeftClick;
+            MiddleClick += ChatListBox_MiddleClick;
         }
 
         private void ChatListBox_DoubleLeftClick(object sender, EventArgs e)
@@ -24,11 +27,35 @@ namespace DTAClient.DXGUI.Multiplayer
             if (SelectedIndex < 0 || SelectedIndex >= Items.Count)
                 return;
 
-            var link = Items[SelectedIndex].Text?.GetLink();
+            link = Items[SelectedIndex].Text?.GetLink();
+            if (link == null)
+                return;
+
+            var msgBox = new XNAMessageBox(WindowManager, 
+                "Open Link Confirmation".L10N("Client:Main:OpenLinkConfirmationTitle"),
+                string.Format("Would you like to view the following website in a browser?\n{0}".L10N("Client:Main:OpenLinkConfirmationText"), link), 
+                XNAMessageBoxButtons.YesNo);
+            msgBox.Show();
+            msgBox.YesClickedAction = OpenLinkConfirmation_YesClicked;
+        }
+
+        private void OpenLinkConfirmation_YesClicked(XNAMessageBox messageBox)
+        {
+            ProcessLauncher.StartShellProcess(link);
+            link = null;
+        }
+
+        private void ChatListBox_MiddleClick(object sender, EventArgs e)
+        {
+            if (SelectedIndex < 0 || SelectedIndex >= Items.Count)
+                return;
+
+            link = Items[SelectedIndex].Text?.GetLink();
             if (link == null)
                 return;
 
             ProcessLauncher.StartShellProcess(link);
+            link = null;
         }
 
         public void AddMessage(string message)

--- a/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
@@ -16,19 +16,18 @@ namespace DTAClient.DXGUI.Multiplayer
     /// </summary>
     public class ChatListBox : XNAListBox, IMessageView
     {
-        private string? link = null;
         public ChatListBox(WindowManager windowManager) : base(windowManager)
         {
             DoubleLeftClick += ChatListBox_DoubleLeftClick;
             MiddleClick += ChatListBox_MiddleClick;
         }
-
+        
         private void ChatListBox_DoubleLeftClick(object sender, EventArgs e)
         {
             if (SelectedIndex < 0 || SelectedIndex >= Items.Count)
                 return;
 
-            link = Items[SelectedIndex].Text?.GetLink();
+            var link = Items[SelectedIndex].Text?.GetLink();
             if (link == null)
                 return;
 
@@ -44,27 +43,22 @@ namespace DTAClient.DXGUI.Multiplayer
                 """.L10N("Client:Main:OpenLinkConfirmationText")
                 + Environment.NewLine + Environment.NewLine + link, 
                 XNAMessageBoxButtons.YesNo);
-            msgBox.YesClickedAction = OpenLinkConfirmation_YesClicked;
+            
+            msgBox.YesClickedAction = (msgBox) => ProcessLink(link);
 
             if (new Regex(ClientConfiguration.Instance.TrustedLinksRegExp).Match(link).Success)
             {
-                ProcessLink();
+                ProcessLink(link);
                 return;
             }
 
             msgBox.Show();
         }
 
-        private void OpenLinkConfirmation_YesClicked(XNAMessageBox messageBox)
-            => ProcessLink();
-
-        private void ProcessLink()
+        private void ProcessLink(string link)
         {
             if (link != null)
-            {
                 ProcessLauncher.StartShellProcess(link);
-                link = null;
-            }
         }
 
         private void ChatListBox_MiddleClick(object sender, EventArgs e)
@@ -72,12 +66,11 @@ namespace DTAClient.DXGUI.Multiplayer
             if (SelectedIndex < 0 || SelectedIndex >= Items.Count)
                 return;
 
-            link = Items[SelectedIndex].Text?.GetLink();
+            var link = Items[SelectedIndex].Text?.GetLink();
             if (link == null)
                 return;
 
             ProcessLauncher.StartShellProcess(link);
-            link = null;
         }
 
         public void AddMessage(string message)

--- a/Docs/INISystem.md
+++ b/Docs/INISystem.md
@@ -505,3 +505,16 @@ Children of [XNAWindow](https://github.com/CnCNet/xna-cncnet-client/blob/develop
 RandomBackgroundTextures=  ; comma-separated list of strings,
                            ; paths of files to use randomly as BackgroundTexture
 ```
+
+# Global Config Files
+
+## [ClientDefinition](https://github.com/CnCNet/xna-cncnet-client/blob/develop/ClientCore/ClientConfiguration.cs)
+
+The `ClientDefinitions.ini` file defines the client's global settings, including the game type, recommended resolutions and the executable file used to launch the game.
+
+```ini
+; ClientDefinitions.ini
+[Settings]
+TrustedLinksRegExp=  ; regular expression to match links and prevent the message box from appearing before they open by default browser
+                     ; defaults to ^((http)|(https))((://)|(://www\.))((github\.com)|(moddb\.com))
+```

--- a/Docs/INISystem.md
+++ b/Docs/INISystem.md
@@ -515,6 +515,7 @@ The `ClientDefinitions.ini` file defines the client's global settings, including
 ```ini
 ; ClientDefinitions.ini
 [Settings]
-TrustedLinksRegExp=  ; regular expression to match links and prevent the message box from appearing before they open by default browser
-                     ; defaults to ^((http)|(https))((://)|(://www\.))((github\.com)|(moddb\.com))
+TrustedDomains=  ; comma-separated list of strings,
+                 ; domain names to match links and prevent the message box from appearing before they open by default browser
+                 ; example: cncnet.org,github.com,moddb.com
 ```

--- a/Docs/INISystem.md
+++ b/Docs/INISystem.md
@@ -509,11 +509,13 @@ RandomBackgroundTextures=  ; comma-separated list of strings,
 # Global Config Files
 
 ## [ClientDefinition](https://github.com/CnCNet/xna-cncnet-client/blob/develop/ClientCore/ClientConfiguration.cs)
+> [!NOTE]
+> _TODO work in progress_
 
 The `ClientDefinitions.ini` file defines the client's global settings, including the game type, recommended resolutions and the executable file used to launch the game.
 
+In `ClientDefinitions.ini`:
 ```ini
-; ClientDefinitions.ini
 [Settings]
 TrustedDomains=  ; comma-separated list of strings,
                  ; domain names to match links and prevent the message box from appearing before they open by default browser


### PR DESCRIPTION
Changes:

* When a user clicks the left mouse button twice on a message containing a link in a chat, a confirmation window appears asking if they want to open the link in a browser;
* ~~When the middle mouse button is clicked, the client will instantly open the link.~~

Example:

![image](https://github.com/user-attachments/assets/9f5a96d2-423b-4577-93d9-fe9d16182b0d)

Reference (Funky's client):

![image](https://github.com/user-attachments/assets/317fb9cd-04d6-4d3a-9515-48d7058ad125)

To Do:

- [x] Add feature to ignore confirmation window if link is trusted
- [x] Add links configurable from `ClientDefinitions.ini` like regexp
- [x] Edit confirmation window message text to something like `msg\n\nLink: {0}`
- [x] Add to confirmation window message text about warning that posted links aren't moderated
- [x] Think about how to delete `private string? link`