### PR TITLE
Fix RA1 indicators being misplaced

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
@@ -1,4 +1,4 @@
-﻿using ClientCore;
+using ClientCore;
 using DTAClient.Domain.Multiplayer;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -468,6 +468,13 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             List<Point> startingLocations = GameModeMap.Map.GetStartingLocationPreviewCoords(new Point(previewTexture.Width, previewTexture.Height));
 
+            // Disable all indicators to be able updated after changing
+            // locations when 2 or more of them have same location (RA1 specifics)
+            foreach (var indicator in startingLocationIndicators)
+            {
+                indicator.Disable();
+            }
+            
             for (int i = 0; i < startingLocations.Count && i < GameModeMap.Map.MaxPlayers; i++)
             {
                 PlayerLocationIndicator indicator = startingLocationIndicators[i];
@@ -480,12 +487,6 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 indicator.Enabled = true;
                 indicator.Visible = true;
             }
-
-            for (int i = startingLocations.Count; i < MAX_STARTING_LOCATIONS; i++)
-            {
-                startingLocationIndicators[i].Disable();
-            }
-
 
             foreach (var mapExtraTexture in GameModeMap.Map.GetExtraMapPreviewTextures())
             {


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/f8608c11-1d18-4e36-826f-32cc3c3158a0

After:

https://github.com/user-attachments/assets/3cfd9433-8ec4-4aa4-a24f-d0ab4e91b1c1