### PR TITLE
Handle multiple links in chat message

### DIFF
--- a/ClientCore/Extensions/StringExtensions.cs
+++ b/ClientCore/Extensions/StringExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.RegularExpressions;
 using System.Collections.Generic;
 
 using ClientCore.I18N;
@@ -7,22 +8,23 @@ namespace ClientCore.Extensions;
 
 public static class StringExtensions
 {
-    public static string GetLink(this string text)
+    private static Regex extractLinksRE = new Regex(@"((http[s]?)|(ftp))\S+");
+
+    public static string[] GetLinks(this string text)
     {
         if (string.IsNullOrWhiteSpace(text))
             return null;
 
-        int index = text.IndexOf("http://", StringComparison.Ordinal);
-        if (index == -1)
-            index = text.IndexOf("ftp://", StringComparison.Ordinal);
-        if (index == -1)
-            index = text.IndexOf("https://", StringComparison.Ordinal);
+        var matches = extractLinksRE.Matches(text);
 
-        if (index == -1)
+        if (matches.Count == 0)
             return null; // No link found
 
-        string link = text.Substring(index);
-        return link.Split(' ')[0]; // Nuke any words coming after the link
+        string[] links = new string[matches.Count];
+        for (int i = 0; i < links.Length; i++)
+            links[i] = matches[i].Value.Trim();
+            
+        return links;
     }
 
     private const string ESCAPED_INI_NEWLINE_PATTERN = $"\\{ProgramConstants.INI_NEWLINE_PATTERN}";

--- a/DXMainClient/DXGUI/Generic/URLHandler.cs
+++ b/DXMainClient/DXGUI/Generic/URLHandler.cs
@@ -1,0 +1,60 @@
+﻿#nullable enable
+using System;
+using System.Linq;
+
+using ClientCore;
+using ClientCore.Extensions;
+
+using ClientGUI;
+
+using Rampastring.Tools;
+using Rampastring.XNAUI;
+
+namespace DTAClient.DXGUI.Generic
+{
+    public static class URLHandler
+    {
+        /// <summary>
+        /// Checks whether a URL is safe before opening it, prompting a warning as an XNAMessageBox otherwise.
+        /// </summary>
+        public static void OpenLink(WindowManager wm, string url)
+        {
+            // Determine if the links is trusted
+            bool isTrusted = false;
+            try
+            {
+                string domain = new Uri(url).Host;
+                var trustedDomains = ClientConfiguration.Instance.TrustedDomains.Concat(ClientConfiguration.Instance.AlwaysTrustedDomains);
+                isTrusted = trustedDomains.Contains(domain, StringComparer.InvariantCultureIgnoreCase)
+                    || trustedDomains.Any(trustedDomain => domain.EndsWith("." + trustedDomain, StringComparison.InvariantCultureIgnoreCase));
+            }
+            catch (Exception ex)
+            {
+                isTrusted = false;
+                Logger.Log($"Error in parsing the URL \"{url}\": {ex.ToString()}");
+            }
+
+            if (isTrusted)
+            {
+                ProcessLauncher.StartShellProcess(url);
+                return;
+            }
+
+            // Show the warning if the links is not trusted
+            var msgBox = new XNAMessageBox(wm,
+                "Open Link Confirmation".L10N("Client:Main:OpenLinkConfirmationTitle"),
+                """
+                    You're about to open a link shared in chat.
+
+                    Please note that this link hasn't been verified,
+                    and CnCNet is not responsible for its content.
+
+                    Would you like to open the following link in your browser?
+                    """.L10N("Client:Main:OpenLinkConfirmationText")
+                + Environment.NewLine + Environment.NewLine + url,
+                XNAMessageBoxButtons.YesNo);
+            msgBox.YesClickedAction = (msgBox) => ProcessLauncher.StartShellProcess(url);
+            msgBox.Show();
+        }
+    }
+}

--- a/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
@@ -1,16 +1,12 @@
 ﻿using System;
-using System.Linq;
 
-using ClientCore;
 using ClientCore.Extensions;
 
-using ClientGUI;
-
+using DTAClient.DXGUI.Generic;
 using DTAClient.Online;
 
 using Microsoft.Xna.Framework;
 
-using Rampastring.Tools;
 using Rampastring.XNAUI;
 using Rampastring.XNAUI.XNAControls;
 
@@ -34,57 +30,15 @@ namespace DTAClient.DXGUI.Multiplayer
 
             // Get the clicked links
             string[] links = Items[SelectedIndex].Text?.GetLinks();
-            
-            if (links == null) 
+
+            if (links == null)
                 return;
 
             if (links.Length == 0 || links.Length > 1)
                 return;
 
             string link = links[0];
-
-            // Determine if the links is trusted
-            bool isTrusted = false;
-            try
-            {
-                string domain = new Uri(link).Host;
-                var trustedDomains = ClientConfiguration.Instance.TrustedDomains.Concat(ClientConfiguration.Instance.AlwaysTrustedDomains);
-                isTrusted = trustedDomains.Contains(domain, StringComparer.InvariantCultureIgnoreCase)
-                    || trustedDomains.Any(trustedDomain => domain.EndsWith("." + trustedDomain, StringComparison.InvariantCultureIgnoreCase));
-            }
-            catch (Exception ex)
-            {
-                isTrusted = false;
-                Logger.Log($"Error in parsing the URL \"{link}\": {ex.ToString()}");
-            }
-
-            if (isTrusted)
-            {
-                ProcessLink(link);
-                return;
-            }
-
-            // Show the warning if the links is not trusted
-            var msgBox = new XNAMessageBox(WindowManager,
-                "Open Link Confirmation".L10N("Client:Main:OpenLinkConfirmationTitle"),
-                """
-                    You're about to open a link shared in chat.
-
-                    Please note that this link hasn't been verified,
-                    and CnCNet is not responsible for its content.
-
-                    Would you like to open the following link in your browser?
-                    """.L10N("Client:Main:OpenLinkConfirmationText")
-                + Environment.NewLine + Environment.NewLine + link,
-                XNAMessageBoxButtons.YesNo);
-            msgBox.YesClickedAction = (msgBox) => ProcessLink(link);
-            msgBox.Show();
-        }
-
-        private void ProcessLink(string link)
-        {
-            if (link != null)
-                ProcessLauncher.StartShellProcess(link);
+            URLHandler.OpenLink(WindowManager, link);
         }
 
         public void AddMessage(string message)

