### PR TITLE
Change the font index of map briefing from 3 to 0

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CoopBriefingBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CoopBriefingBox.cs
@@ -17,7 +17,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         }
 
         string text = string.Empty;
-        int fontIndex = 3;
+        int fontIndex = 0;
 
         private bool isVisible = true;
 


### PR DESCRIPTION
Among the client, in most cases, font 0 and 1 are used. There is only one usage of font 3: briefing

To me I think it is better to use font 0 instead.

In this way, we can just ship two font files. A universal font takes 10--20 MB so reducing the usage of font 2, 3, 4, 5 etc. worth some benifits, especially if they are copied from font 0