### PR TITLE
Fix race condition preventing GameInProgressWindow cleanup when disabled before callback execution

### DIFF
--- a/DXMainClient/DXGUI/Generic/GameInProgressWindow.cs
+++ b/DXMainClient/DXGUI/Generic/GameInProgressWindow.cs
@@ -129,7 +129,7 @@ namespace DTAClient.DXGUI
 
         private void SharedUILogic_GameProcessExited()
         {
-            AddCallback(new Action(HandleGameProcessExited), null);
+            WindowManager.AddCallback(new Action(HandleGameProcessExited), null);
         }
 
         private void HandleGameProcessExited()


### PR DESCRIPTION
This PR potentially fixes a race condition in SharedUILogic_GameProcessExited. 

Both MainMenu and GameInProgressWindow use SharedUILogic_GameProcessExited. When MainMenu's handler executes first, it disables the GameInProgressWindow. Since disabled controls don't have their Update() method called, the scheduled callback never executes.

As the WindowManager never gets disabled, this PR moves the callback to execute there instead.


Fixes #800 