### PR TITLE
Allow randomselector to consider duplicate values

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -1071,7 +1071,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 try
                 {
                     string[] tmp = GameOptionsIni.GetStringListValue("RandomSelectors", randomSelector, string.Empty);
-                    randomSides = Array.ConvertAll(tmp, int.Parse).Distinct().ToList();
+                    randomSides = Array.ConvertAll(tmp, int.Parse).ToList();
                     randomSides.RemoveAll(x => (x >= SideCount || x < 0));
                 }
                 catch (FormatException) { }


### PR DESCRIPTION
For YR repo I have this:

Was wanting to create a random selector for sides, based on popular / preferred sides.

Right now I have this in GameOptions.ini:
[RandomSelectors]
Allied=0,1,2,3,4
Soviet=5,6,7,8
Ladder=0,1,2,6,6,6,9,9,9

Idea is 33% chance for allied, 33% chance for soviets, 33% chance for yuri.

If allied, you either get America, Korea or France.
If soviet, you get Iraq.
If yuri, then duh yuri is master.

I thought relisting the same side index for Iraq and Yuri under Ladder=0,1,2,6,6,6,6,9,9,9 would work, but so far the data suggests this:

America         -> 16
Korea              -> 13
France            -> 14
Iraq                  -> 12
Yuri                  -> 15

Total Games        -> 10
Computers          -> 7
Total Countries  -> 70

% As Allied      -> 61.42%
% As Soviet     -> 17.14%
% As Yuri          -> 21.43%