### PR TITLE
Upgrade ImeSharp v1.4.1 as a potential fix to occasion crash for some IMEs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageVersion Include="DiscordRichPresence" Version="1.2.1.24" />
     <PackageVersion Include="Facepunch.Steamworks" Version="2.4.1" />
-    <PackageVersion Include="ImeSharp" Version="1.4.0" />
+    <PackageVersion Include="ImeSharp" Version="1.4.1" />
     <PackageVersion Include="lzo.net" Version="0.0.6" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" />


### PR DESCRIPTION
Suggested by @frg2089 

Co-authored-by: 舰队的偶像-岛风酱! <frg2089@outlook.com>