### PR TITLE
Show colors and texts in color drop down

### DIFF
--- a/ClientGUI/XNAClientColorDropDown.cs
+++ b/ClientGUI/XNAClientColorDropDown.cs
@@ -51,7 +51,7 @@ namespace ClientGUI
                             
                             Items.ForEach(item =>
                             {
-                                if (!item.Text.Contains("Random".L10N("Client:Main:RandomColor")))
+                                if (Items[0] != item)
                                     item.Texture = AssetLoader.CreateTexture(
                                         item.TextColor ?? Color.White,
                                         ColorTextureWidth,
@@ -78,10 +78,7 @@ namespace ClientGUI
                     break;
                 case nameof(RandomColorTexture):
                     RandomColorTexture = AssetLoader.LoadTexture(value);
-                    Items
-                        .Where(item => item.Text.Contains("Random".L10N("Client:Main:RandomColor")))
-                        .ToList()
-                        .ForEach(item => item.Texture = RandomColorTexture);
+                    Items[0].Texture = RandomColorTexture;
                     break;
                 default:
                     base.ParseControlINIAttribute(iniFile, key, value);
@@ -96,7 +93,7 @@ namespace ClientGUI
             item.Text = text;
             item.TextColor = color;
 
-            if (!text.Contains("Random".L10N("Client:Main:RandomColor")))
+            if (Items.Count > 1)
                 item.Texture = AssetLoader.CreateTexture(color, ColorTextureWidth, ColorTextureHeigth);
             else
                 item.Texture = RandomColorTexture;

--- a/ClientGUI/XNAClientColorDropDown.cs
+++ b/ClientGUI/XNAClientColorDropDown.cs
@@ -10,7 +10,7 @@ using Rampastring.XNAUI.XNAControls;
 
 namespace ClientGUI
 {
-    public class XNAColorDropDown : XNAClientDropDown
+    public class XNAClientColorDropDown : XNAClientDropDown
     {
         private const int VERTICAL_PADDING = 3;
         private const int HORIZONTAL_PADDING = 2;
@@ -21,7 +21,7 @@ namespace ClientGUI
         public Texture2D RandomColorTexture { get; private set; }
         public Texture2D DisabledItemTexture { get; private set; }
 
-        public XNAColorDropDown(WindowManager windowManager) : base(windowManager) 
+        public XNAClientColorDropDown(WindowManager windowManager) : base(windowManager) 
         {
             ColorTextureWidth = Height - VERTICAL_PADDING;
             ColorTextureHeigth = Height - HORIZONTAL_PADDING;

--- a/ClientGUI/XNAClientColorDropDown.cs
+++ b/ClientGUI/XNAClientColorDropDown.cs
@@ -1,6 +1,4 @@
-﻿using System.Linq;
-
-using ClientCore.Extensions;
+﻿using ClientCore.Extensions;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
@@ -17,16 +15,16 @@ namespace ClientGUI
         public ItemsKind ItemsDrawMode { get; private set; } = ItemsKind.TextAndIcon;
 
         public int ColorTextureWidth { get; private set; }
-        public int ColorTextureHeigth { get; private set; }
+        public int ColorTextureHeight { get; private set; }
         public Texture2D RandomColorTexture { get; private set; }
         public Texture2D DisabledItemTexture { get; private set; }
 
         public XNAClientColorDropDown(WindowManager windowManager) : base(windowManager) 
         {
             ColorTextureWidth = Height - VERTICAL_PADDING;
-            ColorTextureHeigth = Height - HORIZONTAL_PADDING;
+            ColorTextureHeight = Height - HORIZONTAL_PADDING;
             RandomColorTexture = AssetLoader.LoadTexture("randomicon.png");
-            DisabledItemTexture = AssetLoader.CreateTexture(DisabledItemColor, ColorTextureWidth, ColorTextureHeigth);
+            DisabledItemTexture = AssetLoader.CreateTexture(DisabledItemColor, ColorTextureWidth, ColorTextureHeight);
         }
 
         protected override void ParseControlINIAttribute(IniFile iniFile, string key, string value)
@@ -47,7 +45,7 @@ namespace ClientGUI
                             break;
                         case ItemsKind.Icon:
                             ColorTextureWidth = Width - VERTICAL_PADDING;
-                            ColorTextureHeigth = Height - HORIZONTAL_PADDING;
+                            ColorTextureHeight = Height - HORIZONTAL_PADDING;
                             
                             Items.ForEach(item =>
                             {
@@ -55,7 +53,7 @@ namespace ClientGUI
                                     item.Texture = AssetLoader.CreateTexture(
                                         item.TextColor ?? Color.White,
                                         ColorTextureWidth,
-                                        ColorTextureHeigth);
+                                        ColorTextureHeight);
 
                                 item.Text = string.Empty;
                             });
@@ -73,8 +71,8 @@ namespace ClientGUI
                 case nameof(ColorTextureWidth):
                     ColorTextureWidth = Conversions.IntFromString(value, ColorTextureWidth);
                     break;
-                case nameof(ColorTextureHeigth):
-                    ColorTextureHeigth = Conversions.IntFromString(value, ColorTextureHeigth);
+                case nameof(ColorTextureHeight):
+                    ColorTextureHeight = Conversions.IntFromString(value, ColorTextureHeight);
                     break;
                 case nameof(RandomColorTexture):
                     RandomColorTexture = AssetLoader.LoadTexture(value);
@@ -94,7 +92,7 @@ namespace ClientGUI
             item.TextColor = color;
 
             if (Items.Count > 1)
-                item.Texture = AssetLoader.CreateTexture(color, ColorTextureWidth, ColorTextureHeigth);
+                item.Texture = AssetLoader.CreateTexture(color, ColorTextureWidth, ColorTextureHeight);
             else
                 item.Texture = RandomColorTexture;
 

--- a/ClientGUI/XNAColorDropDown.cs
+++ b/ClientGUI/XNAColorDropDown.cs
@@ -13,7 +13,7 @@ namespace ClientGUI
     public class XNAColorDropDown : XNAClientDropDown
     {
         private const int PADDING = 3;
-        public ItemsKind ItemsDrawMode { get; set; } = ItemsKind.Text;
+        public ItemsKind ItemsDrawMode { get; set; } = ItemsKind.TextAndIcon;
 
         public int ColorTextureWidth;
         public int ColorTextureHeigth;
@@ -53,8 +53,11 @@ namespace ClientGUI
 
                                 item.Text = string.Empty;
                             });
+                            FixLastItemLength();
+
                             break;
                         case ItemsKind.TextAndIcon:
+                            break;
                         default:
                             break;
                     }
@@ -92,6 +95,16 @@ namespace ClientGUI
                 item.Texture = RandomColorTexture;
 
             Items.Add(item);
+        }
+
+        public void FixLastItemLength(int _padding = 2)
+        {
+            var lastItem = Items[Items.Count - 1];
+            lastItem.Texture = AssetLoader.CreateTexture(
+                        lastItem.TextColor ?? AssetLoader.GetColorFromString("255,255,255"),
+                        lastItem.Texture.Width,
+                        lastItem.Texture.Height - _padding);
+            Items[Items.Count - 1] = lastItem;
         }
 
         public enum ItemsKind

--- a/ClientGUI/XNAColorDropDown.cs
+++ b/ClientGUI/XNAColorDropDown.cs
@@ -12,18 +12,21 @@ namespace ClientGUI
 {
     public class XNAColorDropDown : XNAClientDropDown
     {
-        private const int PADDING = 3;
-        public ItemsKind ItemsDrawMode { get; set; } = ItemsKind.TextAndIcon;
+        private const int VERTICAL_PADDING = 3;
+        private const int HORIZONTAL_PADDING = 2;
+        public ItemsKind ItemsDrawMode { get; private set; } = ItemsKind.TextAndIcon;
 
-        public int ColorTextureWidth;
-        public int ColorTextureHeigth;
+        public int ColorTextureWidth { get; private set; }
+        public int ColorTextureHeigth { get; private set; }
         public Texture2D RandomColorTexture { get; private set; }
+        public Texture2D DisabledItemTexture { get; private set; }
 
         public XNAColorDropDown(WindowManager windowManager) : base(windowManager) 
         {
-            ColorTextureWidth = Height - PADDING;
-            ColorTextureHeigth = Height - PADDING;
+            ColorTextureWidth = Height - VERTICAL_PADDING;
+            ColorTextureHeigth = Height - HORIZONTAL_PADDING;
             RandomColorTexture = AssetLoader.LoadTexture("randomicon.png");
+            DisabledItemTexture = AssetLoader.CreateTexture(DisabledItemColor, ColorTextureWidth, ColorTextureHeigth);
         }
 
         protected override void ParseControlINIAttribute(IniFile iniFile, string key, string value)
@@ -43,17 +46,21 @@ namespace ClientGUI
                             });
                             break;
                         case ItemsKind.Icon:
+                            ColorTextureWidth = Width - VERTICAL_PADDING;
+                            ColorTextureHeigth = Height - HORIZONTAL_PADDING;
+                            
                             Items.ForEach(item =>
                             {
                                 if (!item.Text.Contains("Random".L10N("Client:Main:RandomColor")))
                                     item.Texture = AssetLoader.CreateTexture(
-                                        item.TextColor ?? AssetLoader.GetColorFromString("255,255,255"),
-                                        Width - PADDING,
-                                        Height - PADDING);
+                                        item.TextColor ?? Color.White,
+                                        ColorTextureWidth,
+                                        ColorTextureHeigth);
 
                                 item.Text = string.Empty;
                             });
-                            FixLastItemLength();
+                            
+                            DisabledItemTexture = AssetLoader.CreateTexture(DisabledItemColor, Width - VERTICAL_PADDING, Height - HORIZONTAL_PADDING);
 
                             break;
                         case ItemsKind.TextAndIcon:
@@ -95,16 +102,6 @@ namespace ClientGUI
                 item.Texture = RandomColorTexture;
 
             Items.Add(item);
-        }
-
-        public void FixLastItemLength(int _padding = 2)
-        {
-            var lastItem = Items[Items.Count - 1];
-            lastItem.Texture = AssetLoader.CreateTexture(
-                        lastItem.TextColor ?? AssetLoader.GetColorFromString("255,255,255"),
-                        lastItem.Texture.Width,
-                        lastItem.Texture.Height - _padding);
-            Items[Items.Count - 1] = lastItem;
         }
 
         public enum ItemsKind

