### PR TITLE
Implement user default

### DIFF
--- a/ClientCore/Settings/UserINISettings.cs
+++ b/ClientCore/Settings/UserINISettings.cs
@@ -77,6 +77,11 @@ namespace ClientCore
             {
                 IniSection userSection = userIni.GetSection(sectionName);
                 IniSection combinedUserSection = combinedUserIni.GetSection(sectionName);
+                if (combinedUserSection == null)
+                {
+                    combinedUserSection = new IniSection(sectionName);
+                    combinedUserIni.AddSection(combinedUserSection);
+                }
                 foreach ((var key, var value) in userSection.Keys)
                 {
                     combinedUserSection.AddOrReplaceKey(key, value);

--- a/ClientCore/Settings/UserINISettings.cs
+++ b/ClientCore/Settings/UserINISettings.cs
@@ -83,6 +83,8 @@ namespace ClientCore
                 }
             }
 
+            combinedUserIni.FileName = userIni.FileName;
+
             _instance = new UserINISettings(combinedUserIni);
         }
 

--- a/ClientCore/Settings/UserINISettings.cs
+++ b/ClientCore/Settings/UserINISettings.cs
@@ -40,20 +40,22 @@ namespace ClientCore
             }
         }
 
-        public static void Initialize(string userIniFileName, string userDefaultIniFileName = "UserDefaults.ini")
+        public static void Initialize(string userIniFileName)
         {
             if (_instance != null)
                 throw new InvalidOperationException("UserINISettings has already been initialized!");
 
             var userIni = new IniFile(SafePath.CombineFilePath(ProgramConstants.GamePath, userIniFileName));
 
-            if (string.IsNullOrWhiteSpace(userIniFileName) || !File.Exists(userDefaultIniFileName))
+            string userDefaultIniFilePath = SafePath.CombineFilePath(ProgramConstants.GetResourcePath(), "UserDefaults.ini");
+
+            if (string.IsNullOrWhiteSpace(userIniFileName) || !File.Exists(userDefaultIniFilePath))
             {
                 _instance = new UserINISettings(userIni);
                 return;
             }
-                        
-            var userDefaultIni = new IniFile(SafePath.CombineFilePath(ProgramConstants.GamePath, userDefaultIniFileName));
+
+            var userDefaultIni = new IniFile(userDefaultIniFilePath);
 
             // Clone userDefaultIni to combinedUserIni. Clone() method is not available. https://github.com/Rampastring/Rampastring.Tools/issues/12
             var combinedUserIni = new IniFile();
@@ -393,7 +395,7 @@ namespace ClientCore
         public bool IsGameFiltersApplied()
             => ShowFriendGamesOnly.Value != DEFAULT_SHOW_FRIENDS_ONLY_GAMES
                || HideLockedGames.Value != DEFAULT_HIDE_LOCKED_GAMES
-               || HidePasswordedGames.Value != DEFAULT_HIDE_PASSWORDED_GAMES 
+               || HidePasswordedGames.Value != DEFAULT_HIDE_PASSWORDED_GAMES
                || HideIncompatibleGames.Value != DEFAULT_HIDE_INCOMPATIBLE_GAMES
                || MaxPlayerCount.Value != DEFAULT_MAX_PLAYER_COUNT;
 

--- a/ClientCore/Settings/UserINISettings.cs
+++ b/ClientCore/Settings/UserINISettings.cs
@@ -76,12 +76,14 @@ namespace ClientCore
             foreach (string sectionName in userIni.GetSections())
             {
                 IniSection userSection = userIni.GetSection(sectionName);
+
                 IniSection combinedUserSection = combinedUserIni.GetSection(sectionName);
                 if (combinedUserSection == null)
                 {
                     combinedUserSection = new IniSection(sectionName);
                     combinedUserIni.AddSection(combinedUserSection);
                 }
+
                 foreach ((var key, var value) in userSection.Keys)
                 {
                     combinedUserSection.AddOrReplaceKey(key, value);


### PR DESCRIPTION
This PR introduces `Resources\UserDefaults.ini` file to provide default values if the corresponding item in user setting file (say `RA2MD.ini` for CnCNet YR) is missing, instead of the hard-coded default value in the client.

As an example, one can create a `Resources\UserDefaults.ini` file as below, remove the user setting file, and start the client to watch the difference.

```ini
[Video]
IntegerScaledClient=True
BorderlessWindowedClient=False

[Audio]
ClientVolume=0.3
PlayMainMenuMusic=False
```
