### PR TITLE
Use a shorter timeout for CnCNet player count retrieval

### DIFF
--- a/DXMainClient/Domain/Multiplayer/CnCNet/CnCNetPlayerCountTask.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/CnCNetPlayerCountTask.cs
@@ -22,7 +22,9 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
         public static void InitializeService(CancellationTokenSource cts)
         {
             cncnetLiveStatusIdentifier = ClientConfiguration.Instance.CnCNetLiveStatusIdentifier;
-            PlayerCount = GetCnCNetPlayerCount();
+            
+            // This call is synchronous. Therefore, we use a short timeout to avoid blocking the main thread for too long.
+            PlayerCount = GetCnCNetPlayerCount(timeoutMilliseconds: 1000);
 
             CnCNetGameCountUpdated?.Invoke(null, new PlayerCountEventArgs(PlayerCount));
             ThreadPool.QueueUserWorkItem(new WaitCallback(RunService), cts);
@@ -41,12 +43,12 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
                 }
                 else
                 {
-                    CnCNetGameCountUpdated?.Invoke(null, new PlayerCountEventArgs(GetCnCNetPlayerCount()));
+                    CnCNetGameCountUpdated?.Invoke(null, new PlayerCountEventArgs(GetCnCNetPlayerCount(timeoutMilliseconds: 5000)));
                 }
             }
         }
 
-        private static int GetCnCNetPlayerCount()
+        private static int GetCnCNetPlayerCount(int timeoutMilliseconds = 5000)
         {
             try
             {
@@ -56,7 +58,7 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
                 if (string.IsNullOrWhiteSpace(ClientConfiguration.Instance.CnCNetPlayerCountURL))
                     return -1;
 
-                WebClient client = new ExtendedWebClient();
+                WebClient client = new ExtendedWebClient(timeout: timeoutMilliseconds);
                 Stream data = client.OpenRead(ClientConfiguration.Instance.CnCNetPlayerCountURL);
 
                 string info = string.Empty;

--- a/DXMainClient/Domain/Multiplayer/CnCNet/ExtendedWebClient.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/ExtendedWebClient.cs
@@ -8,8 +8,15 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
     /// </summary>
     class ExtendedWebClient : WebClient
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExtendedWebClient"/> class with a default timeout of 10 seconds.
+        /// </summary>
         public ExtendedWebClient() : this(timeout: 10000) { }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExtendedWebClient"/> class with a specified timeout.
+        /// </summary>
+        /// <param name="timeout">Gets or sets the length of time, in milliseconds, before the request times out.</param>
         public ExtendedWebClient(int timeout)
         {
             this.timeout = timeout;


### PR DESCRIPTION
This PR differs the initial GetCnCNetPlayerCount call (sync) with the upcoming GetCnCNetPlayerCount calls (async), using 1-second and 5-second timeouts respectively. Previously the timeout is 10 second (more previously it was 100 second xD), might be a little bit of long just retrieving a number and therefore unnecessary.