### PR TITLE
Add icon legend to GameInformationPanel

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameInformationIconPanel.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameInformationIconPanel.cs
@@ -15,6 +15,7 @@ namespace DTAClient.DXGUI.Multiplayer
     {
         private readonly Texture2D icon;
         private readonly string label;
+        private const int iconLabelSpacing = 6;
         public int FontIndex = 1;
 
         public GameInformationIconPanel(WindowManager windowManager, Texture2D icon, string label) : base(windowManager)
@@ -40,7 +41,7 @@ namespace DTAClient.DXGUI.Multiplayer
             int panelHeight = Math.Max(icon.Height, textHeight);
             float textY = (panelHeight - textHeight) / 2f;
 
-            DrawString(label, FontIndex, new Vector2(icon.Width + 6, textY), UISettings.ActiveSettings.TextColor);
+            DrawString(label, FontIndex, new Vector2(icon.Width + iconLabelSpacing, textY), UISettings.ActiveSettings.TextColor);
         }
     }
 }

--- a/DXMainClient/DXGUI/Multiplayer/GameInformationIconPanel.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameInformationIconPanel.cs
@@ -1,0 +1,46 @@
+﻿using System;
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+using Rampastring.XNAUI;
+using Rampastring.XNAUI.XNAControls;
+
+namespace DTAClient.DXGUI.Multiplayer
+{
+    ///<summary>
+    /// A panel for showing a game information icon next to its associated label.
+    ///</summary>
+    public class GameInformationIconPanel : XNAPanel
+    {
+        private readonly Texture2D icon;
+        private readonly string label;
+        public int FontIndex = 1;
+
+        public GameInformationIconPanel(WindowManager windowManager, Texture2D icon, string label) : base(windowManager)
+        {
+            this.icon = icon;
+            this.label = label;
+
+            DrawBorders = false;
+        }
+
+        public override void Draw(GameTime gameTime)
+        {
+            base.Draw(gameTime);
+
+            var textSize = Renderer.GetTextDimensions(label, FontIndex);
+            int textHeight = (int)textSize.Y;
+
+            int iconY = (textHeight - icon.Height) / 2;
+            if (iconY < 0) iconY = 0;
+
+            DrawTexture(icon, new Rectangle(0, iconY, icon.Width, icon.Height), Color.White);
+
+            int panelHeight = Math.Max(icon.Height, textHeight);
+            float textY = (panelHeight - textHeight) / 2f;
+
+            DrawString(label, FontIndex, new Vector2(icon.Width + 6, textY), UISettings.ActiveSettings.TextColor);
+        }
+    }
+}

--- a/DXMainClient/DXGUI/Multiplayer/GameInformationPanel.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameInformationPanel.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
 
 using ClientCore;
 using ClientCore.Extensions;
@@ -290,11 +290,11 @@ namespace DTAClient.DXGUI.Multiplayer
             ClientRectangle = new Rectangle(ClientRectangle.X, ClientRectangle.Y, ClientRectangle.Width, pnlIconLegend.Bottom);
         }
 
-        private XNAPanel CreateDivider(int y)
+        private XNAPanel CreateDivider(int y, int height = 1)
         {
             var dividerPanel = new XNAPanel(WindowManager);
             dividerPanel.DrawBorders = true;
-            dividerPanel.ClientRectangle = new Rectangle(0, y, ClientRectangle.Width, 1);
+            dividerPanel.ClientRectangle = new Rectangle(0, y, ClientRectangle.Width, height);
             return dividerPanel;
         }
 


### PR DESCRIPTION
Originally here: #323 by devo1929. I've updated it to work with the latest client and made a couple other minor changes.
Closes #290 

![gameinfopanel](https://github.com/user-attachments/assets/48b03e81-e1d5-42f8-85ec-e44bff76404c)
(poor gif encoding - that red X actually looks fine)