--- a/ClientGUI/XNAColorDropDown.cs
+++ b/ClientGUI/XNAColorDropDown.cs
@@ -1,0 +1,82 @@
+﻿using ClientCore.Extensions;
+using Microsoft.Xna.Framework;
+using Rampastring.Tools;
+using Rampastring.XNAUI;
+using Rampastring.XNAUI.XNAControls;
+
+namespace ClientGUI
+{
+    public class XNAColorDropDown : XNAClientDropDown
+    {
+        private const int PADDING = 3;
+        public ItemsKind ItemsDrawMode { get; set; } = ItemsKind.Text;
+
+        public int ColorTextureWidth;
+        public int ColorTextureHeigth;
+
+        public XNAColorDropDown(WindowManager windowManager) : base(windowManager) 
+        {
+            ColorTextureWidth = Height - PADDING;
+            ColorTextureHeigth = Height - PADDING;
+        }
+
+        protected override void ParseControlINIAttribute(IniFile iniFile, string key, string value)
+        {
+            if (key == nameof(ItemsDrawMode))
+            {
+                ItemsDrawMode = value.FromIniString().ToEnum<ItemsKind>();
+
+                switch (ItemsDrawMode)
+                {
+                    case ItemsKind.Text:
+                        Items.ForEach(item => 
+                        { 
+                            item.Texture = AssetLoader.CreateTexture(AssetLoader.GetRGBAColorFromString("0,0,0,0"), 1, 1); 
+                        });
+                        break;
+                    case ItemsKind.Icon:
+                        Items.ForEach(item => 
+                        {
+                            if (!item.Text.Contains("Random".L10N("Client:Main:RandomColor")))
+                                item.Texture = AssetLoader.CreateTexture(
+                                    item.TextColor ?? AssetLoader.GetColorFromString("255,255,255"), 
+                                    Width - PADDING, 
+                                    Height - PADDING);
+                            
+                            item.Text = string.Empty;
+                        });
+                        break;
+                    case ItemsKind.TextAndIcon:
+                    default:
+                        break;
+                }
+
+                return;
+            }
+
+            base.ParseControlINIAttribute(iniFile, key, value);
+        }
+
+        public new virtual void AddItem(string text, Color color)
+        {
+            var item = new XNADropDownItem();
+
+            item.Text = text;
+            item.TextColor = color;
+
+            if (!text.Contains("Random".L10N("Client:Main:RandomColor")))
+                item.Texture = AssetLoader.CreateTexture(color, ColorTextureWidth, ColorTextureHeigth);
+            else
+                item.Texture = AssetLoader.LoadTexture("randomicon.png");
+
+            Items.Add(item);
+        }
+
+        public enum ItemsKind
+        {
+            Text,
+            Icon,
+            TextAndIcon
+        }
+    }
+}

