### PR TITLE
Improve IME handling for ESC key

### DIFF
--- a/ClientGUI/IME/IMEHandler.cs
+++ b/ClientGUI/IME/IMEHandler.cs
@@ -221,9 +221,6 @@ public abstract class IMEHandler : IIMEHandler
         => false;
 
     bool IIMEHandler.HandleEscapeKey(XNATextBox sender)
-        => HandleEscapeKey();
-
-    private bool HandleEscapeKey()
     {
         //Debug.WriteLine($"IME: HandleEscapeKey: handled: {IMEEventReceived}");
 
@@ -233,6 +230,7 @@ public abstract class IMEHandler : IIMEHandler
         // For example, the user might mistakenly hit ESC key twice to cancel composition -- deleting the whole sentence is definitely a heavy punishment for such a small mistake.
 
         // Note: "!CompositionEmpty => IMEEventReceived" should hold, but just in case
+
         return IMEEventReceived || !CompositionEmpty;
     }
 


### PR DESCRIPTION
An IME user => hit ESC key does not clear the textbox (intended)
A user who has not used IME ever => hit ESC key clears the textbox

Explanation:


        // This method disables the ESC handling of the TextBox as long as the user has ever used IME.
        // This is because IME users often use ESC to cancel composition. Even if currently the composition is empty,
        // the user still expects ESC to cancel composition rather than deleting the whole sentence.
        // For example, the user might mistakenly hit ESC key twice to cancel composition -- deleting the whole sentence is definitely a heavy punishment for such a small mistake.