### PR TITLE
Greatly reduce time cost in generating and loading custom map cache

### DIFF
--- a/DXMainClient/Domain/Multiplayer/CustomMapCache.cs
+++ b/DXMainClient/Domain/Multiplayer/CustomMapCache.cs
@@ -47,17 +47,10 @@ namespace DTAClient.Domain.Multiplayer
                 }
             }
 
-            public void RefreshIfOutdated()
+            public bool IsOutdated()
             {
                 Item refreshedItem = new(Map);
-                bool recalculateSHA = refreshedItem.FileSize != FileSize || refreshedItem.LastWriteTimeUtc != LastWriteTimeUtc;
-                if (recalculateSHA)
-                {
-                    FileSize = refreshedItem.FileSize;
-                    LastWriteTimeUtc = refreshedItem.LastWriteTimeUtc;
-                }
-
-                Map.AfterDeserialize(recalculateSHA);
+                return refreshedItem.FileSize != FileSize || refreshedItem.LastWriteTimeUtc != LastWriteTimeUtc;
             }
         }
     }

--- a/DXMainClient/Domain/Multiplayer/CustomMapCache.cs
+++ b/DXMainClient/Domain/Multiplayer/CustomMapCache.cs
@@ -16,16 +16,16 @@ namespace DTAClient.Domain.Multiplayer
         [JsonPropertyName("maps")]
         public required ConcurrentDictionary<string, Item> Items { get; set; }
 
-        public class Item
+        public record Item
         {
             [JsonInclude]
             public required Map Map { get; init; }
 
             [JsonInclude]
-            public required long FileSize { get; init; }
+            public long FileSize { get; private set; }
 
             [JsonInclude]
-            public required DateTime LastWriteTimeUtc { get; init; }
+            public DateTime LastWriteTimeUtc { get; private set; }
 
             public Item() : base() { }
 
@@ -49,9 +49,15 @@ namespace DTAClient.Domain.Multiplayer
 
             public void RefreshIfOutdated()
             {
-                FileInfo fileInfo = new(Map.CompleteFilePath);
-                bool recalculateSHA = fileInfo.Exists && (fileInfo.Length != FileSize || fileInfo.LastWriteTimeUtc != LastWriteTimeUtc);
-                Map.AfterDeserialize(recalculateSHA);
+                Item refreshedItem = new(Map);
+                bool recalculateSHA = refreshedItem.FileSize != FileSize || refreshedItem.LastWriteTimeUtc != LastWriteTimeUtc;
+                if (recalculateSHA)
+                {
+                    FileSize = refreshedItem.FileSize;
+                    LastWriteTimeUtc = refreshedItem.LastWriteTimeUtc;
+
+                    Map.AfterDeserialize(recalculateSHA);
+                }
             }
         }
     }

--- a/DXMainClient/Domain/Multiplayer/CustomMapCache.cs
+++ b/DXMainClient/Domain/Multiplayer/CustomMapCache.cs
@@ -44,9 +44,6 @@ namespace DTAClient.Domain.Multiplayer
 
             public void RefreshIfOutdated()
             {
-                if (!File.Exists(Map.CompleteFilePath))
-                    return;
-
                 FileInfo fileInfo = new(Map.CompleteFilePath);
                 bool recalculateSHA = fileInfo.Exists && (fileInfo.Length != FileSize || fileInfo.LastWriteTimeUtc != LastWriteTimeUtc);
                 Map.AfterDeserialize(recalculateSHA);

--- a/DXMainClient/Domain/Multiplayer/CustomMapCache.cs
+++ b/DXMainClient/Domain/Multiplayer/CustomMapCache.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Text.Json.Serialization;
 
 namespace DTAClient.Domain.Multiplayer
@@ -7,10 +10,47 @@ namespace DTAClient.Domain.Multiplayer
     {
         [JsonInclude]
         [JsonPropertyName("version")]
-        public int Version { get; set; }
+        public required int Version { get; set; }
 
         [JsonInclude]
         [JsonPropertyName("maps")]
-        public ConcurrentDictionary<string, Map> Maps { get; set; }
+        public required ConcurrentDictionary<string, Item> Items { get; set; }
+
+        public class Item
+        {
+            [JsonInclude]
+            public required Map Map { get; init; }
+
+            [JsonInclude]
+            public required long FileSize { get; init; }
+
+            [JsonInclude]
+            public required DateTime LastWriteTimeUtc { get; init; }
+
+            public Item() : base() { }
+
+            [SetsRequiredMembers]
+            public Item(Map map)
+            {
+                Map = map;
+
+                FileInfo fileInfo = new(Map.CompleteFilePath);
+                if (fileInfo.Exists)
+                {
+                    FileSize = fileInfo.Length;
+                    LastWriteTimeUtc = fileInfo.LastWriteTimeUtc;
+                }
+            }
+
+            public void RefreshIfOutdated()
+            {
+                if (!File.Exists(Map.CompleteFilePath))
+                    return;
+
+                FileInfo fileInfo = new(Map.CompleteFilePath);
+                bool recalculateSHA = fileInfo.Exists && (fileInfo.Length != FileSize || fileInfo.LastWriteTimeUtc != LastWriteTimeUtc);
+                Map.AfterDeserialize(recalculateSHA);
+            }
+        }
     }
 }

