### PR TITLE
Add check for HostedGames count before displaying "no games" message

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
@@ -1509,7 +1509,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 Logger.Log("Ignoring CTCP game message because of an invalid amount of parameters.");
 
                 // Remind users that the network is good but the client is outdated or newer
-                if (lbGameList.Items.Count == 0)
+                if (lbGameList.Items.Count == 0 && lbGameList.HostedGames.Count == 0)
                 {
                     string message = ("There are no games listed but you are indeed connected. The client did receive a game message but can't add it to the list because the message is invalid. " +
                         "You can ignore this prompt if there are games listed later. " +
@@ -1563,7 +1563,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                     Logger.Log("Ignoring CTCP game message because there are no tunnels at all. Available tunnel count: 0. Is the connection to CnCNet HTTP service broken?");
 
                     // Remind users that the game is ignored because of no tunnel
-                    if (lbGameList.Items.Count == 0)
+                    if (lbGameList.Items.Count == 0 && lbGameList.HostedGames.Count == 0)
                     {
                         string message = ("There are no games listed. The client did receive a valid game message but can't add it to the list because there are no available tunnels. " +
                             "You can ignore this prompt if there are games listed later. Otherwise, it might indicate a network problem to CnCNet HTTP service.").L10N("Client:Main:NoTunnels");
@@ -1585,7 +1585,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                         tunnelAddress, tunnelPort, tunnelHandler.Tunnels.Count));
 
                     // Remind users that the game is ignored because of no specified tunnel
-                    if (lbGameList.Items.Count == 0)
+                    if (lbGameList.Items.Count == 0 && lbGameList.HostedGames.Count == 0)
                     {
                         string message = string.Format(("There are no games listed. The client did receive a valid game message but can't add it to the list because the specified tunnel is not available. " +
                             "You can ignore this prompt if there are games listed later. Otherwise, please contact support at {0}.").L10N("Client:Main:NoTunnelForGames"), ClientConfiguration.Instance.LongSupportURL);


### PR DESCRIPTION
With the new message that gets shown when no games are available, we should check the HostedGames count also (or instead of). This is because the user could have filtered the games which means there are no games listed (but there are still games available).

<img width="396" height="125" alt="image" src="https://github.com/user-attachments/assets/bb4ca92a-b907-4d83-baf4-0065740afaee" />
