### PR TITLE
Possible fix for channel already exists error

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
@@ -938,6 +938,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 gameChannel.UserAdded += GameLoadingChannel_UserAdded;
                 //gameChannel.MessageAdded += GameLoadingChannel_MessageAdded;
                 gameChannel.InvalidPasswordEntered += GameChannel_InvalidPasswordEntered_LoadedGame;
+                isJoiningGame = false;
             }
             else
             {
@@ -951,8 +952,6 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
             connectionManager.SendCustomMessage(new QueuedMessage("JOIN " + hg.ChannelName + " " + password,
                 QueuedMessageType.INSTANT_MESSAGE, 0));
-
-            isJoiningGame = false;
         }
 
         private void GameChannel_TargetChangeTooFast(object sender, MessageEventArgs e)


### PR DESCRIPTION
In my previous PR for loaded game lobby fixups, I set isJoiningGame=false; at the end of _JoinGame.
That makes GetJoinGameErrorBase return nothing, which normally isn't a problem, but the XNAListbox fires a DoubleClick event twice if three clicks happen in short succession, which means you get two join attempts with the second one erroring out with "Channel already exists".

This PR should fix it for regular games. Loaded game lobbies would need some more testing.