--- a/DXMainClient/Domain/Multiplayer/CustomMapCache.cs
+++ b/DXMainClient/Domain/Multiplayer/CustomMapCache.cs
@@ -40,6 +40,11 @@ namespace DTAClient.Domain.Multiplayer
                     FileSize = fileInfo.Length;
                     LastWriteTimeUtc = fileInfo.LastWriteTimeUtc;
                 }
+                else
+                {
+                    FileSize = 0;
+                    LastWriteTimeUtc = DateTime.MinValue;
+                }
             }
 
             public void RefreshIfOutdated()

--- a/DXMainClient/Domain/Multiplayer/CustomMapCache.cs
+++ b/DXMainClient/Domain/Multiplayer/CustomMapCache.cs
@@ -55,9 +55,9 @@ namespace DTAClient.Domain.Multiplayer
                 {
                     FileSize = refreshedItem.FileSize;
                     LastWriteTimeUtc = refreshedItem.LastWriteTimeUtc;
-
-                    Map.AfterDeserialize(recalculateSHA);
                 }
+
+                Map.AfterDeserialize(recalculateSHA);
             }
         }
     }

--- a/DXMainClient/Domain/Multiplayer/Map.cs
+++ b/DXMainClient/Domain/Multiplayer/Map.cs
@@ -65,7 +65,7 @@ namespace DTAClient.Domain.Multiplayer
         /// The name of the map.
         /// </summary>
         [JsonIgnore]
-        public string Name => string.IsNullOrEmpty(UntranslatedName) || string.IsNullOrEmpty(BaseFilePath)
+        public string Name => !Official || string.IsNullOrEmpty(UntranslatedName) || string.IsNullOrEmpty(BaseFilePath)
             ? UntranslatedName
             : UntranslatedName.L10N($"INI:Maps:{BaseFilePath}:Description");
 

--- a/DXMainClient/Domain/Multiplayer/Map.cs
+++ b/DXMainClient/Domain/Multiplayer/Map.cs
@@ -637,7 +637,12 @@ namespace DTAClient.Domain.Multiplayer
         {
             Name = UntranslatedName;
             if (recalculateSHA)
+            {
+                // Instead of doing so, we should just remove the Map object from cache when the map file changes.
+                // Otherwise, the metadata can be out of date.
+                Debug.Assert(false, "The map SHA1 should not be recalculated after deserialization. Remove the Map object from cache when the map file changes instead.");
                 CalculateSHA();
+            }
         }
 
         private void ParseForcedOptions(IniFile iniFile, string forcedOptionsSection)

--- a/DXMainClient/Domain/Multiplayer/Map.cs
+++ b/DXMainClient/Domain/Multiplayer/Map.cs
@@ -64,25 +64,13 @@ namespace DTAClient.Domain.Multiplayer
         /// <summary>
         /// The name of the map.
         /// </summary>
-        [JsonIgnore]
-        public string Name => !Official || string.IsNullOrEmpty(UntranslatedName) || string.IsNullOrEmpty(BaseFilePath)
-            ? UntranslatedName
-            : UntranslatedName.L10N($"INI:Maps:{BaseFilePath}:Description");
+        [JsonInclude]
+        public string Name { get; private set; }
 
         /// <summary>
         /// The original untranslated name of the map.
         /// </summary>
-        [JsonInclude]
-        public string UntranslatedName
-        {
-            get => field;
-            private set
-            {
-                field = value;
-                // Force triggering localization of the name now
-                _ = Name;
-            }
-        }
+        public string UntranslatedName { get; private set; }
 
         /// <summary>
         /// The maximum amount of players supported by the map.
