### PR TITLE
Fix ignored-method-result issues

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -76,7 +76,7 @@ dotnet_code_quality_unused_parameters = all:suggestion
 dotnet_remove_unnecessary_suppression_exclusions = none
 
 # CA1806: Do not ignore method results
-dotnet_diagnostic.CA1806.severity = warning
+dotnet_diagnostic.CA1806.severity = error
 
 #### C# Coding Conventions ####
 [*.cs]

--- a/ClientGUI/INItializableWindow.cs
+++ b/ClientGUI/INItializableWindow.cs
@@ -104,7 +104,7 @@ namespace ClientGUI
             ConfigIni = new CCIniFile(configIniPath);
 
             if (Parser.Instance == null)
-                new Parser(WindowManager);
+                _ = new Parser(WindowManager); // Note: Parser.Instance will be set by calling new Parser()
 
             Parser.Instance.SetPrimaryControl(this);
             ReadINIForControl(this);

--- a/DTAConfig/Settings/FileSourceDestinationInfo.cs
+++ b/DTAConfig/Settings/FileSourceDestinationInfo.cs
@@ -1,5 +1,7 @@
 ﻿using ClientCore;
+
 using Rampastring.Tools;
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -42,7 +44,12 @@ namespace DTAConfig.Settings
 
             FileOperationOption option = default(FileOperationOption);
             if (parts.Length >= 3)
-                Enum.TryParse(parts[2], out option);
+            {
+                bool success = Enum.TryParse(parts[2], out option);
+                if (!success)
+                    throw new ArgumentException($"{nameof(FileSourceDestinationInfo)}: " +
+                    $"Error parsing FileOperationOption enum", nameof(value));
+            }
 
             sourcePath = parts[0];
             destinationPath = parts[1];

--- a/DXMainClient/Online/FileHashCalculator.cs
+++ b/DXMainClient/Online/FileHashCalculator.cs
@@ -40,7 +40,7 @@ namespace DTAClient.Online
                 "INI/AIE.ini",
                 "INI/AIFS.ini"
             },
-            ClientType.YR => new string[] 
+            ClientType.YR => new string[]
             {
                 "spawner.xdp",
                 "spawner2.xdp",
@@ -80,7 +80,7 @@ namespace DTAClient.Online
             },
             _ => new string[] { }
         };
-            
+
         public FileHashCalculator() => ParseConfigFile();
 
         private string finalHash = string.Empty;
@@ -146,10 +146,10 @@ namespace DTAClient.Online
                     Logger.Log("Hash for " + relativePath + ": " + hash);
             }
 
-            DirectoryInfo[] iniPaths = { SafePath.GetDirectory(ProgramConstants.GamePath, "INI", "Game Options") };
-            
+            List<DirectoryInfo> iniPaths = [SafePath.GetDirectory(ProgramConstants.GamePath, "INI", "Game Options")];
+
             if (ClientConfiguration.Instance.ClientGameType != ClientType.YR)
-                iniPaths.Append<DirectoryInfo>(SafePath.GetDirectory(ProgramConstants.GamePath, "INI", "Map Code"));
+                iniPaths.Add(SafePath.GetDirectory(ProgramConstants.GamePath, "INI", "Map Code"));
 
             foreach (DirectoryInfo path in iniPaths)
             {


### PR DESCRIPTION
This PR:
- Fix the "Map Code" folder is once again ignored by the file hash calculator
- Prompt the ignored-method-result issue (CA1806) as an error
- Adjusted other codes that violates CA1806