### PR TITLE
Fix loaded preset game options getting reset

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -2718,7 +2718,10 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             {
                 GameLobbyCheckBox checkBox = CheckBoxes.Find(c => c.Name == kvp.Key);
                 if (checkBox != null && checkBox.AllowChanges && checkBox.AllowChecking)
+                {
                     checkBox.Checked = kvp.Value;
+                    checkBox.HostChecked = kvp.Value;
+                }
             }
 
             var dropDownValues = preset.GetDropDownValues();
@@ -2726,7 +2729,10 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             {
                 GameLobbyDropDown dropDown = DropDowns.Find(d => d.Name == kvp.Key);
                 if (dropDown != null && dropDown.AllowDropDown)
+                {
                     dropDown.SelectedIndex = kvp.Value;
+                    dropDown.HostSelectedIndex = kvp.Value;
+                }
             }
 
             disableGameOptionUpdateBroadcast = false;


### PR DESCRIPTION
Closes #795 
Haven't tested, but pretty sure will fix this too https://github.com/CnCNet/cncnet-yr-client-package/issues/368

-----

If you load game options then change map, the game options will revert to what it was before you loaded. This fixes it for both LANLobby and CnCNetLobby. Loading lobby doesn't need changes.

Will approve in a couple days if no feedback.