### PR TITLE
Roll forward .NET SDK when building in GitHub CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         submodules: recursive
 
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         global-json-file: ./global.json
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -16,7 +16,7 @@ jobs:
         submodules: recursive
 
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         global-json-file: ./global.json
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "rollForward": "major",
+    "rollForward": "latestFeature",
     "version": "8.0.200"
   }
 }


### PR DESCRIPTION
This PR avoids always using an outdated .NET `8.0.200` SDK version regardless of there is a newer patch for 8.0.

`"rollForward": "latestFeature"` is the only accepted option in `setup-dotnet` (preserve the first and second number in version)

```
dotnet-install: Installed version is 8.0.416
```

This PR DOES NOT solve the GitVersion `IOException: The process cannot access the file 'D:\a\_temp\_runner_file_commands\set_env_33da9d0c-13f5-427b-9a91-29d3722f485b' because it is being used by another process` error.