### PR TITLE
Update favorite maps to use SHA1 instead of map name

### DIFF
--- a/ClientCore/Settings/UserINISettings.cs
+++ b/ClientCore/Settings/UserINISettings.cs
@@ -318,14 +318,15 @@ namespace ClientCore
         public bool IsGameFollowed(string gameName)
             => SettingsIni.GetBooleanValue("Channels", gameName, false);
 
-        public bool ToggleFavoriteMap(string mapName, string gameModeName, bool isFavorite)
+        public bool ToggleFavoriteMap(string mapSHA1, string gameModeName, bool isFavorite)
         {
-            if (string.IsNullOrEmpty(mapName))
+            if (string.IsNullOrEmpty(mapSHA1))
                 return isFavorite;
 
-            string favoriteMapKey = FavoriteMapKey(mapName, gameModeName);
-            isFavorite = IsFavoriteMap(mapName, gameModeName);
-            if (isFavorite)
+            string favoriteMapKey = FavoriteMapKey(mapSHA1, gameModeName);
+
+            bool isCurrentlyFavorite = FavoriteMaps.Contains(favoriteMapKey);
+            if (isCurrentlyFavorite)
                 FavoriteMaps.Remove(favoriteMapKey);
             else
                 FavoriteMaps.Add(favoriteMapKey);
@@ -334,7 +335,7 @@ namespace ClientCore
 
             WriteFavoriteMaps();
 
-            return !isFavorite;
+            return !isCurrentlyFavorite;
         }
 
         private void LoadFavoriteMaps(IniFile iniFile)
@@ -349,7 +350,7 @@ namespace ClientCore
                 WriteFavoriteMaps();
         }
 
-        private void WriteFavoriteMaps()
+        public void WriteFavoriteMaps()
         {
             var favoriteMapsSection = SettingsIni.GetOrAddSection(FAVORITE_MAPS);
             favoriteMapsSection.RemoveAllKeys();
@@ -361,12 +362,41 @@ namespace ClientCore
 
         /// <summary>
         /// Checks if a specified map name and game mode name belongs to the favorite map list.
+        /// Name-based favorites are migrated to SHA1.
         /// </summary>
-        /// <param name="nameName">The name of the map.</param>
+        /// <param name="mapSHA1">The SHA1 hash of the map.</param>
+        /// <param name="mapName">The name of the map.</param>
         /// <param name="gameModeName">The name of the game mode</param>
-        public bool IsFavoriteMap(string nameName, string gameModeName) => FavoriteMaps.Contains(FavoriteMapKey(nameName, gameModeName));
+        public bool IsFavoriteMap(string mapSHA1, string mapName, string gameModeName)
+        {
+            // SHA1-based lookup first
+            if (!string.IsNullOrEmpty(mapSHA1) && FavoriteMaps.Contains(FavoriteMapKey(mapSHA1, gameModeName)))
+                return true;
 
-        private string FavoriteMapKey(string nameName, string gameModeName) => $"{nameName}:{gameModeName}";
+            // Fallback to name-based
+            string nameKey = FavoriteMapKey(mapName, gameModeName);
+            if (FavoriteMaps.Contains(nameKey))
+            {
+                // Migrate to SHA1
+                if (!string.IsNullOrEmpty(mapSHA1))
+                {
+                    string sha1Key = FavoriteMapKey(mapSHA1, gameModeName);
+                    if (!FavoriteMaps.Contains(sha1Key))
+                    {
+                        FavoriteMaps.Add(sha1Key);
+                        WriteFavoriteMaps();
+                    }
+                    // Note: We don't remove the name-based entry here to allow other maps
+                    // with the same name to also migrate. The name-based entry will be
+                    // cleaned up when all maps with that name have been processed.
+                }
+                return true;
+            }
+
+            return false;
+        }
+
+        private string FavoriteMapKey(string identifier, string gameModeName) => $"{identifier}:{gameModeName}";
 
         public void ReloadSettings() => SettingsIni.Reload();
 

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -697,7 +697,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         {
             if (GameModeMap != null)
             { 
-                GameModeMap.IsFavorite = UserINISettings.Instance.ToggleFavoriteMap(Map.UntranslatedName, GameMode.Name, GameModeMap.IsFavorite);
+                GameModeMap.IsFavorite = UserINISettings.Instance.ToggleFavoriteMap(Map.SHA1, GameMode.Name, GameModeMap.IsFavorite);
                 MapPreviewBox.RefreshFavoriteBtn();
             }
         }

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
@@ -522,7 +522,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
         public void RefreshFavoriteBtn()
         {
-            bool isFav = UserINISettings.Instance.IsFavoriteMap(GameModeMap?.Map.UntranslatedName, GameModeMap?.GameMode.Name);
+            bool isFav = UserINISettings.Instance.IsFavoriteMap(GameModeMap?.Map.SHA1, GameModeMap?.Map.UntranslatedName, GameModeMap?.GameMode.Name);
             var textureName = isFav ? "favActive.png" : "favInactive.png";
             var hoverTextureName = isFav ? "favActive_c.png" : "favInactive_c.png";
             var hoverTexture = AssetLoader.AssetExists(hoverTextureName) ? AssetLoader.LoadTexture(hoverTextureName) : null;

--- a/DXMainClient/Domain/Multiplayer/GameModeMapCollection.cs
+++ b/DXMainClient/Domain/Multiplayer/GameModeMapCollection.cs
@@ -8,7 +8,7 @@ namespace DTAClient.Domain.Multiplayer
     {
         public GameModeMapCollection(IEnumerable<GameMode> gameModes) :
             base(gameModes.SelectMany(gm => gm.Maps.Select(map =>
-                new GameModeMap(gm, map, UserINISettings.Instance.IsFavoriteMap(map.UntranslatedName, gm.Name)))).Distinct())
+                new GameModeMap(gm, map, UserINISettings.Instance.IsFavoriteMap(map.SHA1, map.UntranslatedName, gm.Name)))).Distinct())
         {
         }
 


### PR DESCRIPTION
Currently the favorite map list uses the map's name as an identifier. This is a problem if you have several maps with the same name and you favorite one - they all become favorites and there's no way to remove the ones you don't want. This PR changes to the map's SHA1 as the identifier and migrates the name-based ones over.