--- a/ClientGUI/XNAColorDropDown.cs
+++ b/ClientGUI/XNAColorDropDown.cs
@@ -1,5 +1,9 @@
-﻿using ClientCore.Extensions;
+﻿using System.Linq;
+
+using ClientCore.Extensions;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
 using Rampastring.Tools;
 using Rampastring.XNAUI;
 using Rampastring.XNAUI.XNAControls;
@@ -13,48 +17,66 @@ namespace ClientGUI
 
         public int ColorTextureWidth;
         public int ColorTextureHeigth;
+        public Texture2D RandomColorTexture { get; private set; }
 
         public XNAColorDropDown(WindowManager windowManager) : base(windowManager) 
         {
             ColorTextureWidth = Height - PADDING;
             ColorTextureHeigth = Height - PADDING;
+            RandomColorTexture = AssetLoader.LoadTexture("randomicon.png");
         }
 
         protected override void ParseControlINIAttribute(IniFile iniFile, string key, string value)
         {
-            if (key == nameof(ItemsDrawMode))
+            switch (key)
             {
-                ItemsDrawMode = value.FromIniString().ToEnum<ItemsKind>();
+                case nameof(ItemsDrawMode):
+                    ItemsDrawMode = value.FromIniString().ToEnum<ItemsKind>();
 
-                switch (ItemsDrawMode)
-                {
-                    case ItemsKind.Text:
-                        Items.ForEach(item => 
-                        { 
-                            item.Texture = AssetLoader.CreateTexture(AssetLoader.GetRGBAColorFromString("0,0,0,0"), 1, 1); 
-                        });
-                        break;
-                    case ItemsKind.Icon:
-                        Items.ForEach(item => 
-                        {
-                            if (!item.Text.Contains("Random".L10N("Client:Main:RandomColor")))
-                                item.Texture = AssetLoader.CreateTexture(
-                                    item.TextColor ?? AssetLoader.GetColorFromString("255,255,255"), 
-                                    Width - PADDING, 
-                                    Height - PADDING);
-                            
-                            item.Text = string.Empty;
-                        });
-                        break;
-                    case ItemsKind.TextAndIcon:
-                    default:
-                        break;
-                }
+                    switch (ItemsDrawMode)
+                    {
+                        case ItemsKind.Text:
+                            Items.ForEach(item =>
+                            {
+                                // Disposing cause client to crash, so replace texture with transparent one
+                                item.Texture = AssetLoader.CreateTexture(AssetLoader.GetRGBAColorFromString("0,0,0,0"), 1, 1);
+                            });
+                            break;
+                        case ItemsKind.Icon:
+                            Items.ForEach(item =>
+                            {
+                                if (!item.Text.Contains("Random".L10N("Client:Main:RandomColor")))
+                                    item.Texture = AssetLoader.CreateTexture(
+                                        item.TextColor ?? AssetLoader.GetColorFromString("255,255,255"),
+                                        Width - PADDING,
+                                        Height - PADDING);
 
-                return;
+                                item.Text = string.Empty;
+                            });
+                            break;
+                        case ItemsKind.TextAndIcon:
+                        default:
+                            break;
+                    }
+
+                    return;
+                case nameof(ColorTextureWidth):
+                    ColorTextureWidth = Conversions.IntFromString(value, ColorTextureWidth);
+                    break;
+                case nameof(ColorTextureHeigth):
+                    ColorTextureHeigth = Conversions.IntFromString(value, ColorTextureHeigth);
+                    break;
+                case nameof(RandomColorTexture):
+                    RandomColorTexture = AssetLoader.LoadTexture(value);
+                    Items
+                        .Where(item => item.Text.Contains("Random".L10N("Client:Main:RandomColor")))
+                        .ToList()
+                        .ForEach(item => item.Texture = RandomColorTexture);
+                    break;
+                default:
+                    base.ParseControlINIAttribute(iniFile, key, value);
+                    return;
             }
-
-            base.ParseControlINIAttribute(iniFile, key, value);
         }
 
         public new virtual void AddItem(string text, Color color)
