### PR TITLE
Add watcher for map changes

### DIFF
--- a/DXMainClient/DXGUI/Generic/LoadingScreen.cs
+++ b/DXMainClient/DXGUI/Generic/LoadingScreen.cs
@@ -69,6 +69,7 @@ namespace DTAClient.DXGUI.Generic
                 updaterInitTask.Start();
             }
 
+            mapLoader.Initialize();
             mapLoadTask = mapLoader.LoadMapsAsync();
 
             if (Cursor.Visible)

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -1260,6 +1260,15 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             base.ChangeMap(gameModeMap);
         }
 
+        protected override void HandleMapUpdated(Map updatedMap, string previousSHA1)
+        {
+            base.HandleMapUpdated(updatedMap, previousSHA1);
+
+            // If the host's currently selected map was updated, broadcast the new map to other players
+            if (IsHost && Map != null && Map.SHA1 == updatedMap.SHA1)
+                OnGameOptionChanged();
+        }
+
         /// <summary>
         /// Signals other players that the local player has returned from the game,
         /// and unlocks the game as well as generates a new random seed as the game host.

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -333,6 +333,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             // Allow repositioning / disabling in INI.
             ReadINIForControl(btnMapSortAlphabetically);
+
+            MapLoader.MapChanged += MapLoader_MapChanged;
         }
 
         private void InitializeGameOptionPresetUI()
@@ -384,6 +386,90 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         {
             if (Enum.IsDefined(typeof(SortDirection), UserINISettings.Instance.MapSortState.Value))
                 btnMapSortAlphabetically.SetState((SortDirection)UserINISettings.Instance.MapSortState.Value);
+        }
+
+        private void MapLoader_MapChanged(object sender, MapChangedEventArgs e)
+        {
+            WindowManager.AddCallback(() =>
+            {
+                switch (e.ChangeType)
+                {
+                    case MapChangeType.Added:
+                        HandleMapAdded(e.Map);
+                        break;
+                    case MapChangeType.Updated:
+                        HandleMapUpdated(e.Map, e.PreviousMapSHA1);
+                        break;
+                    case MapChangeType.Removed:
+                        HandleMapRemoved(e.Map);
+                        break;
+                }
+            }, null);
+        }
+
+        private void HandleMapAdded(Map addedMap)
+        {
+            RefreshGameModeFilter();
+
+            if (ShouldShowMapInCurrentFilter(addedMap))
+                ListMaps();
+        }
+
+        protected virtual void HandleMapUpdated(Map updatedMap, string previousSHA1)
+        {
+            // If the currently selected map was updated, refresh the UI
+            if (Map != null && (Map.SHA1 == previousSHA1 || Map.SHA1 == updatedMap.SHA1))
+            {
+                // Find the new GameModeMap for the updated map
+                var updatedGameModeMap = GameModeMaps
+                    .FirstOrDefault(gmm => gmm.Map.SHA1 == updatedMap.SHA1);
+
+                if (updatedGameModeMap != null)
+                    ChangeMap(updatedGameModeMap);
+            }
+
+            ListMaps();
+        }
+
+        private void HandleMapRemoved(Map removedMap)
+        {
+            // If the currently selected map was removed, select a different one
+            if (Map != null && Map.SHA1 == removedMap.SHA1)
+            {
+                var availableMaps = GameModeMaps.Where(gmm => gmm.GameMode == GameMode).ToList();
+                if (availableMaps.Any())
+                {
+                    ChangeMap(availableMaps.First());
+                }
+                else
+                {
+                    // No maps available for current game mode, change to a different one
+                    var firstAvailableGameModeMap = GameModeMaps.FirstOrDefault();
+                    if (firstAvailableGameModeMap != null)
+                    {
+                        ChangeMap(firstAvailableGameModeMap);
+                        RefreshMapSelectionUI();
+                    }
+                }
+            }
+
+            RefreshGameModeFilter();
+            ListMaps();
+        }
+
+        private bool ShouldShowMapInCurrentFilter(Map map)
+        {
+            if (map?.GameModes == null || gameModeMapFilter == null)
+                return false;
+
+            return map.GameModes.Any(gameModeName =>
+            {
+                var gameMode = MapLoader.GameModes.FirstOrDefault(gm => gm.Name == gameModeName);
+                if (gameMode == null) return false;
+
+                return gameModeMapFilter.GetGameModeMaps().Any(gmm =>
+                    gmm.GameMode.Name == gameMode.Name && gmm.Map.SHA1 == map.SHA1);
+            });
         }
 
         private static XNADropDownItem CreateGameFilterItem(string text, GameModeMapFilter filter)