--- a/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
@@ -27,47 +27,50 @@ namespace DTAClient.DXGUI.Multiplayer
             if (SelectedIndex < 0 || SelectedIndex >= Items.Count)
                 return;
 
-            // Get the clicked link
-            string link = Items[SelectedIndex].Text?.GetLink();
-            if (link == null)
+            // Get the clicked links
+            string[] links = Items[SelectedIndex].Text?.GetLinks();
+            if (links == null)
                 return;
 
-            // Determine if the link is trusted
-            bool isTrusted = false;
-            try
+            foreach (string link in links)
             {
-                string domain = new Uri(link).Host;
-                var trustedDomains = ClientConfiguration.Instance.TrustedDomains.Concat(ClientConfiguration.Instance.AlwaysTrustedDomains);
-                isTrusted = trustedDomains.Contains(domain, StringComparer.InvariantCultureIgnoreCase)
-                    || trustedDomains.Any(trustedDomain => domain.EndsWith("." + trustedDomain, StringComparison.InvariantCultureIgnoreCase));
+                // Determine if the links is trusted
+                bool isTrusted = false;
+                try
+                {
+                    string domain = new Uri(link).Host;
+                    var trustedDomains = ClientConfiguration.Instance.TrustedDomains.Concat(ClientConfiguration.Instance.AlwaysTrustedDomains);
+                    isTrusted = trustedDomains.Contains(domain, StringComparer.InvariantCultureIgnoreCase)
+                        || trustedDomains.Any(trustedDomain => domain.EndsWith("." + trustedDomain, StringComparison.InvariantCultureIgnoreCase));
+                }
+                catch (Exception ex)
+                {
+                    isTrusted = false;
+                    Logger.Log($"Error in parsing the URL \"{link}\": {ex.ToString()}");
+                }
+
+                if (isTrusted)
+                {
+                    ProcessLink(link);
+                    continue;
+                }
+
+                // Show the warning if the links is not trusted
+                var msgBox = new XNAMessageBox(WindowManager,
+                    "Open Link Confirmation".L10N("Client:Main:OpenLinkConfirmationTitle"),
+                    """
+                    You're about to open a link shared in chat.
+
+                    Please note that this link hasn't been verified,
+                    and CnCNet is not responsible for its content.
+
+                    Would you like to open the following link in your browser?
+                    """.L10N("Client:Main:OpenLinkConfirmationText")
+                    + Environment.NewLine + Environment.NewLine + link,
+                    XNAMessageBoxButtons.YesNo);
+                msgBox.YesClickedAction = (msgBox) => ProcessLink(link);
+                msgBox.Show();
             }