@@ -67,7 +89,7 @@ namespace ClientGUI
             if (!text.Contains("Random".L10N("Client:Main:RandomColor")))
                 item.Texture = AssetLoader.CreateTexture(color, ColorTextureWidth, ColorTextureHeigth);
             else
-                item.Texture = AssetLoader.LoadTexture("randomicon.png");
+                item.Texture = RandomColorTexture;
 
             Items.Add(item);
         }

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -1,4 +1,4 @@
-﻿using ClientCore;
+using ClientCore;
 using ClientCore.Statistics;
 using ClientGUI;
 using DTAClient.Domain;
@@ -886,7 +886,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 ddPlayerSide.SelectedIndexChanged += CopyPlayerDataFromUI;
                 ddPlayerSide.Tag = true;
 
-                var ddPlayerColor = new XNAClientDropDown(WindowManager);
+                var ddPlayerColor = new XNAColorDropDown(WindowManager);
                 ddPlayerColor.Name = "ddPlayerColor" + i;
                 ddPlayerColor.ClientRectangle = new Rectangle(
                     ddPlayerSide.Right + playerOptionHorizontalMargin,

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -2302,7 +2302,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                         ddColor.Items[disallowedColorIndex + 1].Selectable = false;
                         if (ddColor.ItemsDrawMode == XNAClientColorDropDown.ItemsKind.Text) 
                             continue;
-                        if (!ddColor.Items[disallowedColorIndex + 1].Text.Contains("Random".L10N("Client:Main:RandomColor")))
+                        if (ddColor.Items[disallowedColorIndex + 1] != ddColor.Items[0])
                             ddColor.Items[disallowedColorIndex + 1].Texture = ddColor.DisabledItemTexture;
                     }
 

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -122,7 +122,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
         protected XNAClientDropDown[] ddPlayerNames;
         protected XNAClientDropDown[] ddPlayerSides;
