### PR TITLE
Retain tunnel object through refreshes

### DIFF
--- a/DXMainClient/Domain/Multiplayer/CnCNet/CnCNetTunnel.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/CnCNetTunnel.cs
@@ -34,7 +34,7 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
 
                 string address = parts[0];
                 string[] detailedAddress = address.Split(new char[] { ':' });
-                
+
                 tunnel.Address = detailedAddress[0];
                 tunnel.Port = int.Parse(detailedAddress[1]);
                 tunnel.Country = parts[1];
@@ -86,7 +86,27 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
         public int PingInMs { get; set; } = -1;
 
         /// <summary>
-        /// Gets a list of player ports to use from a specific tunnel server.
+        /// Updates this tunnel's metadata from another tunnel instance, preserving Address, Port, and existing PingInMs.
+        /// </summary>
+        internal void UpdateFrom(CnCNetTunnel updatedTunnel)
+        {
+            Country = updatedTunnel.Country;
+            CountryCode = updatedTunnel.CountryCode;
+            Name = updatedTunnel.Name;
+            Clients = updatedTunnel.Clients;
+            MaxClients = updatedTunnel.MaxClients;
+            Official = updatedTunnel.Official;
+            Recommended = updatedTunnel.Recommended;
+            Version = updatedTunnel.Version;
+
+            RequiresPassword = updatedTunnel.RequiresPassword;
+            Latitude = updatedTunnel.Latitude;
+            Longitude = updatedTunnel.Longitude;
+            Distance = updatedTunnel.Distance;
+        }
+
+        /// <summary>
+        /// Gets a list of player ports to use from a specific V2 tunnel server.
         /// </summary>
         /// <returns>A list of player ports to use.</returns>
         public List<int> GetPlayerPortInfo(int playerCount)

--- a/DXMainClient/Domain/Multiplayer/CnCNet/TunnelHandler.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/TunnelHandler.cs
@@ -282,7 +282,7 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
                     if (tunnel.Version != SUPPORTED_TUNNEL_VERSION)
                         continue;
 
-                    if (!seenAddresses.Add(tunnel.Address))
+                    if (!seenAddresses.Add($"{tunnel.Address}:{tunnel.Port}"))
                         continue;
 
                     returnValue.Add(tunnel);

--- a/DXMainClient/Domain/Multiplayer/CnCNet/TunnelHandler.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/TunnelHandler.cs
@@ -31,6 +31,9 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
 
         private const int SUPPORTED_TUNNEL_VERSION = 2;
 
+        private readonly object _refreshLock = new object();
+        private bool _refreshInProgress = false;
+
         public TunnelHandler(WindowManager wm, CnCNetManager connectionManager) : base(wm.Game)
         {
             this.wm = wm;
@@ -78,26 +81,65 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
 
         private void RefreshTunnelsAsync()
         {
+            lock (_refreshLock)
+            {
+                if (_refreshInProgress)
+                    return;
+                _refreshInProgress = true;
+            }
+
             Task.Factory.StartNew(() =>
             {
-                List<CnCNetTunnel> tunnels = RefreshTunnels();
-                wm.AddCallback(new Action<List<CnCNetTunnel>>(HandleRefreshedTunnels), tunnels);
+                try
+                {
+                    List<CnCNetTunnel> tunnels = RefreshTunnels();
+                    wm.AddCallback(new Action<List<CnCNetTunnel>>(HandleRefreshedTunnels), tunnels);
+                }
+                finally
+                {
+                    lock (_refreshLock)
+                    {
+                        _refreshInProgress = false;
+                    }
+                }
             });
         }
 
-        private void HandleRefreshedTunnels(List<CnCNetTunnel> tunnels)
+        private void HandleRefreshedTunnels(List<CnCNetTunnel> newTunnels)
         {
-            if (tunnels.Count > 0)
-                Tunnels = tunnels;
+            if (newTunnels.Count == 0)
+            {
+                TunnelsRefreshed?.Invoke(this, EventArgs.Empty);
+                return;
+            }
 
+            var existingTunnels = Tunnels.ToDictionary(t => $"{t.Address}:{t.Port}");
+            var updatedTunnels = new List<CnCNetTunnel>();
+
+            foreach (var newTunnel in newTunnels)
+            {
+                string key = $"{newTunnel.Address}:{newTunnel.Port}";
+                if (existingTunnels.TryGetValue(key, out var existingTunnel))
+                {
+                    // update existing tunnels
+                    existingTunnel.UpdateFrom(newTunnel);
+                    updatedTunnels.Add(existingTunnel);
+                }
+                else
+                {
+                    // add new tunnels
+                    updatedTunnels.Add(newTunnel);
+                }
+            }
+
+            // remove old tunnels
+            Tunnels = updatedTunnels;
             TunnelsRefreshed?.Invoke(this, EventArgs.Empty);
-
-            Task[] pingTasks = new Task[Tunnels.Count];
 
             for (int i = 0; i < Tunnels.Count; i++)
             {
                 if (UserINISettings.Instance.PingUnofficialCnCNetTunnels || Tunnels[i].Official || Tunnels[i].Recommended)
-                    pingTasks[i] = PingListTunnelAsync(i);
+                    _ = PingListTunnelAsync(i);
             }
 
             if (CurrentTunnel != null)
@@ -212,6 +254,7 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
         private List<CnCNetTunnel> RefreshTunnels()
         {
             List<CnCNetTunnel> returnValue = new List<CnCNetTunnel>();
+            var seenAddresses = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             FileInfo tunnelCacheFile = SafePath.GetFile(ProgramConstants.ClientUserFilesPath, "tunnel_cache");
 
@@ -237,6 +280,9 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
                         continue;
 
                     if (tunnel.Version != SUPPORTED_TUNNEL_VERSION)
+                        continue;
+
+                    if (!seenAddresses.Add(tunnel.Address))
                         continue;
 
                     returnValue.Add(tunnel);


### PR DESCRIPTION
Tunnel refresh now reuses existing objects to preserve the PingInMs - this should stop pings changing to unknown in game lobbies.
Also prevents multiple refreshes running at once.