-            catch (Exception ex)
-            {
-                isTrusted = false;
-                Logger.Log($"Error in parsing the URL \"{link}\": {ex.ToString()}");
-            }
-
-            if (isTrusted)
-            {
-                ProcessLink(link);
-                return;
-            }
-
-            // Show the warning if the link is not trusted
-            var msgBox = new XNAMessageBox(WindowManager,
-                "Open Link Confirmation".L10N("Client:Main:OpenLinkConfirmationTitle"),
-                """
-                You're about to open a link shared in chat.
-
-                Please note that this link hasn't been verified,
-                and CnCNet is not responsible for its content.
-
-                Would you like to open the following link in your browser?
-                """.L10N("Client:Main:OpenLinkConfirmationText")
-                + Environment.NewLine + Environment.NewLine + link,
-                XNAMessageBoxButtons.YesNo);
-            msgBox.YesClickedAction = (msgBox) => ProcessLink(link);
-            msgBox.Show();
         }
 
         private void ProcessLink(string link)

--- a/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/ChatListBox.cs
@@ -14,8 +14,6 @@ using Rampastring.Tools;
 using Rampastring.XNAUI;
 using Rampastring.XNAUI.XNAControls;
 
-using static System.Windows.Forms.LinkLabel;
-
 namespace DTAClient.DXGUI.Multiplayer
 {
     /// <summary>

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/GlobalContextMenu.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/GlobalContextMenu.cs
@@ -1,14 +1,21 @@
 ﻿using System;
 using System.Linq;
+
 using ClientCore;
 using ClientCore.Extensions;
+
 using ClientGUI;
+
+using DTAClient.DXGUI.Generic;
 using DTAClient.Online;
 using DTAClient.Online.EventArguments;
+
 using Microsoft.Xna.Framework;
+
 using Rampastring.Tools;
 using Rampastring.XNAUI;
 using Rampastring.XNAUI.XNAControls;
+
 using TextCopy;
 
 namespace DTAClient.DXGUI.Multiplayer.CnCNet
@@ -170,44 +177,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 var openLinkItem = new XNAContextMenuItem()
                 {
                     Text = $"{OPEN_LINK} {linkToDisplay}",
-                    SelectAction = () =>
-                    {
-                        bool isTrusted = false;
-                        try
-                        {
-                            string domain = new Uri(link).Host;
-                            var trustedDomains = ClientConfiguration.Instance.TrustedDomains.Concat(ClientConfiguration.Instance.AlwaysTrustedDomains);
-                            isTrusted = trustedDomains.Contains(domain, StringComparer.InvariantCultureIgnoreCase)
-                                || trustedDomains.Any(trustedDomain => domain.EndsWith("." + trustedDomain, StringComparison.InvariantCultureIgnoreCase));
-                        }
-                        catch (Exception ex)
-                        {
-                            isTrusted = false;
-                            Logger.Log($"Error in parsing the URL \"{link}\": {ex.ToString()}");
-                        }
-
-                        if (isTrusted)
-                        {
-                            ProcessLauncher.StartShellProcess(link);
-                            return;
-                        }
-
-                        // Show the warning if the links is not trusted
-                        var msgBox = new XNAMessageBox(WindowManager,
-                        "Open Link Confirmation".L10N("Client:Main:OpenLinkConfirmationTitle"),
-                        """
-                        You're about to open a link shared in chat.
-
-                        Please note that this link hasn't been verified,
-                        and CnCNet is not responsible for its content.
-
-                        Would you like to open the following link in your browser?
-                        """.L10N("Client:Main:OpenLinkConfirmationText")
-                        + Environment.NewLine + Environment.NewLine + link,
-                        XNAMessageBoxButtons.YesNo);
-                        msgBox.YesClickedAction = (msgBox) => ProcessLauncher.StartShellProcess(link);
-                        msgBox.Show();
-                    }
+                    SelectAction = () => URLHandler.OpenLink(WindowManager, link)
                 };
 
                 AddItem(copyLinkItem);

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/GlobalContextMenu.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/GlobalContextMenu.cs
@@ -194,17 +194,17 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
                         // Show the warning if the links is not trusted
                         var msgBox = new XNAMessageBox(WindowManager,
-                            "Open Link Confirmation".L10N("Client:Main:OpenLinkConfirmationTitle"),
-                            """
-                            You're about to open a link shared in chat.
+                        "Open Link Confirmation".L10N("Client:Main:OpenLinkConfirmationTitle"),
+                        """
+                        You're about to open a link shared in chat.
 
-                            Please note that this link hasn't been verified,
-                            and CnCNet is not responsible for its content.
+                        Please note that this link hasn't been verified,
+                        and CnCNet is not responsible for its content.
 
-                            Would you like to open the following link in your browser?
-                            """.L10N("Client:Main:OpenLinkConfirmationText")
-                            + Environment.NewLine + Environment.NewLine + link,
-                            XNAMessageBoxButtons.YesNo);
+                        Would you like to open the following link in your browser?
+                        """.L10N("Client:Main:OpenLinkConfirmationText")
+                        + Environment.NewLine + Environment.NewLine + link,
+                        XNAMessageBoxButtons.YesNo);
                         msgBox.YesClickedAction = (msgBox) => ProcessLauncher.StartShellProcess(link);
                         msgBox.Show();
                     }

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/GlobalContextMenu.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/GlobalContextMenu.cs
@@ -223,7 +223,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             }
             catch (Exception)
             {
-                XNAMessageBox.Show(WindowManager, "Error".L10N("Client:Main:Error"), "Unable to copy links".L10N("Client:Main:ClipboardCopyLinkFailed"));
+                XNAMessageBox.Show(WindowManager, "Error".L10N("Client:Main:Error"), "Unable to copy link".L10N("Client:Main:ClipboardCopyLinkFailed"));
             }
         }
 

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/GlobalContextMenu.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/GlobalContextMenu.cs
@@ -180,8 +180,8 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                     SelectAction = () => URLHandler.OpenLink(WindowManager, link)
                 };
 
