### PR TITLE
Add AssemblyTitle to the main client executable

### DIFF
--- a/DXMainClient/DXMainClient.csproj
+++ b/DXMainClient/DXMainClient.csproj
@@ -6,7 +6,8 @@
     <Prefer32Bit Condition="'$(Engine)' == 'WindowsXNA' And '$(TargetFrameworkIdentifier)' == '.NETFramework'">true</Prefer32Bit>
     <UseAppHost>false</UseAppHost>
     <SelfContained>false</SelfContained>
-    <Description>CnCNet Main Client Library</Description>
+    <Description>CnCNet Main Client</Description>
+    <AssemblyTitle>CnCNet Client</AssemblyTitle>
     <RootNamespace>DTAClient</RootNamespace>
     <ApplicationIcon>clienticon.ico</ApplicationIcon>
     <ApplicationHighDpiMode Condition="'$(Engine)' == 'UniversalGL' OR '$(Engine)' == 'WindowsGL'">SystemAware</ApplicationHighDpiMode>


### PR DESCRIPTION
To display a friendly name "CnCNet Client" in Windows task manager, like the old client build does.

Before:
![图片](https://github.com/user-attachments/assets/9ce036f6-0995-4602-8660-ab6764ba3c90)

Now:

![图片](https://github.com/user-attachments/assets/9d9274f8-0904-4032-9c18-9df15d1ccb1b)