@@ -811,6 +897,27 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             }
 
             return maps;
+        }
+
+        /// <summary>
+        /// Refreshes the game mode filter dropdown to include all current game modes.
+        /// </summary>
+        protected void RefreshGameModeFilter()
+        {
+            string currentSelection = ddGameModeMapFilter.SelectedItem?.Text;
+
+            ddGameModeMapFilter.SelectedIndexChanged -= DdGameModeMapFilter_SelectedIndexChanged;
+            ddGameModeMapFilter.Items.Clear();
+
+            ddGameModeMapFilter.AddItem(CreateGameFilterItem(FavoriteMapsLabel, new GameModeMapFilter(GetFavoriteGameModeMaps)));
+            foreach (GameMode gm in GameModeMaps.GameModes)
+                ddGameModeMapFilter.AddItem(CreateGameFilterItem(gm.UIName, new GameModeMapFilter(GetGameModeMaps(gm))));
+
+            int selectedIndex = ddGameModeMapFilter.Items.FindIndex(i => i.Text == currentSelection);
+            ddGameModeMapFilter.SelectedIndex = selectedIndex >= 0 ? selectedIndex : 0;
+
+            ddGameModeMapFilter.SelectedIndexChanged += DdGameModeMapFilter_SelectedIndexChanged;
+            gameModeMapFilter = ddGameModeMapFilter.SelectedItem.Tag as GameModeMapFilter;
         }
 
         /// <summary>

--- a/DXMainClient/Domain/Multiplayer/MapFileWatcher.cs
+++ b/DXMainClient/Domain/Multiplayer/MapFileWatcher.cs
@@ -1,0 +1,96 @@
+using System;
+using System.IO;
+using Rampastring.Tools;
+
+namespace DTAClient.Domain.Multiplayer
+{
+    public class MapFileEventArgs : EventArgs
+    {
+        public string FilePath { get; set; }
+        public string FileName { get; set; }
+        public WatcherChangeTypes ChangeType { get; set; }
+        public string OldFilePath { get; set; }
+
+        public MapFileEventArgs(string filePath, WatcherChangeTypes changeType, string oldFilePath = null)
+        {
+            FilePath = filePath;
+            FileName = Path.GetFileNameWithoutExtension(filePath);
+            ChangeType = changeType;
+            OldFilePath = oldFilePath;
+        }
+    }
+
+    public class MapFileWatcher
+    {
+        private readonly string mapsDirectory;
+        private readonly string mapFileExtension;
+        private FileSystemWatcher fileSystemWatcher;
+
+        public event EventHandler<MapFileEventArgs> MapFileChanged;
+
+        public MapFileWatcher(string mapsPath, string fileExtension)
+        {
+            mapsDirectory = mapsPath;
+            mapFileExtension = fileExtension;
+        }
+
+        public void StartWatching()
+        {
+            if (fileSystemWatcher != null)
+                return;
+
+            DirectoryInfo directoryInfo = SafePath.GetDirectory(mapsDirectory);
+            if (!directoryInfo.Exists)
+                return;
+
+            try
+            {
+                fileSystemWatcher = new FileSystemWatcher(mapsDirectory, $"*.{mapFileExtension}")
+                {
+                    NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.Size,
+                    IncludeSubdirectories = true
+                };
+
+                fileSystemWatcher.Created += OnFileSystemEvent;
+                fileSystemWatcher.Changed += OnFileSystemEvent;
+                fileSystemWatcher.Deleted += OnFileSystemEvent;
+                fileSystemWatcher.Renamed += OnFileRenamed;
+
+                fileSystemWatcher.EnableRaisingEvents = true;
+
+                Logger.Log($"MapFileWatcher: Started watching {mapsDirectory} for *.{mapFileExtension} files");
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"MapFileWatcher: Failed to start watching directory {mapsDirectory}: {ex.Message}");
+                fileSystemWatcher?.Dispose();
+                fileSystemWatcher = null;
+            }
+        }
+
+        private void OnFileSystemEvent(object sender, FileSystemEventArgs e)
+        {
+            ProcessFileEvent(e.FullPath, e.ChangeType);
+        }
+
+        private void OnFileRenamed(object sender, RenamedEventArgs e)
+        {
+            // delete + create
+            ProcessFileEvent(e.OldFullPath, WatcherChangeTypes.Deleted);
+            ProcessFileEvent(e.FullPath, WatcherChangeTypes.Created);
+        }
+
+        private void ProcessFileEvent(string filePath, WatcherChangeTypes changeType)
+        {
+            try
+            {
+                var eventArgs = new MapFileEventArgs(filePath, changeType);
+                MapFileChanged?.Invoke(this, eventArgs);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"MapFileWatcher: Error processing file event for {filePath}: {ex.Message}");
+            }
+        }
+    }
+}

