### PR TITLE
Reset player pings on tunnel change

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -1660,6 +1660,14 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         {
             tunnelHandler.CurrentTunnel = tunnel;
             AddNotice(string.Format("The game host has changed the tunnel server to: {0}".L10N("Client:Main:HostChangeTunnel"), tunnel.Name));
+
+            foreach (PlayerInfo pInfo in Players)
+            {
+                pInfo.Ping = -1;
+                UpdatePlayerPingIndicator(pInfo);
+            }
+
+            CopyPlayerDataToUI();
             UpdatePing();
         }
 


### PR DESCRIPTION
We should reset players' pings to unknown when the tunnel changes, otherwise the pings can be stale.