### PR TITLE
Try to avoid GitVersion race condition in writing log file

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,6 +12,9 @@
     <Trademark>CnCNet</Trademark>
     <!-- GitVersion will rewrite the informational version anyway -->
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
+
+    <!-- There is a race condition in GitVersion. Disable writing version info should help a bit -->
+    <WriteVersionInfoToBuildLog Condition="'$(IsSubmodule)' == 'true'">true</WriteVersionInfoToBuildLog>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 
     <!-- There is a race condition in GitVersion. Disable writing version info should help a bit -->
-    <WriteVersionInfoToBuildLog Condition="'$(IsSubmodule)' == 'true'">true</WriteVersionInfoToBuildLog>
+    <WriteVersionInfoToBuildLog>false</WriteVersionInfoToBuildLog>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
After including Rampastring.Tools and Rampastring.XNAUI with GitVersion support, the chance of CI crash has been significantly increasing.

>   Rampastring.Tools -> D:\a\xna-cncnet-client\xna-cncnet-client\Rampastring.XNAUI\Rampastring.Tools\bin\Release\WindowsGL\netstandard2.0\Rampastring.Tools.dll
C:\Users\runneradmin.nuget\packages\gitversion.msbuild\5.12.0\tools\GitVersion.MsBuild.targets(13,9): error : IOException: The process cannot access the file 'D:\a_temp_runner_file_commands\set_env_f2fb62c7-554b-4a2f-ade8-e20b4c296919' because it is being used by another process. [D:\a\xna-cncnet-client\xna-cncnet-client\Rampastring.XNAUI\Rampastring.Tools\Rampastring.Tools.csproj::TargetFramework=net8.0]

This PR turned off the corresponding file writing (we don't need it anyway), hoping it can avoid such a race condition

Ref:

`GitVersion.MsBuild.targets` file:
```xml
    <Target Name="WriteVersionInfoToBuildLog" DependsOnTargets="RunGitVersion" BeforeTargets="$(GitVersionTargetsBefore)" Condition="$(WriteVersionInfoToBuildLog) == 'true'">
        <WriteVersionInfoToBuildLog SolutionDirectory="$(GitVersionPath)" VersionFile="$(GitVersionOutputFile)" />
    </Target>
```