@@ -301,6 +289,8 @@ namespace DTAClient.Domain.Multiplayer
                 var section = iniFile.GetSection(BaseFilePath);
 
                 UntranslatedName = section.GetStringValue("Description", "Unnamed map");
+                Name = UntranslatedName
+                    .L10N($"INI:Maps:{BaseFilePath}:Description");
 
                 Author = section.GetStringValue("Author", "Unknown author");
                 GameModes = section.GetStringValue("GameModes", "Default").Split(',');
@@ -541,7 +531,7 @@ namespace DTAClient.Domain.Multiplayer
 
                 IniSection basicSection = iniFile.GetSection("Basic");
 
-                UntranslatedName = basicSection.GetStringValue("Name", "Unnamed map");
+                UntranslatedName = Name = basicSection.GetStringValue("Name", "Unnamed map");
                 Author = basicSection.GetStringValue("Author", "Unknown author");
 
                 string gameModesString = basicSection.GetStringValue("GameModes", string.Empty);
@@ -656,6 +646,8 @@ namespace DTAClient.Domain.Multiplayer
                 Debug.Assert(false, "The map SHA1 should not be recalculated after deserialization. Remove the Map object from cache when the map file changes instead.");
                 CalculateSHA();
             }
+
+            UntranslatedName = Name;
         }
 
         private void ParseForcedOptions(IniFile iniFile, string forcedOptionsSection)

--- a/DXMainClient/Domain/Multiplayer/Map.cs
+++ b/DXMainClient/Domain/Multiplayer/Map.cs
@@ -64,12 +64,13 @@ namespace DTAClient.Domain.Multiplayer
         /// <summary>
         /// The name of the map.
         /// </summary>
-        [JsonInclude]
+        [JsonIgnore]
         public string Name { get; private set; }
 
         /// <summary>
         /// The original untranslated name of the map.
         /// </summary>
+        [JsonInclude]
         public string UntranslatedName { get; private set; }
 
         /// <summary>
@@ -127,7 +128,7 @@ namespace DTAClient.Domain.Multiplayer
         /// <summary>
         /// The calculated SHA1 of the map.
         /// </summary>
-        [JsonIgnore]
+        [JsonInclude]
         public string SHA1 { get; private set; }
 
         /// <summary>
@@ -641,10 +642,10 @@ namespace DTAClient.Domain.Multiplayer
         }
 
         // Ran after the map has been loaded from cache if it is a custom map.
-        public void AfterDeserialize()
+        public void AfterDeserialize(bool recalculateSHA = true)
         {
-            CalculateSHA();
-            UntranslatedName = Name;
+            if (recalculateSHA)
+                CalculateSHA();
         }
 
         private void ParseForcedOptions(IniFile iniFile, string forcedOptionsSection)

--- a/DXMainClient/Domain/Multiplayer/Map.cs
+++ b/DXMainClient/Domain/Multiplayer/Map.cs
@@ -73,7 +73,16 @@ namespace DTAClient.Domain.Multiplayer
         /// The original untranslated name of the map.
         /// </summary>
         [JsonInclude]
-        public string UntranslatedName { get; private set; }
+        public string UntranslatedName
+        {
+            get => field;
+            private set
+            {
+                field = value;
+                // Force triggering localization of the name now
+                _ = Name;
+            }
+        }
 
         /// <summary>
         /// The maximum amount of players supported by the map.

--- a/DXMainClient/Domain/Multiplayer/Map.cs
+++ b/DXMainClient/Domain/Multiplayer/Map.cs
@@ -644,6 +644,7 @@ namespace DTAClient.Domain.Multiplayer
         // Ran after the map has been loaded from cache if it is a custom map.
         public void AfterDeserialize(bool recalculateSHA = true)
         {
+            Name = UntranslatedName;
             if (recalculateSHA)
                 CalculateSHA();
         }

--- a/DXMainClient/Domain/Multiplayer/Map.cs
+++ b/DXMainClient/Domain/Multiplayer/Map.cs
@@ -65,7 +65,9 @@ namespace DTAClient.Domain.Multiplayer
         /// The name of the map.
         /// </summary>
         [JsonIgnore]
-        public string Name { get; private set; }
+        public string Name => string.IsNullOrEmpty(UntranslatedName) || string.IsNullOrEmpty(BaseFilePath)
+            ? UntranslatedName
+            : UntranslatedName.L10N($"INI:Maps:{BaseFilePath}:Description");
 
         /// <summary>
         /// The original untranslated name of the map.