-        protected XNAColorDropDown[] ddPlayerColors;
+        protected XNAClientColorDropDown[] ddPlayerColors;
         protected XNAClientDropDown[] ddPlayerStarts;
         protected XNAClientDropDown[] ddPlayerTeams;
 
@@ -828,7 +828,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         {
             ddPlayerNames = new XNAClientDropDown[MAX_PLAYER_COUNT];
             ddPlayerSides = new XNAClientDropDown[MAX_PLAYER_COUNT];
-            ddPlayerColors = new XNAColorDropDown[MAX_PLAYER_COUNT];
+            ddPlayerColors = new XNAClientColorDropDown[MAX_PLAYER_COUNT];
             ddPlayerStarts = new XNAClientDropDown[MAX_PLAYER_COUNT];
             ddPlayerTeams = new XNAClientDropDown[MAX_PLAYER_COUNT];
 
@@ -887,7 +887,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 ddPlayerSide.SelectedIndexChanged += CopyPlayerDataFromUI;
                 ddPlayerSide.Tag = true;
 
-                var ddPlayerColor = new XNAColorDropDown(WindowManager);
+                var ddPlayerColor = new XNAClientColorDropDown(WindowManager);
                 ddPlayerColor.Name = "ddPlayerColor" + i;
                 ddPlayerColor.ClientRectangle = new Rectangle(
                     ddPlayerSide.Right + playerOptionHorizontalMargin,
@@ -2246,7 +2246,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                     // Random color has its own texture
                     if (ddColor.Items[0] == item) return;
 
-                    if (ddColor.ItemsDrawMode == XNAColorDropDown.ItemsKind.Text) return;
+                    if (ddColor.ItemsDrawMode == XNAClientColorDropDown.ItemsKind.Text) return;
 
                     item.Texture = AssetLoader.CreateTexture(item.TextColor ?? Color.White, ddColor.ColorTextureWidth, ddColor.ColorTextureHeigth); 
                 });
