### PR TITLE
Add prompts when there are no games listed

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
@@ -1513,7 +1513,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 {
                     string message = "There are no games listed but you are indeed connected. The client did receive a game message but can't add it to the list because the message is invalid. " +
                         "You can ignore this prompt if there are games listed later. " +
-                        "Otherwise, this usually means that your client is outdated, or, in a rare case, newer than the server. Please check for updates.".L10N("Client:Main:InvalidGameMessage");
+                        "Otherwise, this usually means that your client is outdated, or, in a rare case, newer than others. Please check for updates.".L10N("Client:Main:InvalidGameMessage");
 
                     if ((lbChatMessages.Items.LastOrDefault()?.Tag as ChatMessage)?.Message != message)
                     {


### PR DESCRIPTION
Be aware! There is a localization bug in this PR, which is later fixed via commit https://github.com/CnCNet/xna-cncnet-client/commit/e41bb9eb4eecf80bad885992b9870f94e7124196

----
Currently the client shows nothing when a game is rejected to be shown in the game list, resulting in a confusing status. An empty game list might be causes by multiple reasons, and the most common ones are no tunnels or version mismatch. This PR addes some prompts when there are no games listed but the client does received CTCP messages, making users and/or the technical support easier.

<img width="2052" height="1260" alt="图片" src="https://github.com/user-attachments/assets/4b1dd38b-0416-443c-aeb5-5a98c25fefd7" />
