### PR TITLE
Add map hash to game broadcast

### DIFF
--- a/ClientCore/ProgramConstants.cs
+++ b/ClientCore/ProgramConstants.cs
@@ -26,8 +26,8 @@ namespace ClientCore
 
         public const string QRES_EXECUTABLE = "qres.dat";
 
-        public const string CNCNET_PROTOCOL_REVISION = "R12";
-        public const string LAN_PROTOCOL_REVISION = "RL7";
+        public const string CNCNET_PROTOCOL_REVISION = "R13";
+        public const string LAN_PROTOCOL_REVISION = "RL8";
         public const int LAN_PORT = 1234;
         public const int LAN_INGAME_PORT = 1234;
         public const int LAN_LOBBY_PORT = 1232;

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
@@ -1507,7 +1507,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             string msg = e.Message.Substring(5); // Cut out GAME part
             string[] splitMessage = msg.Split(new char[] { ';' });
 
-            if (splitMessage.Length != 12)
+            if (splitMessage.Length != 13)
             {
                 Logger.Log("Ignoring CTCP game message because of an invalid amount of parameters.");
                 return;
@@ -1538,6 +1538,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
                 string loadedGameId = splitMessage[10];
                 int skillLevel = int.Parse(splitMessage[11]);
+                string mapHash = splitMessage[12];
 
                 CnCNetGame cncnetGame = gameCollection.GameList.Find(g => g.GameBroadcastChannel == channel.ChannelName);
 
@@ -1551,7 +1552,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
                 HostedCnCNetGame game = new HostedCnCNetGame(gameRoomChannelName, revision, gameVersion, maxPlayers,
                     gameRoomDisplayName, isCustomPassword, true, players,
-                    e.UserName, mapName, gameMode);
+                    e.UserName, mapName, gameMode, mapHash);
                 game.IsLoadedGame = isLoadedGame;
                 game.MatchID = loadedGameId;
                 game.LastRefreshTime = DateTime.Now;

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -2002,6 +2002,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             sb.Append(0); // LoadedGameId
             sb.Append(";");
             sb.Append(skillLevel); // SkillLevel
+            sb.Append(";");
+            sb.Append(Map?.SHA1);
 
             broadcastChannel.SendCTCPMessage(sb.ToString(), QueuedMessageType.SYSTEM_MESSAGE, 20);
         }

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
@@ -759,6 +759,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             sb.Append(sbPlayers.ToString());
             sb.Append(Convert.ToInt32(Locked));
             sb.Append(0); // IsLoadedGame
+            sb.Append(Map?.SHA1);
 
             GameBroadcast?.Invoke(this, new GameBroadcastEventArgs(sb.ToString()));
         }

--- a/DXMainClient/Domain/Multiplayer/CnCNet/HostedCnCNetGame.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/HostedCnCNetGame.cs
@@ -9,7 +9,7 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
         public HostedCnCNetGame(string channelName, string revision, string gamever, int maxPlayers,
             string roomName, bool passworded,
             bool tunneled,
-            string[] players, string adminName, string mapName, string gameMode)
+            string[] players, string adminName, string mapName, string gameMode, string mapHash)
         {
             ChannelName = channelName;
             Revision = revision;
@@ -22,6 +22,7 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
             HostName = adminName;
             Map = mapName;
             GameMode = gameMode;
+            MapHash = mapHash;
         }
 
         public string ChannelName { get; set; }

--- a/DXMainClient/Domain/Multiplayer/GenericHostedGame.cs
+++ b/DXMainClient/Domain/Multiplayer/GenericHostedGame.cs
@@ -17,6 +17,7 @@ namespace DTAClient.Domain.Multiplayer
         public CnCNetGame Game { get; set; }
         public string GameMode { get; set; }
         public string Map { get; set; }
+        public string MapHash { get; set; }
         public string GameVersion { get; set; }
         public string HostName { get; set; }
         public string[] Players { get; set; }

--- a/DXMainClient/Domain/Multiplayer/LAN/HostedLANGame.cs
+++ b/DXMainClient/Domain/Multiplayer/LAN/HostedLANGame.cs
@@ -24,7 +24,7 @@ namespace DTAClient.Domain.LAN
 
         public bool SetDataFromStringArray(GameCollection gc, string[] parameters)
         {
-            if (parameters.Length != 9)
+            if (parameters.Length != 10)
             {
                 Logger.Log("Ignoring LAN GAME message because of an incorrect number of parameters.");
                 return false;
@@ -51,6 +51,7 @@ namespace DTAClient.Domain.LAN
             LastRefreshTime = DateTime.Now;
             TimeWithoutRefresh = TimeSpan.Zero;
             RoomName = HostName + "'s Game";
+            MapHash = parameters[9];
 
             return true;
         }


### PR DESCRIPTION
I propose adding the map's SHA1 to the game broadcast. This allows for more accurate lookup of thumbnails and translated name. And also allows bots to properly match games to maps for more accurate map usage stats.