@@ -2300,7 +2300,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                     foreach (var ddColor in ddPlayerColors)
                     {
                         ddColor.Items[disallowedColorIndex + 1].Selectable = false;
-                        if (ddColor.ItemsDrawMode == XNAColorDropDown.ItemsKind.Text) 
+                        if (ddColor.ItemsDrawMode == XNAClientColorDropDown.ItemsKind.Text) 
                             continue;
                         if (!ddColor.Items[disallowedColorIndex + 1].Text.Contains("Random".L10N("Client:Main:RandomColor")))
                             ddColor.Items[disallowedColorIndex + 1].Texture = ddColor.DisabledItemTexture;

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -18,6 +18,7 @@ using DTAClient.Online.EventArguments;
 using ClientCore.Extensions;
 using TextCopy;
 
+
 namespace DTAClient.DXGUI.Multiplayer.GameLobby
 {
     /// <summary>
@@ -121,7 +122,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
         protected XNAClientDropDown[] ddPlayerNames;
         protected XNAClientDropDown[] ddPlayerSides;
-        protected XNAClientDropDown[] ddPlayerColors;
+        protected XNAColorDropDown[] ddPlayerColors;
         protected XNAClientDropDown[] ddPlayerStarts;
         protected XNAClientDropDown[] ddPlayerTeams;
 
@@ -827,7 +828,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         {
             ddPlayerNames = new XNAClientDropDown[MAX_PLAYER_COUNT];
             ddPlayerSides = new XNAClientDropDown[MAX_PLAYER_COUNT];
-            ddPlayerColors = new XNAClientDropDown[MAX_PLAYER_COUNT];
+            ddPlayerColors = new XNAColorDropDown[MAX_PLAYER_COUNT];
             ddPlayerStarts = new XNAClientDropDown[MAX_PLAYER_COUNT];
             ddPlayerTeams = new XNAClientDropDown[MAX_PLAYER_COUNT];
 
@@ -2238,7 +2239,17 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             // Enable all colors by default
             foreach (var ddColor in ddPlayerColors)
             {
-                ddColor.Items.ForEach(item => item.Selectable = true);
+                ddColor.Items.ForEach(item => 
+                { 
+                    item.Selectable = true;
+                    
+                    // Random color has its own texture
+                    if (ddColor.Items[0] == item) return;
+
+                    if (ddColor.ItemsDrawMode == XNAColorDropDown.ItemsKind.Text) return;
+
+                    item.Texture = AssetLoader.CreateTexture(item.TextColor ?? Color.White, ddColor.ColorTextureWidth, ddColor.ColorTextureHeigth); 
+                });
             }
 
             // Apply starting locations
@@ -2286,8 +2297,14 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                     if (disallowedColorIndex >= MPColors.Count)
                         continue;
 
-                    foreach (XNADropDown ddColor in ddPlayerColors)
+                    foreach (var ddColor in ddPlayerColors)
+                    {
                         ddColor.Items[disallowedColorIndex + 1].Selectable = false;
+                        if (ddColor.ItemsDrawMode == XNAColorDropDown.ItemsKind.Text) 
+                            continue;
+                        if (!ddColor.Items[disallowedColorIndex + 1].Text.Contains("Random".L10N("Client:Main:RandomColor")))
+                            ddColor.Items[disallowedColorIndex + 1].Texture = ddColor.DisabledItemTexture;
+                    }
 
                     foreach (PlayerInfo pInfo in concatPlayerList)
                     {

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -2248,7 +2248,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
                     if (ddColor.ItemsDrawMode == XNAClientColorDropDown.ItemsKind.Text) return;
 
-                    item.Texture = AssetLoader.CreateTexture(item.TextColor ?? Color.White, ddColor.ColorTextureWidth, ddColor.ColorTextureHeigth); 
+                    item.Texture = AssetLoader.CreateTexture(item.TextColor ?? Color.White, ddColor.ColorTextureWidth, ddColor.ColorTextureHeight); 
                 });
             }
 

--- a/Docs/INISystem.md
+++ b/Docs/INISystem.md
@@ -288,6 +288,20 @@ _(inherits XNADropDown)_
 ToolTip=            ; text, tooltip for dropdown.
 ```
 
+#### [XNAColorDropDown](https://github.com/CnCNet/xna-cncnet-client/blob/develop/ClientGUI/XNAColorDropDown.cs)
+
+_(inherits XNAClientDropDown)_
+
+```ini
+[SOMECOLORDROPDOWN] ; XNAColorDropDown
+ItemsDrawMode=TextAndIcon         ; enum (Text | Icon | TextAndIcon),
+                                  ; this will set what combination of texture and text should client use.
+RandomColorTexture=randomicon.png ; string, the file to load as texture for random color.
+ColorTextureHeight=               ; int, color icon height in pixels.
+ColorTextureWidth=                ; int, color icon width in pixels.
+```
+
+
 #### [XNATabControl](https://github.com/Rampastring/Rampastring.XNAUI/blob/master/XNAControls/XNATabControl.cs)
 
 _(inherits [XNAControl](#XNAControl))_


### PR DESCRIPTION
## Description

New implementation of drop-down with colors for Skirmish/LAN/Multiplayer lobby offering 3 possible types of draw items.

Closes #369, closes #760, closes #368

## Examples

![image](https://github.com/user-attachments/assets/ad722632-7ae9-4955-8163-6e0f34e292ec)

![image](https://github.com/user-attachments/assets/943421d3-fe08-4b5a-adb2-bd8240a7ba23)

![image](https://github.com/user-attachments/assets/897d221a-09e5-42cd-8dec-49990a961ca0)

Code (`GameLobbyBase.ini`):

```ini
[ddPlayerColor0]
ItemsDrawMode=Icon
```

## To Do List

- [x] Implement `XNAColorDropDown` class basis
- [x] Add information to the documentation
- [x] Add keys:
    - [x] `ItemsDrawMode` (`Text`, `Icon`, `TextAndIcon` -- by default)
    - [x] `RandomColorTexture` (`randomicon.png` -- by default)
    - [x] `ColorTextureHeight` (`Height - 3` by default)
    - [x] `ColorTextureWidth` (`Width - 3` by default)