### PR TITLE
Fix missing important native DLLs for GL and XNA builds

### DIFF
--- a/DXClient.slnx
+++ b/DXClient.slnx
@@ -32,7 +32,16 @@
     <Platform Solution="WindowsXNADebug|*" Project="x86" />
     <Platform Solution="WindowsXNARelease|*" Project="x86" />
   </Project>
-  <Project Path="Rampastring.XNAUI/Rampastring.Tools/Rampastring.Tools.csproj" />
+  <Project Path="Rampastring.XNAUI/Rampastring.Tools/Rampastring.Tools.csproj">
+    <BuildType Solution="UniversalGLDebug|*" Project="Debug" />
+    <BuildType Solution="UniversalGLRelease|*" Project="Release" />
+    <BuildType Solution="WindowsDXDebug|*" Project="Debug" />
+    <BuildType Solution="WindowsDXRelease|*" Project="Release" />
+    <BuildType Solution="WindowsGLDebug|*" Project="Debug" />
+    <BuildType Solution="WindowsGLRelease|*" Project="Release" />
+    <BuildType Solution="WindowsXNADebug|*" Project="Debug" />
+    <BuildType Solution="WindowsXNARelease|*" Project="Release" />
+  </Project>
   <Project Path="Rampastring.XNAUI/Rampastring.XNAUI.csproj" />
   <Project Path="SecondStageUpdater/SecondStageUpdater.csproj" />
   <Project Path="TranslationNotifierGenerator/TranslationNotifierGenerator.csproj" />


### PR DESCRIPTION
Need some people to test this branch:

https://github.com/CnCNet/xna-cncnet-client/tree/test-xnaui

1. checkout to this branch

2. `git submodule update --init --recursive`

3. then, open both DXClient.slnx and Rampastring.XNAUI\Rampastring.XNAUI.sln using Visual Studio (either 2022 or 2026)

4. Switch the configuration, and observe whether there are red error texts (ignore yellow warnings if there are)
<img width="1438" height="95" alt="" src="https://github.com/user-attachments/assets/b063ac91-9e65-46f2-ac26-8437aa7bf93c" />

6. Switch configurations (and restart VS), build solutions, and open the other solution after build (e.g. after building DXClient, open XNAUI sln) and observe if there are red errors