@@ -290,8 +292,6 @@ namespace DTAClient.Domain.Multiplayer
                 var section = iniFile.GetSection(BaseFilePath);
 
                 UntranslatedName = section.GetStringValue("Description", "Unnamed map");
-                Name = UntranslatedName
-                    .L10N($"INI:Maps:{BaseFilePath}:Description");
 
                 Author = section.GetStringValue("Author", "Unknown author");
                 GameModes = section.GetStringValue("GameModes", "Default").Split(',');
@@ -532,7 +532,7 @@ namespace DTAClient.Domain.Multiplayer
 
                 IniSection basicSection = iniFile.GetSection("Basic");
 
-                UntranslatedName = Name = basicSection.GetStringValue("Name", "Unnamed map");
+                UntranslatedName = basicSection.GetStringValue("Name", "Unnamed map");
                 Author = basicSection.GetStringValue("Author", "Unknown author");
 
                 string gameModesString = basicSection.GetStringValue("GameModes", string.Empty);
@@ -640,7 +640,6 @@ namespace DTAClient.Domain.Multiplayer
         // Ran after the map has been loaded from cache if it is a custom map.
         public void AfterDeserialize(bool recalculateSHA = true)
         {
-            Name = UntranslatedName;
             if (recalculateSHA)
             {
                 // Instead of doing so, we should just remove the Map object from cache when the map file changes.

--- a/DXMainClient/Domain/Multiplayer/Map.cs
+++ b/DXMainClient/Domain/Multiplayer/Map.cs
@@ -496,16 +496,21 @@ namespace DTAClient.Domain.Multiplayer
         }
 
         /// <summary>Returns the loaded INI file of a custom map.</summary>
-        private IniFile GetCustomMapIniFile()
+        private IniFile GetCustomMapIniFile(bool loadPreviewTextureSection = true)
         {
             var customMapIni = new IniFile { FileName = SafePath.CombineFilePath(customMapFilePath) };
             customMapIni.AddSection("Basic");
             customMapIni.AddSection("Map");
             customMapIni.AddSection("Waypoints");
-            customMapIni.AddSection("Preview");
-            customMapIni.AddSection("PreviewPack");
             customMapIni.AddSection("ForcedOptions");
             customMapIni.AddSection("ForcedSpawnIniOptions");
+
+            // Optionally load preview sections, to accelerate building custom map caches without reading preview.
+            if (loadPreviewTextureSection)
+            {
+                customMapIni.AddSection("Preview");
+                customMapIni.AddSection("PreviewPack");
+            }
             customMapIni.AllowNewSections = false;
             customMapIni.Parse();
 
@@ -523,7 +528,7 @@ namespace DTAClient.Domain.Multiplayer
 
             try
             {
-                IniFile iniFile = GetCustomMapIniFile();
+                IniFile iniFile = GetCustomMapIniFile(loadPreviewTextureSection: false);
 
                 IniSection basicSection = iniFile.GetSection("Basic");
 
@@ -696,7 +701,7 @@ namespace DTAClient.Domain.Multiplayer
             {
                 // Extract preview from the map itself
                 // TODO: implement a global cache for the preview texture. Don't cache either the texture or the map ini in the Map object itself.
-                using Image preview = MapPreviewExtractor.ExtractMapPreview(GetCustomMapIniFile());
+                using Image preview = MapPreviewExtractor.ExtractMapPreview(GetCustomMapIniFile(loadPreviewTextureSection: true));
 
                 if (preview != null)
                 {

--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -481,7 +481,7 @@ namespace DTAClient.Domain.Multiplayer
         /// <summary>
         /// Save cache of custom maps.
         /// </summary>
-        /// <param name="customMaps">Custom maps to cache</param>
+        /// <param name="customMapCache">Custom maps to cache</param>
         private void CacheCustomMaps(CustomMapCache customMapCache)
         {
             var jsonData = JsonSerializer.Serialize(customMapCache, jsonSerializerOptions);

--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -23,11 +23,14 @@ namespace DTAClient.Domain.Multiplayer
     public class MapLoader
     {
         private const string CUSTOM_MAPS_DIRECTORY = "Maps/Custom";
-        private static readonly string CUSTOM_MAPS_CACHE = SafePath.CombineFilePath(ProgramConstants.ClientUserFilesPath, "custom_map_cache");
+        private static readonly IReadOnlyList<string> LEGACY_CUSTOM_MAP_CACHE_FILES = [
+            SafePath.CombineFilePath(ProgramConstants.ClientUserFilesPath, "custom_map_cache"),
+        ];
+        private static readonly string CUSTOM_MAPS_CACHE = SafePath.CombineFilePath(ProgramConstants.ClientUserFilesPath, "custom_map_cache_v2");
         private const string MultiMapsSection = "MultiMaps";
         private const string GameModesSection = "GameModes";
         private const string GameModeAliasesSection = "GameModeAliases";
-        private const int CurrentCustomMapCacheVersion = 1;
+        private const int CurrentCustomMapCacheVersion = 2;
         private readonly JsonSerializerOptions jsonSerializerOptions = new JsonSerializerOptions { IncludeFields = true };
         private MapFileWatcher mapFileWatcher;
         private readonly object mapModificationLock = new object();
@@ -161,7 +164,7 @@ namespace DTAClient.Domain.Multiplayer
                     }
                     catch (IOException)
                     {
-                        if (attempt < _mapChangeRetryCount-1)
+                        if (attempt < _mapChangeRetryCount - 1)
                             await Task.Delay(100);
                         else
                             throw;
@@ -219,7 +222,7 @@ namespace DTAClient.Domain.Multiplayer
                     }
                     catch (IOException)
                     {
-                        if (attempt < _mapChangeRetryCount-1)
+                        if (attempt < _mapChangeRetryCount - 1)
                             await Task.Delay(100);
                         else
                             throw;
@@ -436,7 +439,7 @@ namespace DTAClient.Domain.Multiplayer
             }
 
             IEnumerable<FileInfo> mapFiles = customMapsDirectory.EnumerateFiles($"*.{ClientConfiguration.Instance.MapFileExtension}");
-            ConcurrentDictionary<string, Map> customMapCache = LoadCustomMapCache();
+            CustomMapCache customMapCache = LoadCustomMapCache();
             var localMapSHAs = new ConcurrentBag<string>();
 
             var tasks = new List<Task>();
@@ -453,23 +456,23 @@ namespace DTAClient.Domain.Multiplayer
                         .Replace(Path.AltDirectorySeparatorChar, '/'), true);
                     map.CalculateSHA();
                     localMapSHAs.Add(map.SHA1);
-                    if (!customMapCache.ContainsKey(map.SHA1) && map.SetInfoFromCustomMap())
-                        customMapCache.TryAdd(map.SHA1, map);
+                    if (!customMapCache.Items.ContainsKey(map.SHA1) && map.SetInfoFromCustomMap())
+                        customMapCache.Items.TryAdd(map.SHA1, new CustomMapCache.Item(map));
                 }));
             }
 
             Task.WaitAll(tasks.ToArray());
 
             // remove cached maps that no longer exist locally
-            foreach (var missingSHA in customMapCache.Keys.Where(cachedSHA => !localMapSHAs.Contains(cachedSHA)))
+            foreach (var missingSHA in customMapCache.Items.Keys.Where(cachedSHA => !localMapSHAs.Contains(cachedSHA)))
             {
-                customMapCache.TryRemove(missingSHA, out _);
+                customMapCache.Items.TryRemove(missingSHA, out _);
             }
 
             // save cache
             CacheCustomMaps(customMapCache);
 
-            foreach (Map map in customMapCache.Values)
+            foreach (Map map in customMapCache.Items.Values.Select(item => item.Map))
             {
                 AddMapToGameModes(map, false);
             }
@@ -479,13 +482,8 @@ namespace DTAClient.Domain.Multiplayer
         /// Save cache of custom maps.
         /// </summary>
         /// <param name="customMaps">Custom maps to cache</param>
-        private void CacheCustomMaps(ConcurrentDictionary<string, Map> customMaps)
+        private void CacheCustomMaps(CustomMapCache customMapCache)
         {
-            var customMapCache = new CustomMapCache
-            {
-                Maps = customMaps,
-                Version = CurrentCustomMapCacheVersion
-            };
             var jsonData = JsonSerializer.Serialize(customMapCache, jsonSerializerOptions);
 
             File.WriteAllText(CUSTOM_MAPS_CACHE, jsonData);
@@ -495,25 +493,42 @@ namespace DTAClient.Domain.Multiplayer
         /// Load previously cached custom maps
         /// </summary>
         /// <returns></returns>
-        private ConcurrentDictionary<string, Map> LoadCustomMapCache()
+        private CustomMapCache LoadCustomMapCache()
         {
+            // Delete any legacy cache files
+            foreach (string legacyCacheFile in LEGACY_CUSTOM_MAP_CACHE_FILES)
+            {
+                if (File.Exists(legacyCacheFile))
+                {
+                    try
+                    {
+                        File.Delete(legacyCacheFile);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Log($"Failed to delete legacy custom map cache file {legacyCacheFile}: {ex.Message}");
+                    }
+                }
+            }
+
+            // Load current cache
             try
             {
                 var jsonData = File.ReadAllText(CUSTOM_MAPS_CACHE);
 
                 var customMapCache = JsonSerializer.Deserialize<CustomMapCache>(jsonData, jsonSerializerOptions);
 
-                var customMaps = customMapCache?.Version == CurrentCustomMapCacheVersion && customMapCache.Maps != null
-                    ? customMapCache.Maps : new ConcurrentDictionary<string, Map>();
+                if (customMapCache?.Version != CurrentCustomMapCacheVersion)
+                    return new CustomMapCache() { Version = CurrentCustomMapCacheVersion, Items = [] };
 
-                foreach (var customMap in customMaps.Values)
-                    customMap.AfterDeserialize();
+                foreach (CustomMapCache.Item customMap in customMapCache.Items.Values)
+                    customMap.RefreshIfOutdated();
 
-                return customMaps;
+                return customMapCache;
             }
             catch (Exception)
             {
-                return new ConcurrentDictionary<string, Map>();
+                return new CustomMapCache() { Version = CurrentCustomMapCacheVersion, Items = [] };
             }
         }
 

--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -496,18 +496,15 @@ namespace DTAClient.Domain.Multiplayer
         private CustomMapCache LoadCustomMapCache()
         {
             // Delete any legacy cache files
-            foreach (string legacyCacheFile in LEGACY_CUSTOM_MAP_CACHE_FILES)
+            foreach (string legacyCacheFile in LEGACY_CUSTOM_MAP_CACHE_FILES.Where(File.Exists))
             {
-                if (File.Exists(legacyCacheFile))
+                try
                 {
-                    try
-                    {
-                        File.Delete(legacyCacheFile);
-                    }
-                    catch (Exception ex)
-                    {
-                        Logger.Log($"Failed to delete legacy custom map cache file {legacyCacheFile}: {ex.Message}");
-                    }
+                    File.Delete(legacyCacheFile);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log($"Failed to delete legacy custom map cache file {legacyCacheFile}: {ex.Message}");
                 }
             }
 

--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -519,7 +519,7 @@ namespace DTAClient.Domain.Multiplayer
                     return new CustomMapCache() { Version = CurrentCustomMapCacheVersion, Items = [] };
 
                 foreach (CustomMapCache.Item customMap in customMapCache.Items.Values)
-                    customMap.Map.AfterDeserialize();
+                    customMap.Map.AfterDeserialize(recalculateSHA: false);
 
                 // Remove outdated items
                 foreach (var sha1 in customMapCache.Items.Keys.ToList())

--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -519,7 +519,16 @@ namespace DTAClient.Domain.Multiplayer
                     return new CustomMapCache() { Version = CurrentCustomMapCacheVersion, Items = [] };
 
                 foreach (CustomMapCache.Item customMap in customMapCache.Items.Values)
-                    customMap.RefreshIfOutdated();
+                    customMap.Map.AfterDeserialize();
+
+                // Remove outdated items
+                foreach (var sha1 in customMapCache.Items.Keys.ToList())
+                {
+                    if (customMapCache.Items[sha1].IsOutdated())
+                    {
+                        customMapCache.Items.TryRemove(sha1, out _);
+                    }
+                }
 
                 return customMapCache;
             }


### PR DESCRIPTION
This PR upgrades the custom map cache feature, bumping version to v2.
- Optionally invalidate the map file only if the file size or last write time gets changed. The old recalculate SHA method is not used anymore since it is time consuming and also results in metadata mismatch.
- Improve the behavior with map name translation in cached map.

<img width="933" height="671" alt="图片" src="https://github.com/user-attachments/assets/e187e54d-97d0-4d0f-bab6-a2065d01ba5f" />
<img width="970" height="707" alt="图片" src="https://github.com/user-attachments/assets/642a0d2c-a5b2-4af9-9c64-f4954f02fc97" />