-                AddItem(copyLinkItem);
                 AddItem(openLinkItem);
+                AddItem(copyLinkItem);
             }
         }
 

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/GlobalContextMenu.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/GlobalContextMenu.cs
@@ -169,7 +169,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
                 var openLinkItem = new XNAContextMenuItem()
                 {
-                    Text = string.Format("{0} {1}", OPEN_LINK, linkToDisplay),
+                    Text = $"{OPEN_LINK} {linkToDisplay}",
                     SelectAction = () =>
                     {
                         bool isTrusted = false;

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/GlobalContextMenu.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/GlobalContextMenu.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 using ClientCore;
@@ -48,6 +49,8 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
         public EventHandler<JoinUserEventArgs> JoinEvent;
 
+        private IReadOnlyList<XNAContextMenuItem> DefaultMenuItems = [];
+
         public GlobalContextMenu(
             WindowManager windowManager,
             CnCNetManager connectionManager,
@@ -93,11 +96,10 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 SelectAction = () => JoinEvent?.Invoke(this, new JoinUserEventArgs(GetIrcUser()))
             };
 
-            AddItem(privateMessageItem);
-            AddItem(toggleFriendItem);
-            AddItem(toggleIgnoreItem);
-            AddItem(invitePlayerItem);
-            AddItem(joinPlayerItem);
+            DefaultMenuItems = [privateMessageItem, toggleFriendItem, toggleIgnoreItem, invitePlayerItem, joinPlayerItem];
+
+            foreach (var item in DefaultMenuItems)
+                AddItem(item);
         }
 
         private void Invite()
@@ -149,7 +151,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
         private void UpdateMessageBasedButtons()
         {
-            RemoveLinks();
+            Items = DefaultMenuItems.ToList();
 
             var links = contextMenuData?.ChatMessage?.Message?.GetLinks();
 
@@ -233,19 +235,6 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 return connectionManager.UserList.Find(u => u.Name == contextMenuData.ChatMessage.SenderName);
 
             return null;
-        }
-
-        public void RemoveLinks()
-        {
-            for (int i = 0; i < Items.Count; i++)
-            {
-                if (!(Items[i].Text.Contains(COPY_LINK) || Items[i].Text.Contains(OPEN_LINK)))
-                    continue;
-
-                Items.RemoveAt(i);
-
-                i--;
-            }
         }
 
         public void Show(string playerName, Point cursorPoint)

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/GlobalContextMenu.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/GlobalContextMenu.cs
@@ -163,7 +163,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
                 var copyLinkItem = new XNAContextMenuItem()
                 {
-                    Text = string.Format("{0} {1}", COPY_LINK, linkToDisplay),
+                    Text = $"{COPY_LINK} {linkToDisplay}",
                     SelectAction = () => CopyLink(link)
                 };
 

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/GlobalContextMenu.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/GlobalContextMenu.cs
@@ -141,18 +141,12 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
         private void UpdateMessageBasedButtons()
         {
+            RemoveLinks();
+
             var links = contextMenuData?.ChatMessage?.Message?.GetLinks();
 
             if (links == null)
             {
-                for (int i = 0; i < Items.Count; i++)
-                {
-                    if (!(Items[i].Text.Contains(COPY_LINK) || Items[i].Text.Contains(OPEN_LINK)))
-                        continue;
-
-                    i--;
-                }
-
                 ClientRectangle = STD_SIZE;
                 return;
             }
@@ -231,6 +225,19 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 return connectionManager.UserList.Find(u => u.Name == contextMenuData.ChatMessage.SenderName);
 
             return null;
+        }
+
+        public void RemoveLinks()
+        {
+            for (int i = 0; i < Items.Count; i++)
+            {
+                if (!(Items[i].Text.Contains(COPY_LINK) || Items[i].Text.Contains(OPEN_LINK)))
+                    continue;
+
+                Items.RemoveAt(i);
+
+                i--;
+            }
         }
 
         public void Show(string playerName, Point cursorPoint)

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/GlobalContextMenu.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/GlobalContextMenu.cs
@@ -32,7 +32,11 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
         private readonly string JOIN = "Join".L10N("Client:Main:Join");
         private readonly string COPY_LINK = "Copy Link".L10N("Client:Main:CopyLink");
         private readonly string OPEN_LINK = "Open Link".L10N("Client:Main:OpenLink");
-        private readonly int LINK_LENGTH = 30;
+
+        private readonly int SHORT_LINK_MINIMAL_LENGTH = 40;
+        private readonly int SHORT_LINK_PREFIX_LENGTH = 30;
+        private readonly int SHORT_LINK_SUFFIX_LENGTH = 5;
+
         private readonly Rectangle STD_SIZE = new Rectangle(0, 0, 150, 2);
         private readonly Rectangle LNK_SIZE = new Rectangle(0, 0, 300, 2);
 
@@ -165,7 +169,10 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
             foreach (string link in links)
             {
-                string linkToDisplay = LINK_LENGTH > link.Length ? link.Substring(0, link.Length) : link.Substring(0, LINK_LENGTH) + "...";
+                // Shorten the links if it's too long
+                string linkToDisplay = link;
+                if (link.Length > SHORT_LINK_MINIMAL_LENGTH)
+                    linkToDisplay = link[..SHORT_LINK_PREFIX_LENGTH] + "..." + link[^SHORT_LINK_SUFFIX_LENGTH..];
 
                 if (Items.Where(item => item.Text.Contains(linkToDisplay)).ToList().Count > 0)
                     continue;


### PR DESCRIPTION
New implementation can handle one or more links in single message.

Example: 
![image](https://github.com/user-attachments/assets/af1fc232-4e50-4bba-aa82-8db4eda289a9)

Closes #762