--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 using ClientCore;
@@ -14,6 +15,27 @@ using Rampastring.Tools;
 
 namespace DTAClient.Domain.Multiplayer
 {
+    public class MapChangedEventArgs : EventArgs
+    {
+        public Map Map { get; set; }
+        public MapChangeType ChangeType { get; set; }
+        public string PreviousMapSHA1 { get; set; }
+
+        public MapChangedEventArgs(Map map, MapChangeType changeType, string previousMapSHA1 = null)
+        {
+            Map = map;
+            ChangeType = changeType;
+            PreviousMapSHA1 = previousMapSHA1;
+        }
+    }
+
+    public enum MapChangeType
+    {
+        Added,
+        Updated,
+        Removed
+    }
+
     public class MapLoader
     {
         private const string CUSTOM_MAPS_DIRECTORY = "Maps/Custom";
@@ -23,6 +45,8 @@ namespace DTAClient.Domain.Multiplayer
         private const string GameModeAliasesSection = "GameModeAliases";
         private const int CurrentCustomMapCacheVersion = 1;
         private readonly JsonSerializerOptions jsonSerializerOptions = new JsonSerializerOptions { IncludeFields = true };
+        private MapFileWatcher mapFileWatcher;
+        private readonly object mapModificationLock = new object();
 
         /// <summary>
         /// List of game modes.
@@ -35,6 +59,11 @@ namespace DTAClient.Domain.Multiplayer
         /// An event that is fired when the maps have been loaded.
         /// </summary>
         public event EventHandler MapLoadingComplete;
+
+        /// <summary>
+        /// Fired when a map file is added, updated, or removed.
+        /// </summary>
+        public event EventHandler<MapChangedEventArgs> MapChanged;
 
         /// <summary>
         /// A list of game mode aliases.
@@ -56,6 +85,21 @@ namespace DTAClient.Domain.Multiplayer
         /// List of gamemodes allowed to be used on custom maps in order for them to display in map list.
         /// </summary>
         private string[] AllowedGameModes = ClientConfiguration.Instance.AllowedCustomGameModes.Split(',');
+
+        /// <summary>
+        /// Sets up file watching for maps.
+        /// </summary>
+        public void Initialize()
+        {
+            if (mapFileWatcher != null)
+                return;
+
+            string customMapsPath = SafePath.CombineDirectoryPath(ProgramConstants.GamePath, CUSTOM_MAPS_DIRECTORY);
+
+            mapFileWatcher = new MapFileWatcher(customMapsPath, ClientConfiguration.Instance.MapFileExtension);
+            mapFileWatcher.MapFileChanged += OnMapFileChanged;
+            mapFileWatcher.StartWatching();
+        }
 
         /// <summary>
         /// Loads multiplayer map info asynchonously.
@@ -82,6 +126,233 @@ namespace DTAClient.Domain.Multiplayer
             GameModeMaps = new GameModeMapCollection(GameModes);
 
             MapLoadingComplete?.Invoke(this, EventArgs.Empty);
+        }
+
+        private async void OnMapFileChanged(object sender, MapFileEventArgs e)
+        {
+            switch (e.ChangeType)
+            {
+                case WatcherChangeTypes.Created:
+                    await HandleMapFileAdded(e.FilePath);
+                    break;
+                case WatcherChangeTypes.Changed:
+                    await HandleMapFileChanged(e.FilePath);
+                    break;
+                case WatcherChangeTypes.Deleted:
+                    HandleMapFileDeleted(e.FilePath);
+                    break;
+            }
+        }
+
+        private async Task HandleMapFileAdded(string filePath)
+        {
+            await Task.Run(() =>
+            {
+                try
+                {
+                    if (!File.Exists(filePath))
+                        return;
+
+                    string baseFilePath = GetBaseFilePathFromFullPath(filePath);
+                    if (string.IsNullOrEmpty(baseFilePath))
+                        return;
+
+                    var map = new Map(baseFilePath, true);
+
+                    if (map.SetInfoFromCustomMap())
+                    {
+                        lock (mapModificationLock)
+                        {
+                            if (IsMapAlreadyLoaded(map.SHA1))
+                                return;
+
+                            AddMapToGameModes(map, true);
+                            UpdateGameModeMaps();
+
+                            Logger.Log($"MapLoader: Added new map {map.Name} from {filePath}");
+                            MapChanged?.Invoke(this, new MapChangedEventArgs(map, MapChangeType.Added));
+                        }
+                    }
+                    else
+                    {
+                        Logger.Log($"MapLoader: Failed to load map info from {filePath}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log($"MapLoader: Error adding map from {filePath}: {ex.Message}");
+                }
+            });
+        }
+
+        private async Task HandleMapFileChanged(string filePath)
+        {
+            await Task.Run(() =>
+            {
+                try
+                {
+                    string baseFilePath = GetBaseFilePathFromFullPath(filePath);
+                    if (string.IsNullOrEmpty(baseFilePath))
+                        return;
+
+                    // If editing a map, the program that saved the new version may still
+                    // have a lock on the file. Retry a couple of times.
+                    Map newMap = null;
+                    bool success = false;
+                    for (int attempt = 0; attempt < 3; attempt++)
+                    {
+                        try
+                        {
+                            newMap = new Map(baseFilePath, true);
+                            if (newMap.SetInfoFromCustomMap())
+                            {
+                                success = true;
+                                break;
+                            }
+                        }
+                        catch (IOException)
+                        {
+                            if (attempt < 2)
+                                Thread.Sleep(100);
+                            else
+                                throw;
+                        }
+                    }
+
+                    if (success && newMap != null)
+                    {
+                        lock (mapModificationLock)
+                        {
+                            string oldSHA1 = FindMapSHA1ByFilePath(baseFilePath);
+
+                            if (!string.IsNullOrEmpty(oldSHA1))
+                            {
+                                if (oldSHA1 != newMap.SHA1)
+                                {
+                                    // SHA1 changed, remove old and add new
+                                    RemoveMapBySHA1(oldSHA1);
+                                    AddMapToGameModes(newMap, true);
+                                    UpdateGameModeMaps();
+
+                                    Logger.Log($"MapLoader: Updated map {newMap.Name} from {filePath} (SHA1 changed: {oldSHA1} -> {newMap.SHA1})");
+                                    MapChanged?.Invoke(this, new MapChangedEventArgs(newMap, MapChangeType.Updated, oldSHA1));
+                                }
+                                else
+                                {
+                                    Logger.Log($"MapLoader: Map file {filePath} changed but SHA1 remained the same ({newMap.SHA1})");
+                                }
+                            }
+                            else
+                            {
+                                // Map not found, treat as new
+                                Logger.Log($"MapLoader: Changed event for unknown map {filePath}, treating as new");
+                                AddMapToGameModes(newMap, true);
+                                UpdateGameModeMaps();
+                                MapChanged?.Invoke(this, new MapChangedEventArgs(newMap, MapChangeType.Added));
+                            }
+                        }
+                    }
+                    else
+                    {
+                        Logger.Log($"MapLoader: Failed to reload map info from {filePath}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log($"MapLoader: Error updating map from {filePath}: {ex.Message}");
+                }
+            });
+        }
+
+        private void HandleMapFileDeleted(string filePath)
+        {
+            try
+            {
+                string baseFilePath = GetBaseFilePathFromFullPath(filePath);
+                if (string.IsNullOrEmpty(baseFilePath))
+                    return;
+
+                lock (mapModificationLock)
+                {
+                    string mapSHA1 = FindMapSHA1ByFilePath(baseFilePath);
+
+                    if (!string.IsNullOrEmpty(mapSHA1))
+                    {
+                        var removedMap = FindMapBySHA1(mapSHA1);
+                        RemoveMapBySHA1(mapSHA1);
+                        UpdateGameModeMaps();
+
+                        Logger.Log($"MapLoader: Removed map from {filePath}");
+                        if (removedMap != null)
+                            MapChanged?.Invoke(this, new MapChangedEventArgs(removedMap, MapChangeType.Removed));
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"MapLoader: Error removing map from {filePath}: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Converts a full file path to the base file path used by the map system.
+        /// C:\YR\Maps\Custom\abc123.map > Maps\Custom\abc123
+        /// </summary>
+        private string GetBaseFilePathFromFullPath(string fullPath)
+        {
+            try
+            {
+                string gamePathNormalized = Path.GetFullPath(ProgramConstants.GamePath);
+                string fullPathNormalized = Path.GetFullPath(fullPath);
+
+                if (!fullPathNormalized.StartsWith(gamePathNormalized, StringComparison.OrdinalIgnoreCase))
+                    return null;
+
+                string relativePath = fullPathNormalized.Substring(gamePathNormalized.Length);
+                if (relativePath.StartsWith(Path.DirectorySeparatorChar.ToString()) ||
+                    relativePath.StartsWith(Path.AltDirectorySeparatorChar.ToString()))
+                {
+                    relativePath = relativePath.Substring(1);
+                }
+
+                string baseFilePath = relativePath.Substring(0, relativePath.Length - Path.GetExtension(relativePath).Length);
+
+                return baseFilePath.Replace(Path.DirectorySeparatorChar, '/').Replace(Path.AltDirectorySeparatorChar, '/');
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"MapLoader: Error converting file path {fullPath}: {ex.Message}");
+                return null;
+            }
+        }
+
+        private bool IsMapAlreadyLoaded(string sha1)
+        {
+            return GameModes.SelectMany(gm => gm.Maps).Any(map => map.SHA1 == sha1);
+        }
+
+        private Map FindMapBySHA1(string sha1)
+        {
+            return GameModes.SelectMany(gm => gm.Maps).FirstOrDefault(map => map.SHA1 == sha1);
+        }
+
+        private string FindMapSHA1ByFilePath(string baseFilePath)
+        {
+            return GameModes.SelectMany(gm => gm.Maps)
+                           .Where(map => !map.Official && map.BaseFilePath.Equals(baseFilePath, StringComparison.OrdinalIgnoreCase))
+                           .FirstOrDefault()?.SHA1;
+        }
+
+        private void RemoveMapBySHA1(string sha1)
+        {
+            foreach (var gameMode in GameModes)
+                gameMode.Maps.RemoveAll(map => map.SHA1 == sha1);
+        }
+
+        private void UpdateGameModeMaps()
+        {
+            GameModes.RemoveAll(g => g.Maps.Count < 1);
+            GameModeMaps = new GameModeMapCollection(GameModes);
         }
 
         private void LoadMultiMaps(IniFile mpMapsIni)


### PR DESCRIPTION
This PR adds a FileSystemWatcher to monitor the \maps\custom folder in order to add/update/remove maps on the fly without needing to restart the client.

![fsw-maps](https://github.com/user-attachments/assets/d29170a7-52a7-4dad-8e7f-30d65d5b1173)
