### PR TITLE
Correct GameCreationWindow height for undefined size

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/GameCreationWindow.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/GameCreationWindow.cs
@@ -181,9 +181,9 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 AddChild(btnLoadMPGame);
             AddChild(btnCancel);
 
-            base.Initialize();
-
             Height = btnCreateGame.Bottom + UIDesignConstants.CONTROL_VERTICAL_MARGIN + UIDesignConstants.EMPTY_SPACE_BOTTOM;
+
+            base.Initialize();
 
             CenterOnParent();
 


### PR DESCRIPTION
This PR allows modders NOT defining the size of the GameCreationWindow.

This is because the height has been changed in https://github.com/CnCNet/xna-cncnet-client/pull/598 and since modders must specify the height of the GameCreationWindow before this PR (otherwise see the first screenshot titled "before" below), they will get an incorrect border if they forgot to update the height. 

Before this PR, they must manually increase the height for this window after https://github.com/CnCNet/xna-cncnet-client/pull/598. Now they can also choose to remove the size definition.

This PR will still respect for a defined size.

```diff
[GameCreationWindow]
-Size=493,204
DrawMode=Tiled
BackgroundTexture=longdescbg.png
DrawBorders=false

[GameCreationWindow_Advanced]
-Size=493,404
DrawMode=Tiled
BackgroundTexture=longdescbg.png
DrawBorders=false
```

![图片](https://github.com/user-attachments/assets/4bade509-061a-47b5-8b5c-bf0e22c2c215)
![图片](https://github.com/user-attachments/assets/a5aed130-36ad-4931-a07f-a2e444265122)
