### PR TITLE
Add DirectDrawCompatibilityFixer

### DIFF
--- a/ClientCore/AdminRestarter.cs
+++ b/ClientCore/AdminRestarter.cs
@@ -38,14 +38,50 @@ namespace ClientCore
         /// <returns>True if the restart was initiated successfully, false otherwise.</returns>
         public static bool RestartAsAdmin()
         {
+            bool runNativeWindowsExe = true;
+#if !NETFRAMEWORK
+            runNativeWindowsExe = false;
+#endif
+
             try
             {
-                using var _ = Process.Start(new ProcessStartInfo
+                if (runNativeWindowsExe)
                 {
-                    FileName = SafePath.CombineFilePath(ProgramConstants.StartupExecutable),
-                    Verb = "runas",
-                    UseShellExecute = true,
-                });
+                    using var _ = Process.Start(new ProcessStartInfo
+                    {
+                        FileName = SafePath.CombineFilePath(ProgramConstants.StartupExecutable),
+                        Verb = "runas",
+                        UseShellExecute = true,
+                    });
+                }
+                else
+                {
+                    // Calling dotnet.exe has the following disadvantages:
+                    // 1. We need to specify `UseShellExecute = true` for the `Runas` verb, which means we cannot hide the console window despite setting `CreateNoWindow = true`.
+                    // 2. For XNA build, we need to call the x86 version of dotnet.exe.
+
+                    // Therefore, we calls the launcher exe with the argument of current platform. This makes the client tightly coupled with the launcher, which is not ideal but acceptable for now.
+
+                    string arguments;
+#if XNA
+                    arguments = "-NET8 -XNA";
+#elif DX
+                    arguments = "-NET8 -DX";
+#elif GL
+                    // Note: we can assume no UGL build here because this class is labeled as Windows-only.
+                    arguments = "-NET8 -OGL";
+#else
+#error Unknown build configuration
+#endif
+
+                    using var _ = Process.Start(new ProcessStartInfo
+                    {
+                        FileName = SafePath.CombineFilePath(ProgramConstants.GamePath, ClientConfiguration.Instance.LauncherExe),
+                        Verb = "runas",
+                        Arguments = arguments,
+                        UseShellExecute = true,
+                    });
+                }
 
                 return true;
             }

--- a/ClientCore/AdminRestarter.cs
+++ b/ClientCore/AdminRestarter.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.Versioning;
+using System.Security.Principal;
+using Rampastring.Tools;
+
+namespace ClientCore
+{
+    /// <summary>
+    /// Utility for restarting the client with administrator privileges.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    public static class AdminRestarter
+    {
+        /// <summary>
+        /// Checks if the application is running with administrator privileges.
+        /// </summary>
+        /// <returns>True if running as administrator, false otherwise.</returns>
+        public static bool IsRunningAsAdministrator()
+        {
+            try
+            {
+                using WindowsIdentity identity = WindowsIdentity.GetCurrent();
+                WindowsPrincipal principal = new WindowsPrincipal(identity);
+                return principal.IsInRole(WindowsBuiltInRole.Administrator);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Restarts the current application with administrator privileges.
+        /// </summary>
+        /// <returns>True if the restart was initiated successfully, false otherwise.</returns>
+        public static bool RestartAsAdmin()
+        {
+            try
+            {
+                using var _ = Process.Start(new ProcessStartInfo
+                {
+                    FileName = SafePath.CombineFilePath(ProgramConstants.StartupExecutable),
+                    Verb = "runas",
+                    UseShellExecute = true,
+                });
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.Log("Failed to restart with admin privileges: " + ex.ToString());
+                return false;
+            }
+        }
+    }
+}

--- a/ClientCore/AdminRestarter.cs
+++ b/ClientCore/AdminRestarter.cs
@@ -1,7 +1,9 @@
+#nullable enable
 using System;
 using System.Diagnostics;
 using System.Runtime.Versioning;
 using System.Security.Principal;
+
 using Rampastring.Tools;
 
 namespace ClientCore

--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -383,6 +383,13 @@ namespace ClientCore
 
         public string GameLauncherExecutableName => clientDefinitionsIni.GetStringValue(SETTINGS, "GameLauncherExecutableName", string.Empty);
 
+        public string[] GetCompatibilityCheckExecutables()
+        {
+            string[] exeNames = clientDefinitionsIni.GetStringListValue(SETTINGS, "CompatibilityCheckExecutables", string.Empty);
+
+            return exeNames;
+        }
+
         public bool SaveSkirmishGameOptions => clientDefinitionsIni.GetBooleanValue(SETTINGS, "SaveSkirmishGameOptions", false);
         
         public bool SaveCampaignGameOptions => clientDefinitionsIni.GetBooleanValue(SETTINGS, "SaveCampaignGameOptions", false);

--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -258,7 +258,8 @@ namespace DTAClient.DXGUI
                             .AddSingleton<DiscordHandler>()
                             .AddSingleton<PrivateMessageHandler>()
                             .AddSingleton<MapLoader>()
-                            .AddSingleton<Random>(GetRandom());
+                            .AddSingleton<Random>(GetRandom())
+                            .AddSingleton<DirectDrawWrapperManager>();
 
                         // singleton xna controls - same instance on each request
                         services

--- a/DXMainClient/DXGUI/Generic/MainMenu.cs
+++ b/DXMainClient/DXGUI/Generic/MainMenu.cs
@@ -671,9 +671,7 @@ namespace DTAClient.DXGUI.Generic
 
 #if ISWINDOWS
             if (!directDrawWrapperManager.SelectedRenderer.IsDummy)
-            {
                 DirectDrawCompatibilityChecker.CheckAndPromptFix(WindowManager);
-            }
 #endif
         }
 

--- a/DXMainClient/DXGUI/Generic/MainMenu.cs
+++ b/DXMainClient/DXGUI/Generic/MainMenu.cs
@@ -59,7 +59,8 @@ namespace DTAClient.DXGUI.Generic
             UpdateQueryWindow updateQueryWindow,
             ManualUpdateQueryWindow manualUpdateQueryWindow,
             UpdateWindow updateWindow,
-            ExtrasWindow extrasWindow
+            ExtrasWindow extrasWindow,
+            DirectDrawWrapperManager directDrawWrapperManager
         ) : base(windowManager)
         {
             this.lanLobby = lanLobby;
@@ -82,6 +83,7 @@ namespace DTAClient.DXGUI.Generic
             this.manualUpdateQueryWindow = manualUpdateQueryWindow;
             this.updateWindow = updateWindow;
             this.extrasWindow = extrasWindow;
+            this.directDrawWrapperManager = directDrawWrapperManager;
 
             this.cncnetLobby.UpdateCheck += CncnetLobby_UpdateCheck;
             isMediaPlayerAvailable = IsMediaPlayerAvailable();
@@ -117,6 +119,7 @@ namespace DTAClient.DXGUI.Generic
         private readonly ManualUpdateQueryWindow manualUpdateQueryWindow;
         private readonly UpdateWindow updateWindow;
         private readonly ExtrasWindow extrasWindow;
+        private readonly DirectDrawWrapperManager directDrawWrapperManager;
 
         private XNAMessageBox firstRunMessageBox;
 
@@ -667,7 +670,10 @@ namespace DTAClient.DXGUI.Generic
             };
 
 #if ISWINDOWS
-            DirectDrawCompatibilityChecker.CheckAndPromptFix(WindowManager);
+            if (!directDrawWrapperManager.SelectedRenderer.IsDummy)
+            {
+                DirectDrawCompatibilityChecker.CheckAndPromptFix(WindowManager);
+            }
 #endif
         }
 

--- a/DXMainClient/DXGUI/Generic/MainMenu.cs
+++ b/DXMainClient/DXGUI/Generic/MainMenu.cs
@@ -665,6 +665,10 @@ namespace DTAClient.DXGUI.Generic
 
                 }.Show();
             };
+
+#if ISWINDOWS
+            DirectDrawCompatibilityChecker.CheckAndPromptFix(WindowManager);
+#endif
         }
 
         private void LoadThemeSong()

--- a/DXMainClient/DXGUI/Generic/OptionPanels/DisplayOptionsPanel.cs
+++ b/DXMainClient/DXGUI/Generic/OptionPanels/DisplayOptionsPanel.cs
@@ -631,7 +631,6 @@ namespace DTAClient.DXGUI.Generic.OptionPanels
             int dragDistance = ingameRes.Width / ORIGINAL_RESOLUTION_WIDTH * DRAG_DISTANCE_DEFAULT;
             IniSettings.DragDistance.Value = dragDistance;
 
-            DirectDrawWrapper originalRenderer = directDrawWrapperManager.SelectedRenderer;
             var newSelectedRenderer = (DirectDrawWrapper)ddRenderer.SelectedItem.Tag;
 
             IniSettings.WindowedMode.Value = chkWindowedMode.Checked &&

--- a/DXMainClient/DXGUI/Generic/OptionPanels/DisplayOptionsPanel.cs
+++ b/DXMainClient/DXGUI/Generic/OptionPanels/DisplayOptionsPanel.cs
@@ -726,9 +726,7 @@ namespace DTAClient.DXGUI.Generic.OptionPanels
 
 #if ISWINDOWS
             if (isChangingRenderer && !directDrawWrapperManager.SelectedRenderer.IsDummy)
-            {
                 DirectDrawCompatibilityChecker.CheckAndPromptFix(WindowManager);
-            }
 #endif
 
             if (ClientConfiguration.Instance.ClientGameType == ClientType.TS)

--- a/DXMainClient/DXGUI/Generic/OptionPanels/DisplayOptionsPanel.cs
+++ b/DXMainClient/DXGUI/Generic/OptionPanels/DisplayOptionsPanel.cs
@@ -1,6 +1,7 @@
 using ClientCore.Extensions;
 using ClientCore;
 using ClientGUI;
+using DTAClient.Domain;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Rampastring.Tools;
@@ -786,6 +787,13 @@ namespace DTAClient.DXGUI.Generic.OptionPanels
             }
 
             IniSettings.Renderer.Value = selectedRenderer.InternalName;
+
+#if ISWINDOWS
+            if (selectedRenderer.InternalName == "DDRAWCompat")
+            {
+                DirectDrawCompatibilityChecker.CheckAndPromptFix(WindowManager);
+            }
+#endif
 
             if (ClientConfiguration.Instance.ClientGameType == ClientType.TS)
             {

--- a/DXMainClient/DXGUI/Generic/OptionPanels/DisplayOptionsPanel.cs
+++ b/DXMainClient/DXGUI/Generic/OptionPanels/DisplayOptionsPanel.cs
@@ -724,11 +724,6 @@ namespace DTAClient.DXGUI.Generic.OptionPanels
                 rendererSettingsIni.WriteIniFile();
             }
 
-#if ISWINDOWS
-            if (isChangingRenderer && !directDrawWrapperManager.SelectedRenderer.IsDummy)
-                DirectDrawCompatibilityChecker.CheckAndPromptFix(WindowManager);
-#endif
-
             if (ClientConfiguration.Instance.ClientGameType == ClientType.TS)
             {
                 if (ClientConfiguration.Instance.CopyResolutionDependentLanguageDLL)
@@ -750,6 +745,12 @@ namespace DTAClient.DXGUI.Generic.OptionPanels
                         File.Copy(SafePath.CombineFilePath(ProgramConstants.GamePath, "Resources", "language_640x480.dll"), languageDllDestinationPath);
                 }
             }
+
+#if ISWINDOWS
+            // Since `CheckAndPromptFix` method might restart the client if the admin rights are required, we do this at the end of the Save() method
+            if (isChangingRenderer && !directDrawWrapperManager.SelectedRenderer.IsDummy)
+                DirectDrawCompatibilityChecker.CheckAndPromptFix(WindowManager);
+#endif
 
             return restartRequired;
         }

--- a/DXMainClient/DXGUI/Generic/OptionPanels/DisplayOptionsPanel.cs
+++ b/DXMainClient/DXGUI/Generic/OptionPanels/DisplayOptionsPanel.cs
@@ -27,11 +27,13 @@ namespace DTAClient.DXGUI.Generic.OptionPanels
     {
         private const int DRAG_DISTANCE_DEFAULT = 4;
         private const int ORIGINAL_RESOLUTION_WIDTH = 640;
-        private const string RENDERERS_INI = "Renderers.ini";
 
-        public DisplayOptionsPanel(WindowManager windowManager, UserINISettings iniSettings)
+        private readonly DirectDrawWrapperManager directDrawWrapperManager;
+
+        public DisplayOptionsPanel(WindowManager windowManager, UserINISettings iniSettings, DirectDrawWrapperManager directDrawWrapperManager)
             : base(windowManager, iniSettings)
         {
+            this.directDrawWrapperManager = directDrawWrapperManager;
         }
 
         private XNAClientDropDown ddIngameResolution;
@@ -45,11 +47,6 @@ namespace DTAClient.DXGUI.Generic.OptionPanels
         private XNAClientCheckBox chkIntegerScaledClient;
         private XNAClientDropDown ddClientTheme;
         private XNAClientDropDown ddTranslation;
-
-        private List<DirectDrawWrapper> renderers;
-
-        private string defaultRenderer;
-        private DirectDrawWrapper selectedRenderer = null;
 
         private XNALabel lblCompatibilityFixes;
         private XNALabel lblGameCompatibilityFix;
@@ -128,20 +125,13 @@ namespace DTAClient.DXGUI.Generic.OptionPanels
                 ddDetailLevel.Width,
                 ddDetailLevel.Height);
 
-            GetRenderers();
-
-            var localOS = ClientConfiguration.Instance.GetOperatingSystemVersion();
-
-            foreach (var renderer in renderers)
+            foreach (var renderer in directDrawWrapperManager.GetRenderers(ClientConfiguration.Instance.GetOperatingSystemVersion()))
             {
-                if (renderer.IsCompatibleWithOS(localOS) && !renderer.Hidden)
+                ddRenderer.AddItem(new XNADropDownItem()
                 {
-                    ddRenderer.AddItem(new XNADropDownItem()
-                    {
-                        Text = renderer.UIName,
-                        Tag = renderer
-                    });
-                }
+                    Text = renderer.UIName,
+                    Tag = renderer
+                });
             }
 
             chkWindowedMode = new XNAClientCheckBox(WindowManager);
@@ -287,7 +277,7 @@ namespace DTAClient.DXGUI.Generic.OptionPanels
             {
                 AddCompatibilityFixControls();
             }
-            
+
             AddChild(chkWindowedMode);
             AddChild(chkBorderlessWindowedMode);
             AddChild(chkBackBufferInVRAM);
@@ -397,45 +387,6 @@ namespace DTAClient.DXGUI.Generic.OptionPanels
             }
         }
 
-        private void GetRenderers()
-        {
-            renderers = new List<DirectDrawWrapper>();
-
-            var renderersIni = new IniFile(SafePath.CombineFilePath(ProgramConstants.GetBaseResourcePath(), RENDERERS_INI));
-
-            var keys = renderersIni.GetSectionKeys("Renderers");
-            if (keys == null)
-                throw new ClientConfigurationException("[Renderers] not found from Renderers.ini!");
-
-            foreach (string key in keys)
-            {
-                string internalName = renderersIni.GetStringValue("Renderers", key, string.Empty);
-
-                var ddWrapper = new DirectDrawWrapper(internalName, renderersIni);
-                renderers.Add(ddWrapper);
-            }
-
-            OSVersion osVersion = ClientConfiguration.Instance.GetOperatingSystemVersion();
-
-            defaultRenderer = renderersIni.GetStringValue("DefaultRenderer", osVersion.ToString(), string.Empty);
-
-            if (defaultRenderer == null)
-                throw new ClientConfigurationException("Invalid or missing default renderer for operating system: " + osVersion);
-
-            string renderer = UserINISettings.Instance.Renderer;
-
-            selectedRenderer = renderers.Find(r => r.InternalName == renderer);
-
-            if (selectedRenderer == null)
-                selectedRenderer = renderers.Find(r => r.InternalName == defaultRenderer);
-
-            if (selectedRenderer == null)
-                throw new ClientConfigurationException("Missing renderer: " + renderer);
-
-            GameProcessLogic.UseQres = selectedRenderer.UseQres;
-            GameProcessLogic.SingleCoreAffinity = selectedRenderer.SingleCoreAffinity;
-        }
-      
         /// <summary>
         /// Asks the user whether they want to install the DTA/TI/TS compatibility fix.
         /// </summary>
@@ -565,14 +516,14 @@ namespace DTAClient.DXGUI.Generic.OptionPanels
         private void LoadRenderer()
         {
             int index = ddRenderer.Items.FindIndex(
-                           r => ((DirectDrawWrapper)r.Tag).InternalName == selectedRenderer.InternalName);
+                           r => ((DirectDrawWrapper)r.Tag).InternalName == directDrawWrapperManager.SelectedRenderer.InternalName);
 
-            if (index < 0 && selectedRenderer.Hidden)
+            if (index < 0 && directDrawWrapperManager.SelectedRenderer.Hidden)
             {
                 ddRenderer.AddItem(new XNADropDownItem()
                 {
-                    Text = selectedRenderer.UIName,
-                    Tag = selectedRenderer
+                    Text = directDrawWrapperManager.SelectedRenderer.UIName,
+                    Tag = directDrawWrapperManager.SelectedRenderer
                 });
                 index = ddRenderer.Items.Count - 1;
             }
@@ -680,14 +631,14 @@ namespace DTAClient.DXGUI.Generic.OptionPanels
             int dragDistance = ingameRes.Width / ORIGINAL_RESOLUTION_WIDTH * DRAG_DISTANCE_DEFAULT;
             IniSettings.DragDistance.Value = dragDistance;
 
-            DirectDrawWrapper originalRenderer = selectedRenderer;
-            selectedRenderer = (DirectDrawWrapper)ddRenderer.SelectedItem.Tag;
+            DirectDrawWrapper originalRenderer = directDrawWrapperManager.SelectedRenderer;
+            var newSelectedRenderer = (DirectDrawWrapper)ddRenderer.SelectedItem.Tag;
 
             IniSettings.WindowedMode.Value = chkWindowedMode.Checked &&
-                !selectedRenderer.UsesCustomWindowedOption();
+                !newSelectedRenderer.UsesCustomWindowedOption();
 
             IniSettings.BorderlessWindowedMode.Value = chkBorderlessWindowedMode.Checked &&
-                string.IsNullOrEmpty(selectedRenderer.BorderlessWindowedModeKey);
+                string.IsNullOrEmpty(newSelectedRenderer.BorderlessWindowedModeKey);
 
             ScreenResolution clientRes = (string)ddClientResolution.SelectedItem.Tag;
 
@@ -745,51 +696,36 @@ namespace DTAClient.DXGUI.Generic.OptionPanels
                     }
                 }
             }
-            
+
             if (ClientConfiguration.Instance.ClientGameType == ClientType.TS)
                 IniSettings.BackBufferInVRAM.Value = !chkBackBufferInVRAM.Checked;
             else
                 IniSettings.BackBufferInVRAM.Value = chkBackBufferInVRAM.Checked;
 
-            if (selectedRenderer != originalRenderer ||
-                !SafePath.GetFile(ProgramConstants.GamePath, selectedRenderer.ConfigFileName).Exists)
+            directDrawWrapperManager.Save(newSelectedRenderer);
+
+            if (directDrawWrapperManager.SelectedRenderer.UsesCustomWindowedOption())
             {
-                foreach (var renderer in renderers)
-                {
-                    if (renderer != selectedRenderer)
-                        renderer.Clean();
-                }
-            }
+                IniFile rendererSettingsIni = new IniFile(SafePath.CombineFilePath(ProgramConstants.GamePath, directDrawWrapperManager.SelectedRenderer.ConfigFileName));
 
-            selectedRenderer.Apply();
+                rendererSettingsIni.SetBooleanValue(directDrawWrapperManager.SelectedRenderer.WindowedModeSection,
+                    directDrawWrapperManager.SelectedRenderer.WindowedModeKey, chkWindowedMode.Checked);
 
-            GameProcessLogic.UseQres = selectedRenderer.UseQres;
-            GameProcessLogic.SingleCoreAffinity = selectedRenderer.SingleCoreAffinity;
-
-            if (selectedRenderer.UsesCustomWindowedOption())
-            {
-                IniFile rendererSettingsIni = new IniFile(SafePath.CombineFilePath(ProgramConstants.GamePath, selectedRenderer.ConfigFileName));
-
-                rendererSettingsIni.SetBooleanValue(selectedRenderer.WindowedModeSection,
-                    selectedRenderer.WindowedModeKey, chkWindowedMode.Checked);
-
-                if (!string.IsNullOrEmpty(selectedRenderer.BorderlessWindowedModeKey))
+                if (!string.IsNullOrEmpty(directDrawWrapperManager.SelectedRenderer.BorderlessWindowedModeKey))
                 {
                     bool borderlessModeIniValue = chkBorderlessWindowedMode.Checked;
-                    if (selectedRenderer.IsBorderlessWindowedModeKeyReversed)
+                    if (directDrawWrapperManager.SelectedRenderer.IsBorderlessWindowedModeKeyReversed)
                         borderlessModeIniValue = !borderlessModeIniValue;
 
-                    rendererSettingsIni.SetBooleanValue(selectedRenderer.WindowedModeSection,
-                        selectedRenderer.BorderlessWindowedModeKey, borderlessModeIniValue);
+                    rendererSettingsIni.SetBooleanValue(directDrawWrapperManager.SelectedRenderer.WindowedModeSection,
+                        directDrawWrapperManager.SelectedRenderer.BorderlessWindowedModeKey, borderlessModeIniValue);
                 }
 
                 rendererSettingsIni.WriteIniFile();
             }
 
-            IniSettings.Renderer.Value = selectedRenderer.InternalName;
-
 #if ISWINDOWS
-            if (selectedRenderer.InternalName == "DDRAWCompat")
+            if (!directDrawWrapperManager.SelectedRenderer.IsDummy)
             {
                 DirectDrawCompatibilityChecker.CheckAndPromptFix(WindowManager);
             }

--- a/DXMainClient/DXGUI/Generic/OptionPanels/DisplayOptionsPanel.cs
+++ b/DXMainClient/DXGUI/Generic/OptionPanels/DisplayOptionsPanel.cs
@@ -632,6 +632,7 @@ namespace DTAClient.DXGUI.Generic.OptionPanels
             IniSettings.DragDistance.Value = dragDistance;
 
             var newSelectedRenderer = (DirectDrawWrapper)ddRenderer.SelectedItem.Tag;
+            bool isChangingRenderer = newSelectedRenderer != directDrawWrapperManager.SelectedRenderer;
 
             IniSettings.WindowedMode.Value = chkWindowedMode.Checked &&
                 !newSelectedRenderer.UsesCustomWindowedOption();
@@ -724,7 +725,7 @@ namespace DTAClient.DXGUI.Generic.OptionPanels
             }
 
 #if ISWINDOWS
-            if (!directDrawWrapperManager.SelectedRenderer.IsDummy)
+            if (isChangingRenderer && !directDrawWrapperManager.SelectedRenderer.IsDummy)
             {
                 DirectDrawCompatibilityChecker.CheckAndPromptFix(WindowManager);
             }

--- a/DXMainClient/DXGUI/Generic/OptionsWindow.cs
+++ b/DXMainClient/DXGUI/Generic/OptionsWindow.cs
@@ -10,14 +10,16 @@ using Rampastring.XNAUI;
 using Rampastring.XNAUI.XNAControls;
 using System;
 using ClientUpdater;
+using DTAClient.Domain;
 
 namespace DTAClient.DXGUI.Generic
 {
     public class OptionsWindow : XNAWindow
     {
-        public OptionsWindow(WindowManager windowManager, GameCollection gameCollection) : base(windowManager)
+        public OptionsWindow(WindowManager windowManager, GameCollection gameCollection, DirectDrawWrapperManager directDrawWrapperManager) : base(windowManager)
         {
             this.gameCollection = gameCollection;
+            this.directDrawWrapperManager = directDrawWrapperManager;
         }
 
         public event EventHandler OnForceUpdate;
@@ -31,6 +33,7 @@ namespace DTAClient.DXGUI.Generic
         private XNAControl topBar;
 
         private GameCollection gameCollection;
+        private DirectDrawWrapperManager directDrawWrapperManager;
 
         public override void Initialize()
         {
@@ -64,7 +67,7 @@ namespace DTAClient.DXGUI.Generic
             btnSave.Text = "Save".L10N("Client:DTAConfig:ButtonSave");
             btnSave.LeftClick += BtnSave_LeftClick;
 
-            displayOptionsPanel = new DisplayOptionsPanel(WindowManager, UserINISettings.Instance);
+            displayOptionsPanel = new DisplayOptionsPanel(WindowManager, UserINISettings.Instance, directDrawWrapperManager);
             componentsPanel = new ComponentsPanel(WindowManager, UserINISettings.Instance);
             var updaterOptionsPanel = new UpdaterOptionsPanel(WindowManager, UserINISettings.Instance);
             updaterOptionsPanel.OnForceUpdate += (s, e) => { Disable(); OnForceUpdate?.Invoke(this, EventArgs.Empty); };

--- a/DXMainClient/DXGUI/Generic/OptionsWindow.cs
+++ b/DXMainClient/DXGUI/Generic/OptionsWindow.cs
@@ -32,8 +32,8 @@ namespace DTAClient.DXGUI.Generic
         private DisplayOptionsPanel displayOptionsPanel;
         private XNAControl topBar;
 
-        private GameCollection gameCollection;
-        private DirectDrawWrapperManager directDrawWrapperManager;
+        private readonly GameCollection gameCollection;
+        private readonly DirectDrawWrapperManager directDrawWrapperManager;
 
         public override void Initialize()
         {

--- a/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
+++ b/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.Versioning;
 
@@ -26,15 +27,21 @@ public static class DirectDrawCompatibilityChecker
         "WIN8RTM", "WIN7RTM", "VISTASP2", "VISTASP1", "VISTARTM", "WINXPSP3", "WINXPSP2", "WIN98", "WIN95"
     ];
 
-    private static IEnumerable<string> GetExecutablesToCheck()
+    private static IEnumerable<string> GetExecutableFilePathsToCheck()
     {
-        string[] configExecutables = ClientConfiguration.Instance.GetCompatibilityCheckExecutables();
+        List<string> executablePaths = ClientConfiguration.Instance.GetCompatibilityCheckExecutables()
+            .Select(executableName => SafePath.CombineFilePath(ProgramConstants.GamePath, executableName))
+            .ToList();
 
         // clientdx.exe, clientogl.exe, or clientxna.exe
-        string currentExeName = SafePath.GetFile(ProgramConstants.StartupExecutable).Name;
+        string currentExeName = SafePath.GetFile(ProgramConstants.StartupExecutable).FullName;
 
-        // config list plus the current executable
-        return configExecutables.Append(currentExeName);
+        executablePaths.Add(currentExeName);
+
+        Logger.Log("Checking compatibility settings for executables: " +
+                   string.Join(", ", currentExeName));
+
+        return executablePaths;
     }
 
     private static void Examine(out bool requireFix, out bool requireAdmin, out IEnumerable<string> problematicExeNames)
@@ -52,10 +59,8 @@ public static class DirectDrawCompatibilityChecker
         bool anyHklmRequireFix = false;
 
         var problematicExeNameHashSet = new HashSet<string>();
-        foreach (string executableName in GetExecutablesToCheck())
+        foreach (string exeFullPath in GetExecutableFilePathsToCheck())
         {
-            string exeFullPath = SafePath.CombineFilePath(ProgramConstants.GamePath, executableName);
-
             object? hkcuValue = hkcuKey?.GetValue(exeFullPath);
             object? hklmValue = hklmKey?.GetValue(exeFullPath);
 
@@ -63,14 +68,14 @@ public static class DirectDrawCompatibilityChecker
             {
                 Logger.Log($"Executable '{exeFullPath}' has problematic compatibility settings in HKCU. Value: {hkcuValue}");
                 anyHkcuRequireFix = true;
-                problematicExeNameHashSet.Add(executableName);
+                problematicExeNameHashSet.Add(Path.GetFileName(exeFullPath));
             }
 
             if (IsFixRequired(hklmValue))
             {
                 Logger.Log($"Executable '{exeFullPath}' has problematic compatibility settings in HKLM. Value: {hklmValue}");
                 anyHklmRequireFix = true;
-                problematicExeNameHashSet.Add(executableName);
+                problematicExeNameHashSet.Add(Path.GetFileName(exeFullPath));
             }
         }
 
@@ -108,9 +113,8 @@ public static class DirectDrawCompatibilityChecker
                 if (key == null)
                     return;
 
-                foreach (string executableName in GetExecutablesToCheck())
+                foreach (string exeFullPath in GetExecutableFilePathsToCheck())
                 {
-                    string exeFullPath = SafePath.CombineFilePath(ProgramConstants.GamePath, executableName);
                     object? value = key.GetValue(exeFullPath);
 
                     FixRegValue(value, out bool success, out string newValue);

--- a/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
+++ b/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
@@ -162,19 +162,21 @@ public static class DirectDrawCompatibilityChecker
 
             Logger.Log("DirectDraw compatibility issue detected.");
 
-            string message = "Problematic Windows compatibility mode settings have been detected that may interfere with the game.\n\n" +
-                "Affected executables:" + "\n- " + string.Join("\n- ", problematicExeNames) + "\n\n" +
-                "Would you like to remove these compatibility settings now?";
+            string localizedMessage = "Problematic Windows compatibility mode settings have been detected that may interfere with the game."
+                .L10N("Client:Main:ProblematicCompatibilityText1") + "\n\n"
+                + "Affected executables:".L10N("Client:Main:ProblematicCompatibilityText2")
+                + "\n- " + string.Join("\n- ", problematicExeNames) + "\n\n" +
+                "Would you like to remove these compatibility settings now?".L10N("Client:Main:ProblematicCompatibilityText3");
 
             if (requireAdmin)
             {
-                message += "\n\nNote: Administrator privileges are required to remove compatibility settings." + " " +
-                    "Clicking Yes will relaunch the client with administrator permissions.";
+                localizedMessage += "\n\n" + ("Note: Administrator privileges are required to remove compatibility settings." + " " +
+                    "Clicking Yes will relaunch the client with administrator permissions.").L10N("Client:Main:ProblematicCompatibilityText4");
             }
 
             var messageBox = XNAMessageBox.ShowYesNoDialog(windowManager,
-                "Compatibility Settings Detected",
-                message);
+                "Problematic Compatibility Settings Detected".L10N("Client:Main:ProblematicCompatibilityTitle"),
+                localizedMessage);
 
             messageBox.YesClickedAction = _ =>
             {
@@ -192,8 +194,8 @@ public static class DirectDrawCompatibilityChecker
                     Logger.Log("DirectDraw compatibility settings fixed successfully.");
 
                     XNAMessageBox.Show(windowManager,
-                        "Fix Applied",
-                        "Compatibility settings have been removed successfully.");
+                        "Fix Applied".L10N("Client:Main:CompatibilityFixAppliedTitle"),
+                        "Compatibility settings have been removed successfully.".L10N("Client:Main:CompatibilityFixAppliedText"));
                 }
             };
 

--- a/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
+++ b/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
@@ -3,10 +3,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Versioning;
+
 using ClientCore;
 using ClientCore.Extensions;
+
 using ClientGUI;
+
 using Microsoft.Win32;
+
 using Rampastring.Tools;
 using Rampastring.XNAUI;
 
@@ -65,16 +69,18 @@ public static class DirectDrawCompatibilityChecker
         requireAdmin = anyHklmRequireFix;
     }
 
+    private static string FixCompatLayerString(string value) => string.Join(" ",
+            value
+                .SplitWithCleanup(new[] { ' ' })
+                .Where(v => !OSCompatibilityValues.Contains(v, StringComparer.InvariantCultureIgnoreCase)));
+
     private static void Fix()
     {
-        void FixValue(object? regValue, out bool success, out string newRegValue)
+        void FixRegValue(object? regValue, out bool success, out string newRegValue)
         {
             if (regValue is string regValueString)
             {
-                newRegValue = string.Join(" ",
-                    regValueString
-                        .SplitWithCleanup(new [] {' '})
-                        .Where(v => !OSCompatibilityValues.Contains(v)));
+                newRegValue = FixCompatLayerString(regValueString);
                 success = true;
             }
             else
@@ -97,7 +103,7 @@ public static class DirectDrawCompatibilityChecker
                     string exeFullPath = SafePath.CombineFilePath(ProgramConstants.GamePath, executableName);
                     object? value = key.GetValue(exeFullPath);
 
-                    FixValue(value, out bool success, out string newValue);
+                    FixRegValue(value, out bool success, out string newValue);
 
                     if (success)
                     {
@@ -127,6 +133,17 @@ public static class DirectDrawCompatibilityChecker
     /// <param name="windowManager">The WindowManager for displaying message boxes.</param>
     public static void CheckAndPromptFix(WindowManager windowManager)
     {
+        // Fix environment variable __COMPAT_LAYER first, for the client itself.
+        string compatLayerEnv = Environment.GetEnvironmentVariable("__COMPAT_LAYER") ?? string.Empty;
+        string fixedCompatLayerEnv = FixCompatLayerString(compatLayerEnv);
+        if (compatLayerEnv != fixedCompatLayerEnv)
+        {
+            Logger.Log("Fixing __COMPAT_LAYER environment variable. Previous value: " +
+                       $"'{compatLayerEnv}', new value: '{fixedCompatLayerEnv}'");
+            Environment.SetEnvironmentVariable("__COMPAT_LAYER", fixedCompatLayerEnv);
+        }
+
+        // Now check registry compatibility settings for all relevant executables.
         try
         {
             Examine(out bool requireFix, out bool requireAdmin);

--- a/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
+++ b/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
@@ -3,39 +3,37 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Versioning;
-
 using ClientCore;
 using ClientCore.Extensions;
-
+using ClientGUI;
 using Microsoft.Win32;
-
 using Rampastring.Tools;
+using Rampastring.XNAUI;
 
 namespace DTAClient.Domain;
 
+/// <summary>
+/// Handles checking and fixing DirectDraw compatibility issues with user interaction.
+/// </summary>
 [SupportedOSPlatform("windows")]
-public static class DirectDrawCompatibilityFixer
+public static class DirectDrawCompatibilityChecker
 {
     private static readonly IReadOnlyList<string> OSCompatibilityValues = [
         "WIN8RTM", "WIN7RTM", "VISTASP2", "VISTASP1", "VISTARTM", "WINXPSP3", "WINXPSP2", "WIN98", "WIN95"
     ];
 
-    private static readonly IReadOnlyList<string> StaticExecutablesToCheck = [
-        "CnCNetYRLauncher.exe",
-        "gamemd.exe",
-        "gamemd-spawn.exe"
-    ];
-
     private static IEnumerable<string> GetExecutablesToCheck()
     {
+        string[] configExecutables = ClientConfiguration.Instance.GetCompatibilityCheckExecutables();
+
         // clientdx.exe, clientogl.exe, or clientxna.exe
         string currentExeName = SafePath.GetFile(ProgramConstants.StartupExecutable).Name;
 
-        // static list plus the current executable
-        return StaticExecutablesToCheck.Append(currentExeName);
+        // config list plus the current executable
+        return configExecutables.Append(currentExeName);
     }
 
-    public static void Examine(out bool requireFix, out bool requireAdmin)
+    private static void Examine(out bool requireFix, out bool requireAdmin)
     {
         using RegistryKey? hkcuKey = Registry.CurrentUser.OpenSubKey(
             @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
@@ -67,7 +65,7 @@ public static class DirectDrawCompatibilityFixer
         requireAdmin = anyHklmRequireFix;
     }
 
-    public static void Fix()
+    private static void Fix()
     {
         void FixValue(object? regValue, out bool success, out string newRegValue)
         {
@@ -121,5 +119,77 @@ public static class DirectDrawCompatibilityFixer
         FixRegistryKey(Registry.CurrentUser, subKeyPath);
 
         FixRegistryKey(Registry.LocalMachine, subKeyPath);
+    }
+
+    /// <summary>
+    /// Checks for DirectDraw compatibility issues and prompts the user to fix them.
+    /// </summary>
+    /// <param name="windowManager">The WindowManager for displaying message boxes.</param>
+    public static void CheckAndPromptFix(WindowManager windowManager)
+    {
+        try
+        {
+            Examine(out bool requireFix, out bool requireAdmin);
+
+            if (!requireFix)
+                return;
+
+            Logger.Log("DirectDraw compatibility issue detected.");
+
+            string message = "Problematic Windows compatibility mode settings have been detected that may interfere with the game.\n\n" +
+                            "Would you like to remove these compatibility settings now?";
+
+            if (requireAdmin)
+            {
+                message += "\n\nNote: Administrator privileges are required to remove compatibility settings.";
+            }
+
+            var messageBox = XNAMessageBox.ShowYesNoDialog(windowManager,
+                "Compatibility Settings Detected",
+                message);
+
+            messageBox.YesClickedAction = _ =>
+            {
+                if (requireAdmin && !AdminRestarter.IsRunningAsAdministrator())
+                {
+                    Logger.Log("Administrator privileges required. Prompting to restart with elevated privileges.");
+
+                    var adminMessageBox = XNAMessageBox.ShowYesNoDialog(windowManager,
+                        "Administrator Required",
+                        "Administrator privileges are required to fix compatibility settings.\n\n" +
+                        "Would you like to restart the application as administrator?");
+
+                    adminMessageBox.YesClickedAction = _ =>
+                    {
+                        if (AdminRestarter.RestartAsAdmin())
+                            Environment.Exit(0);
+                    };
+
+                    adminMessageBox.NoClickedAction = _ =>
+                    {
+                        Logger.Log("User declined to restart with admin privileges.");
+                    };
+                }
+                else
+                {
+                    Logger.Log("Attempting to fix DirectDraw compatibility settings.");
+                    Fix();
+                    Logger.Log("DirectDraw compatibility settings fixed successfully.");
+
+                    XNAMessageBox.Show(windowManager,
+                        "Fix Applied",
+                        "Compatibility settings have been removed successfully.");
+                }
+            };
+
+            messageBox.NoClickedAction = _ =>
+            {
+                Logger.Log("User declined to fix DirectDraw compatibility settings.");
+            };
+        }
+        catch (Exception ex)
+        {
+            Logger.Log("Error checking DirectDraw compatibility: " + ex.ToString());
+        }
     }
 }

--- a/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
+++ b/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
@@ -59,10 +59,16 @@ public static class DirectDrawCompatibilityChecker
             object? hklmValue = hklmKey?.GetValue(exeFullPath);
 
             if (IsFixRequired(hkcuValue))
+            {
+                Logger.Log($"Executable '{exeFullPath}' has problematic compatibility settings in HKCU. Value: {hkcuValue}");
                 anyHkcuRequireFix = true;
+            }
 
             if (IsFixRequired(hklmValue))
+            {
+                Logger.Log($"Executable '{exeFullPath}' has problematic compatibility settings in HKCU. Value: {hklmValue}");
                 anyHklmRequireFix = true;
+            }
         }
 
         requireFix = anyHkcuRequireFix || anyHklmRequireFix;

--- a/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
+++ b/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
@@ -68,7 +68,7 @@ public static class DirectDrawCompatibilityChecker
 
             if (IsFixRequired(hklmValue))
             {
-                Logger.Log($"Executable '{exeFullPath}' has problematic compatibility settings in HKCU. Value: {hklmValue}");
+                Logger.Log($"Executable '{exeFullPath}' has problematic compatibility settings in HKLM. Value: {hklmValue}");
                 anyHklmRequireFix = true;
                 problematicExeNames.Add(executableName);
             }

--- a/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
+++ b/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
@@ -37,7 +37,7 @@ public static class DirectDrawCompatibilityChecker
         return configExecutables.Append(currentExeName);
     }
 
-    private static void Examine(out bool requireFix, out bool requireAdmin, out List<string> problematicExeNames)
+    private static void Examine(out bool requireFix, out bool requireAdmin, out IEnumerable<string> problematicExeNames)
     {
         using RegistryKey? hkcuKey = Registry.CurrentUser.OpenSubKey(
             @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
@@ -51,7 +51,7 @@ public static class DirectDrawCompatibilityChecker
         bool anyHkcuRequireFix = false;
         bool anyHklmRequireFix = false;
 
-        problematicExeNames = [];
+        var problematicExeNameHashSet = new HashSet<string>();
         foreach (string executableName in GetExecutablesToCheck())
         {
             string exeFullPath = SafePath.CombineFilePath(ProgramConstants.GamePath, executableName);
@@ -63,19 +63,20 @@ public static class DirectDrawCompatibilityChecker
             {
                 Logger.Log($"Executable '{exeFullPath}' has problematic compatibility settings in HKCU. Value: {hkcuValue}");
                 anyHkcuRequireFix = true;
-                problematicExeNames.Add(executableName);
+                problematicExeNameHashSet.Add(executableName);
             }
 
             if (IsFixRequired(hklmValue))
             {
                 Logger.Log($"Executable '{exeFullPath}' has problematic compatibility settings in HKLM. Value: {hklmValue}");
                 anyHklmRequireFix = true;
-                problematicExeNames.Add(executableName);
+                problematicExeNameHashSet.Add(executableName);
             }
         }
 
         requireFix = anyHkcuRequireFix || anyHklmRequireFix;
         requireAdmin = anyHklmRequireFix;
+        problematicExeNames = problematicExeNameHashSet;
     }
 
     private static string FixCompatLayerString(string value) => string.Join(" ",

--- a/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
+++ b/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
@@ -37,7 +37,7 @@ public static class DirectDrawCompatibilityChecker
         return configExecutables.Append(currentExeName);
     }
 
-    private static void Examine(out bool requireFix, out bool requireAdmin)
+    private static void Examine(out bool requireFix, out bool requireAdmin, out List<string> problematicExeNames)
     {
         using RegistryKey? hkcuKey = Registry.CurrentUser.OpenSubKey(
             @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
@@ -51,6 +51,7 @@ public static class DirectDrawCompatibilityChecker
         bool anyHkcuRequireFix = false;
         bool anyHklmRequireFix = false;
 
+        problematicExeNames = [];
         foreach (string executableName in GetExecutablesToCheck())
         {
             string exeFullPath = SafePath.CombineFilePath(ProgramConstants.GamePath, executableName);
@@ -62,12 +63,14 @@ public static class DirectDrawCompatibilityChecker
             {
                 Logger.Log($"Executable '{exeFullPath}' has problematic compatibility settings in HKCU. Value: {hkcuValue}");
                 anyHkcuRequireFix = true;
+                problematicExeNames.Add(executableName);
             }
 
             if (IsFixRequired(hklmValue))
             {
                 Logger.Log($"Executable '{exeFullPath}' has problematic compatibility settings in HKCU. Value: {hklmValue}");
                 anyHklmRequireFix = true;
+                problematicExeNames.Add(executableName);
             }
         }
 
@@ -152,7 +155,7 @@ public static class DirectDrawCompatibilityChecker
         // Now check registry compatibility settings for all relevant executables.
         try
         {
-            Examine(out bool requireFix, out bool requireAdmin);
+            Examine(out bool requireFix, out bool requireAdmin, out var problematicExeNames);
 
             if (!requireFix)
                 return;
@@ -160,7 +163,8 @@ public static class DirectDrawCompatibilityChecker
             Logger.Log("DirectDraw compatibility issue detected.");
 
             string message = "Problematic Windows compatibility mode settings have been detected that may interfere with the game.\n\n" +
-                            "Would you like to remove these compatibility settings now?";
+                "Affected executables:" + "\n- " + string.Join("\n- ", problematicExeNames) + "\n\n" +
+                "Would you like to remove these compatibility settings now?";
 
             if (requireAdmin)
             {

--- a/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
+++ b/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
@@ -34,12 +34,12 @@ public static class DirectDrawCompatibilityChecker
             .ToList();
 
         // clientdx.exe, clientogl.exe, or clientxna.exe
-        string currentExeName = SafePath.GetFile(ProgramConstants.StartupExecutable).FullName;
+        string currentExePath = SafePath.GetFile(ProgramConstants.StartupExecutable).FullName;
 
-        executablePaths.Add(currentExeName);
+        executablePaths.Add(currentExePath);
 
         Logger.Log("Checking compatibility settings for executables: " +
-                   string.Join(", ", currentExeName));
+                   string.Join(", ", executablePaths));
 
         return executablePaths;
     }

--- a/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
+++ b/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
@@ -139,9 +139,12 @@ public static class DirectDrawCompatibilityChecker
 
         string subKeyPath = @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers";
 
-        FixRegistryKey(Registry.CurrentUser, subKeyPath);
+        RegistryKey hklm = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64);
+        RegistryKey hkcu = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Registry64);
 
-        FixRegistryKey(Registry.LocalMachine, subKeyPath);
+        FixRegistryKey(hkcu, subKeyPath);
+
+        FixRegistryKey(hklm, subKeyPath);
     }
 
     /// <summary>

--- a/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
+++ b/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
@@ -46,12 +46,12 @@ public static class DirectDrawCompatibilityChecker
 
     private static void Examine(out bool requireFix, out bool requireAdmin, out IEnumerable<string> problematicExeNames)
     {
-        // Note: since the XNA build runs in x86, it can't access the 64-bit registry view on 64-bit Windows. The function will not work properly in this case.
-        // We accept this limitation since the XNA build is legacy.
+        RegistryKey hklm = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64);
+        RegistryKey hkcu = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Registry64);
 
-        using RegistryKey? hkcuKey = Registry.CurrentUser.OpenSubKey(
+        using RegistryKey? hkcuKey = hkcu.OpenSubKey(
             @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
-        using RegistryKey? hklmKey = Registry.LocalMachine.OpenSubKey(
+        using RegistryKey? hklmKey = hklm.OpenSubKey(
             @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
 
         static bool IsFixRequired(object? regValue)

--- a/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
+++ b/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
@@ -173,7 +173,7 @@ public static class DirectDrawCompatibilityChecker
                 + "\n- " + string.Join("\n- ", problematicExeNames) + "\n\n" +
                 "Would you like to remove these compatibility settings now?".L10N("Client:Main:ProblematicCompatibilityText3");
 
-            if (requireAdmin)
+            if (requireAdmin && !AdminRestarter.IsRunningAsAdministrator())
             {
                 localizedMessage += "\n\n" + ("Note: Administrator privileges are required to remove compatibility settings." + " " +
                     "Clicking Yes will relaunch the client with administrator permissions.").L10N("Client:Main:ProblematicCompatibilityText4");

--- a/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
+++ b/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
@@ -168,7 +168,8 @@ public static class DirectDrawCompatibilityChecker
 
             if (requireAdmin)
             {
-                message += "\n\nNote: Administrator privileges are required to remove compatibility settings.";
+                message += "\n\nNote: Administrator privileges are required to remove compatibility settings." + " " +
+                    "Clicking Yes will relaunch the client with administrator permissions.";
             }
 
             var messageBox = XNAMessageBox.ShowYesNoDialog(windowManager,
@@ -179,23 +180,10 @@ public static class DirectDrawCompatibilityChecker
             {
                 if (requireAdmin && !AdminRestarter.IsRunningAsAdministrator())
                 {
-                    Logger.Log("Administrator privileges required. Prompting to restart with elevated privileges.");
+                    Logger.Log("Administrator privileges required. Restart with elevated privileges.");
 
-                    var adminMessageBox = XNAMessageBox.ShowYesNoDialog(windowManager,
-                        "Administrator Required",
-                        "Administrator privileges are required to fix compatibility settings.\n\n" +
-                        "Would you like to restart the application as administrator?");
-
-                    adminMessageBox.YesClickedAction = _ =>
-                    {
-                        if (AdminRestarter.RestartAsAdmin())
-                            Environment.Exit(0);
-                    };
-
-                    adminMessageBox.NoClickedAction = _ =>
-                    {
-                        Logger.Log("User declined to restart with admin privileges.");
-                    };
+                    if (AdminRestarter.RestartAsAdmin())
+                        Environment.Exit(0);
                 }
                 else
                 {

--- a/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
+++ b/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
@@ -46,6 +46,9 @@ public static class DirectDrawCompatibilityChecker
 
     private static void Examine(out bool requireFix, out bool requireAdmin, out IEnumerable<string> problematicExeNames)
     {
+        // Note: since the XNA build runs in x86, it can't access the 64-bit registry view on 64-bit Windows. The function will not work properly in this case.
+        // We accept this limitation since the XNA build is legacy.
+
         using RegistryKey? hkcuKey = Registry.CurrentUser.OpenSubKey(
             @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
         using RegistryKey? hklmKey = Registry.LocalMachine.OpenSubKey(

--- a/DXMainClient/Domain/DirectDrawCompatibilityFixer.cs
+++ b/DXMainClient/Domain/DirectDrawCompatibilityFixer.cs
@@ -43,8 +43,8 @@ public static class DirectDrawCompatibilityFixer
 
     public static void Fix()
     {
-        using RegistryKey hkcuKey = Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
-        using RegistryKey hklmKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
+        using RegistryKey hkcuKey = Registry.CurrentUser.CreateSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
+        using RegistryKey hklmKey = Registry.LocalMachine.CreateSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
             
         string gameExeFullPath = SafePath.CombineFilePath(ProgramConstants.GamePath,
             ClientConfiguration.Instance.GetGameExecutableName());

--- a/DXMainClient/Domain/DirectDrawCompatibilityFixer.cs
+++ b/DXMainClient/Domain/DirectDrawCompatibilityFixer.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Versioning;
+
+using ClientCore;
+using ClientCore.Extensions;
+
+using Microsoft.Win32;
+
+using Rampastring.Tools;
+
+namespace DTAClient.Domain;
+
+[SupportedOSPlatform("windows")]
+public static class DirectDrawCompatibilityFixer
+{
+    private static IReadOnlyList<string> OSCompatibilityValues = [
+        "WIN8RTM", "WIN7RTM", "VISTASP2", "VISTASP1", "VISTARTM", "WINXPSP3", "WINXPSP2", "WIN98", "WIN95"
+    ];
+    
+    public static void Examine(out bool requireFix, out bool requireAdmin)
+    {
+        using RegistryKey hkcuKey = Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
+        using RegistryKey hklmKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
+            
+        string gameExeFullPath = SafePath.CombineFilePath(ProgramConstants.GamePath,
+            ClientConfiguration.Instance.GetGameExecutableName());
+            
+        object hkcuValue = hkcuKey.GetValue(gameExeFullPath);
+        object hklmValue = hklmKey.GetValue(gameExeFullPath);
+
+        bool IsFixRequired(object regValue)
+            => regValue is string regValueString 
+               && regValueString.Split(" ").Intersect(OSCompatibilityValues).Any();
+
+        bool hkcuRequireFix = IsFixRequired(hkcuValue);
+        bool hklmRequireFix = IsFixRequired(hklmValue);
+
+        requireFix = hkcuRequireFix || hklmRequireFix;
+        requireAdmin = hklmRequireFix;
+    }
+
+    public static void Fix()
+    {
+        using RegistryKey hkcuKey = Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
+        using RegistryKey hklmKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
+            
+        string gameExeFullPath = SafePath.CombineFilePath(ProgramConstants.GamePath,
+            ClientConfiguration.Instance.GetGameExecutableName());
+            
+        object hkcuValue = hkcuKey.GetValue(gameExeFullPath);
+        object hklmValue = hklmKey.GetValue(gameExeFullPath);
+
+        void FixValue(object regValue, out bool success, out string newRegValue)
+        {
+            if (regValue is string regValueString)
+            {
+                newRegValue = string.Join(' ', 
+                    regValueString
+                        .SplitWithCleanup([' '])
+                        .Where(v => !OSCompatibilityValues.Contains(v)));
+                success = true;
+            }
+            else
+            {
+                success = false;
+                newRegValue = null;
+            }
+        }
+
+        FixValue(hkcuValue, out bool hkcuFixSuccess, out string newHKCUValue);
+        FixValue(hklmValue, out bool hklmFixSuccess, out string newHKLMValue);
+
+        if (hkcuFixSuccess)
+            hkcuKey.SetValue(gameExeFullPath, newHKCUValue, RegistryValueKind.String);
+        
+        if (hklmFixSuccess)
+            hklmKey.SetValue(gameExeFullPath, newHKLMValue, RegistryValueKind.String);
+    }
+}

--- a/DXMainClient/Domain/DirectDrawCompatibilityFixer.cs
+++ b/DXMainClient/Domain/DirectDrawCompatibilityFixer.cs
@@ -32,7 +32,7 @@ public static class DirectDrawCompatibilityFixer
 
         bool IsFixRequired(object regValue)
             => regValue is string regValueString 
-               && regValueString.Split(" ").Intersect(OSCompatibilityValues).Any();
+               && regValueString.Split([' ']).Intersect(OSCompatibilityValues).Any();
 
         bool hkcuRequireFix = IsFixRequired(hkcuValue);
         bool hklmRequireFix = IsFixRequired(hklmValue);

--- a/DXMainClient/Domain/DirectDrawCompatibilityFixer.cs
+++ b/DXMainClient/Domain/DirectDrawCompatibilityFixer.cs
@@ -43,14 +43,14 @@ public static class DirectDrawCompatibilityFixer
 
     public static void Fix()
     {
-        using RegistryKey hkcuKey = Registry.CurrentUser.CreateSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
-        using RegistryKey hklmKey = Registry.LocalMachine.CreateSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
+        using RegistryKey hkcuKey = Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers", writable: true);
+        using RegistryKey hklmKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers", writable: true);
             
         string gameExeFullPath = SafePath.CombineFilePath(ProgramConstants.GamePath,
             ClientConfiguration.Instance.GetGameExecutableName());
             
-        object hkcuValue = hkcuKey.GetValue(gameExeFullPath);
-        object hklmValue = hklmKey.GetValue(gameExeFullPath);
+        object hkcuValue = hkcuKey?.GetValue(gameExeFullPath);
+        object hklmValue = hklmKey?.GetValue(gameExeFullPath);
 
         void FixValue(object regValue, out bool success, out string newRegValue)
         {

--- a/DXMainClient/Domain/DirectDrawCompatibilityFixer.cs
+++ b/DXMainClient/Domain/DirectDrawCompatibilityFixer.cs
@@ -15,7 +15,7 @@ namespace DTAClient.Domain;
 [SupportedOSPlatform("windows")]
 public static class DirectDrawCompatibilityFixer
 {
-    private static IReadOnlyList<string> OSCompatibilityValues = [
+    private static readonly IReadOnlyList<string> OSCompatibilityValues = [
         "WIN8RTM", "WIN7RTM", "VISTASP2", "VISTASP1", "VISTARTM", "WINXPSP3", "WINXPSP2", "WIN98", "WIN95"
     ];
     

--- a/DXMainClient/Domain/DirectDrawCompatibilityFixer.cs
+++ b/DXMainClient/Domain/DirectDrawCompatibilityFixer.cs
@@ -56,9 +56,9 @@ public static class DirectDrawCompatibilityFixer
         {
             if (regValue is string regValueString)
             {
-                newRegValue = string.Join(' ', 
+                newRegValue = string.Join(" ", 
                     regValueString
-                        .SplitWithCleanup([' '])
+                        .SplitWithCleanup(new char[] {' '})
                         .Where(v => !OSCompatibilityValues.Contains(v)));
                 success = true;
             }

--- a/DXMainClient/Domain/DirectDrawCompatibilityFixer.cs
+++ b/DXMainClient/Domain/DirectDrawCompatibilityFixer.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Versioning;
@@ -18,45 +19,61 @@ public static class DirectDrawCompatibilityFixer
     private static readonly IReadOnlyList<string> OSCompatibilityValues = [
         "WIN8RTM", "WIN7RTM", "VISTASP2", "VISTASP1", "VISTARTM", "WINXPSP3", "WINXPSP2", "WIN98", "WIN95"
     ];
-    
+
+    private static readonly IReadOnlyList<string> StaticExecutablesToCheck = [
+        "CnCNetYRLauncher.exe",
+        "gamemd.exe",
+        "gamemd-spawn.exe"
+    ];
+
+    private static IEnumerable<string> GetExecutablesToCheck()
+    {
+        // clientdx.exe, clientogl.exe, or clientxna.exe
+        string currentExeName = SafePath.GetFile(ProgramConstants.StartupExecutable).Name;
+
+        // static list plus the current executable
+        return StaticExecutablesToCheck.Append(currentExeName);
+    }
+
     public static void Examine(out bool requireFix, out bool requireAdmin)
     {
-        using RegistryKey? hkcuKey = Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
-        using RegistryKey? hklmKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
-            
-        string gameExeFullPath = SafePath.CombineFilePath(ProgramConstants.GamePath,
-            ClientConfiguration.Instance.GetGameExecutableName());
-            
-        object? hkcuValue = hkcuKey?.GetValue(gameExeFullPath);
-        object? hklmValue = hklmKey?.GetValue(gameExeFullPath);
+        using RegistryKey? hkcuKey = Registry.CurrentUser.OpenSubKey(
+            @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
+        using RegistryKey? hklmKey = Registry.LocalMachine.OpenSubKey(
+            @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
 
-        bool IsFixRequired(object? regValue)
-            => regValue is string regValueString 
+        static bool IsFixRequired(object? regValue)
+            => regValue is string regValueString
                && regValueString.Split([' ']).Intersect(OSCompatibilityValues).Any();
 
-        bool hkcuRequireFix = IsFixRequired(hkcuValue);
-        bool hklmRequireFix = IsFixRequired(hklmValue);
+        bool anyHkcuRequireFix = false;
+        bool anyHklmRequireFix = false;
 
-        requireFix = hkcuRequireFix || hklmRequireFix;
-        requireAdmin = hklmRequireFix;
+        foreach (string executableName in GetExecutablesToCheck())
+        {
+            string exeFullPath = SafePath.CombineFilePath(ProgramConstants.GamePath, executableName);
+
+            object? hkcuValue = hkcuKey?.GetValue(exeFullPath);
+            object? hklmValue = hklmKey?.GetValue(exeFullPath);
+
+            if (IsFixRequired(hkcuValue))
+                anyHkcuRequireFix = true;
+
+            if (IsFixRequired(hklmValue))
+                anyHklmRequireFix = true;
+        }
+
+        requireFix = anyHkcuRequireFix || anyHklmRequireFix;
+        requireAdmin = anyHklmRequireFix;
     }
 
     public static void Fix()
     {
-        using RegistryKey hkcuKey = Registry.CurrentUser.CreateSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers", writable: true);
-        using RegistryKey hklmKey = Registry.LocalMachine.CreateSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers", writable: true);
-            
-        string gameExeFullPath = SafePath.CombineFilePath(ProgramConstants.GamePath,
-            ClientConfiguration.Instance.GetGameExecutableName());
-            
-        object? hkcuValue = hkcuKey.GetValue(gameExeFullPath);
-        object? hklmValue = hklmKey.GetValue(gameExeFullPath);
-
         void FixValue(object? regValue, out bool success, out string newRegValue)
         {
             if (regValue is string regValueString)
             {
-                newRegValue = string.Join(" ", 
+                newRegValue = string.Join(" ",
                     regValueString
                         .SplitWithCleanup(new [] {' '})
                         .Where(v => !OSCompatibilityValues.Contains(v)));
@@ -69,23 +86,40 @@ public static class DirectDrawCompatibilityFixer
             }
         }
 
-        FixValue(hkcuValue, out bool hkcuFixSuccess, out string newHkcuValue);
-        FixValue(hklmValue, out bool hklmFixSuccess, out string newHklmValue);
-
-        if (hkcuFixSuccess)
+        void FixRegistryKey(RegistryKey rootKey, string subKeyPath)
         {
-            if (string.IsNullOrEmpty(newHkcuValue))
-                hkcuKey.DeleteValue(gameExeFullPath, false);
-            else
-                hkcuKey.SetValue(gameExeFullPath, newHkcuValue, RegistryValueKind.String);
+            try
+            {
+                using RegistryKey? key = rootKey.OpenSubKey(subKeyPath, writable: true);
+                if (key == null)
+                    return;
+
+                foreach (string executableName in GetExecutablesToCheck())
+                {
+                    string exeFullPath = SafePath.CombineFilePath(ProgramConstants.GamePath, executableName);
+                    object? value = key.GetValue(exeFullPath);
+
+                    FixValue(value, out bool success, out string newValue);
+
+                    if (success)
+                    {
+                        if (string.IsNullOrEmpty(newValue))
+                            key.DeleteValue(exeFullPath, false);
+                        else
+                            key.SetValue(exeFullPath, newValue, RegistryValueKind.String);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"Failed to fix registry key {rootKey.Name}\\{subKeyPath}: {ex.Message}");
+            }
         }
 
-        if (hklmFixSuccess)
-        {
-            if (string.IsNullOrEmpty(newHklmValue))
-                hklmKey.DeleteValue(gameExeFullPath, false);
-            else
-                hklmKey.SetValue(gameExeFullPath, newHklmValue, RegistryValueKind.String);
-        }
+        string subKeyPath = @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers";
+
+        FixRegistryKey(Registry.CurrentUser, subKeyPath);
+
+        FixRegistryKey(Registry.LocalMachine, subKeyPath);
     }
 }

--- a/DXMainClient/Domain/DirectDrawCompatibilityFixer.cs
+++ b/DXMainClient/Domain/DirectDrawCompatibilityFixer.cs
@@ -15,7 +15,7 @@ namespace DTAClient.Domain;
 [SupportedOSPlatform("windows")]
 public static class DirectDrawCompatibilityFixer
 {
-    private readonly static IReadOnlyList<string> OSCompatibilityValues = [
+    private static readonly IReadOnlyList<string> OSCompatibilityValues = [
         "WIN8RTM", "WIN7RTM", "VISTASP2", "VISTASP1", "VISTARTM", "WINXPSP3", "WINXPSP2", "WIN98", "WIN95"
     ];
     

--- a/DXMainClient/Domain/DirectDrawCompatibilityFixer.cs
+++ b/DXMainClient/Domain/DirectDrawCompatibilityFixer.cs
@@ -73,9 +73,19 @@ public static class DirectDrawCompatibilityFixer
         FixValue(hklmValue, out bool hklmFixSuccess, out string newHKLMValue);
 
         if (hkcuFixSuccess)
-            hkcuKey.SetValue(gameExeFullPath, newHKCUValue, RegistryValueKind.String);
-        
+        {
+            if (string.IsNullOrEmpty(newHKCUValue))
+                hkcuKey.DeleteValue(gameExeFullPath, false);
+            else
+                hkcuKey.SetValue(gameExeFullPath, newHKCUValue, RegistryValueKind.String);
+        }
+
         if (hklmFixSuccess)
-            hklmKey.SetValue(gameExeFullPath, newHKLMValue, RegistryValueKind.String);
+        {
+            if (string.IsNullOrEmpty(newHKLMValue))
+                hklmKey.DeleteValue(gameExeFullPath, false);
+            else
+                hklmKey.SetValue(gameExeFullPath, newHKLMValue, RegistryValueKind.String);
+        }
     }
 }

--- a/DXMainClient/Domain/DirectDrawCompatibilityFixer.cs
+++ b/DXMainClient/Domain/DirectDrawCompatibilityFixer.cs
@@ -27,8 +27,8 @@ public static class DirectDrawCompatibilityFixer
         string gameExeFullPath = SafePath.CombineFilePath(ProgramConstants.GamePath,
             ClientConfiguration.Instance.GetGameExecutableName());
             
-        object hkcuValue = hkcuKey.GetValue(gameExeFullPath);
-        object hklmValue = hklmKey.GetValue(gameExeFullPath);
+        object hkcuValue = hkcuKey?.GetValue(gameExeFullPath);
+        object hklmValue = hklmKey?.GetValue(gameExeFullPath);
 
         bool IsFixRequired(object regValue)
             => regValue is string regValueString 

--- a/DXMainClient/Domain/DirectDrawCompatibilityFixer.cs
+++ b/DXMainClient/Domain/DirectDrawCompatibilityFixer.cs
@@ -1,4 +1,4 @@
-using System;
+#nullable enable
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Versioning;
@@ -15,22 +15,22 @@ namespace DTAClient.Domain;
 [SupportedOSPlatform("windows")]
 public static class DirectDrawCompatibilityFixer
 {
-    private static IReadOnlyList<string> OSCompatibilityValues = [
+    private readonly static IReadOnlyList<string> OSCompatibilityValues = [
         "WIN8RTM", "WIN7RTM", "VISTASP2", "VISTASP1", "VISTARTM", "WINXPSP3", "WINXPSP2", "WIN98", "WIN95"
     ];
     
     public static void Examine(out bool requireFix, out bool requireAdmin)
     {
-        using RegistryKey hkcuKey = Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
-        using RegistryKey hklmKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
+        using RegistryKey? hkcuKey = Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
+        using RegistryKey? hklmKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
             
         string gameExeFullPath = SafePath.CombineFilePath(ProgramConstants.GamePath,
             ClientConfiguration.Instance.GetGameExecutableName());
             
-        object hkcuValue = hkcuKey?.GetValue(gameExeFullPath);
-        object hklmValue = hklmKey?.GetValue(gameExeFullPath);
+        object? hkcuValue = hkcuKey?.GetValue(gameExeFullPath);
+        object? hklmValue = hklmKey?.GetValue(gameExeFullPath);
 
-        bool IsFixRequired(object regValue)
+        bool IsFixRequired(object? regValue)
             => regValue is string regValueString 
                && regValueString.Split([' ']).Intersect(OSCompatibilityValues).Any();
 
@@ -43,49 +43,49 @@ public static class DirectDrawCompatibilityFixer
 
     public static void Fix()
     {
-        using RegistryKey hkcuKey = Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers", writable: true);
-        using RegistryKey hklmKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers", writable: true);
+        using RegistryKey hkcuKey = Registry.CurrentUser.CreateSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers", writable: true);
+        using RegistryKey hklmKey = Registry.LocalMachine.CreateSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers", writable: true);
             
         string gameExeFullPath = SafePath.CombineFilePath(ProgramConstants.GamePath,
             ClientConfiguration.Instance.GetGameExecutableName());
             
-        object hkcuValue = hkcuKey?.GetValue(gameExeFullPath);
-        object hklmValue = hklmKey?.GetValue(gameExeFullPath);
+        object? hkcuValue = hkcuKey.GetValue(gameExeFullPath);
+        object? hklmValue = hklmKey.GetValue(gameExeFullPath);
 
-        void FixValue(object regValue, out bool success, out string newRegValue)
+        void FixValue(object? regValue, out bool success, out string newRegValue)
         {
             if (regValue is string regValueString)
             {
                 newRegValue = string.Join(" ", 
                     regValueString
-                        .SplitWithCleanup(new char[] {' '})
+                        .SplitWithCleanup(new [] {' '})
                         .Where(v => !OSCompatibilityValues.Contains(v)));
                 success = true;
             }
             else
             {
                 success = false;
-                newRegValue = null;
+                newRegValue = string.Empty;
             }
         }
 
-        FixValue(hkcuValue, out bool hkcuFixSuccess, out string newHKCUValue);
-        FixValue(hklmValue, out bool hklmFixSuccess, out string newHKLMValue);
+        FixValue(hkcuValue, out bool hkcuFixSuccess, out string newHkcuValue);
+        FixValue(hklmValue, out bool hklmFixSuccess, out string newHklmValue);
 
         if (hkcuFixSuccess)
         {
-            if (string.IsNullOrEmpty(newHKCUValue))
+            if (string.IsNullOrEmpty(newHkcuValue))
                 hkcuKey.DeleteValue(gameExeFullPath, false);
             else
-                hkcuKey.SetValue(gameExeFullPath, newHKCUValue, RegistryValueKind.String);
+                hkcuKey.SetValue(gameExeFullPath, newHkcuValue, RegistryValueKind.String);
         }
 
         if (hklmFixSuccess)
         {
-            if (string.IsNullOrEmpty(newHKLMValue))
+            if (string.IsNullOrEmpty(newHklmValue))
                 hklmKey.DeleteValue(gameExeFullPath, false);
             else
-                hklmKey.SetValue(gameExeFullPath, newHKLMValue, RegistryValueKind.String);
+                hklmKey.SetValue(gameExeFullPath, newHklmValue, RegistryValueKind.String);
         }
     }
 }

--- a/DXMainClient/Domain/DirectDrawWrapper.cs
+++ b/DXMainClient/Domain/DirectDrawWrapper.cs
@@ -229,8 +229,10 @@ namespace DTAClient.Domain
         {
             if (ReferenceEquals(a, b))
                 return true;
+                
             if (a is null || b is null)
                 return false;
+                
             return a.InternalName == b.InternalName;
         }
 

--- a/DXMainClient/Domain/DirectDrawWrapper.cs
+++ b/DXMainClient/Domain/DirectDrawWrapper.cs
@@ -229,17 +229,25 @@ namespace DTAClient.Domain
         {
             if (ReferenceEquals(a, b))
                 return true;
-                
+
             if (a is null || b is null)
                 return false;
-                
+
             return a.InternalName == b.InternalName;
         }
 
-        public static bool operator !=(DirectDrawWrapper a, DirectDrawWrapper b)
+        public static bool operator !=(DirectDrawWrapper a, DirectDrawWrapper b) => !(a == b);
+
+        public override bool Equals(object obj)
         {
-            return !(a == b);
+            if (obj is DirectDrawWrapper other)
+            {
+                return this == other;
+            }
+            return false;
         }
+
+        public override int GetHashCode() => InternalName.GetHashCode();
     }
 
     /// <summary>

--- a/DXMainClient/Domain/DirectDrawWrapper.cs
+++ b/DXMainClient/Domain/DirectDrawWrapper.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
-namespace ClientGUI
+namespace DTAClient.Domain
 {
     /// <summary>
     /// A DirectDraw wrapper option.
@@ -74,6 +74,11 @@ namespace ClientGUI
         /// The filename of the configuration INI of the renderer in the game directory.
         /// </summary>
         public string ConfigFileName { get; private set; }
+
+        /// <summary>
+        /// Indicates whether this DirectDrawWrapper is a dummy wrapper (i.e. no wrapper).
+        /// </summary>
+        public bool IsDummy => string.IsNullOrEmpty(ddrawDLLPath);
 
         private string ddrawDLLPath;
         private string resConfigFileName;

--- a/DXMainClient/Domain/DirectDrawWrapper.cs
+++ b/DXMainClient/Domain/DirectDrawWrapper.cs
@@ -1,6 +1,8 @@
 ﻿using ClientCore;
 using ClientCore.Extensions;
+
 using Rampastring.Tools;
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -220,6 +222,21 @@ namespace DTAClient.Domain
         {
             return !string.IsNullOrEmpty(WindowedModeSection) &&
                 !string.IsNullOrEmpty(WindowedModeKey);
+        }
+
+        // Override == and != operators to compare by InternalName
+        public static bool operator ==(DirectDrawWrapper a, DirectDrawWrapper b)
+        {
+            if (ReferenceEquals(a, b))
+                return true;
+            if (a is null || b is null)
+                return false;
+            return a.InternalName == b.InternalName;
+        }
+
+        public static bool operator !=(DirectDrawWrapper a, DirectDrawWrapper b)
+        {
+            return !(a == b);
         }
     }
 

--- a/DXMainClient/Domain/DirectDrawWrapperManager.cs
+++ b/DXMainClient/Domain/DirectDrawWrapperManager.cs
@@ -49,7 +49,7 @@ namespace DTAClient.Domain
 
             defaultRenderer = renderersIni.GetStringValue("DefaultRenderer", osVersion.ToString(), string.Empty);
 
-            if (defaultRenderer == null)
+            if (string.IsNullOrEmpty(defaultRenderer))
                 throw new ClientConfigurationException("Invalid or missing default renderer for operating system: " + osVersion);
 
             string renderer = UserINISettings.Instance.Renderer;

--- a/DXMainClient/Domain/DirectDrawWrapperManager.cs
+++ b/DXMainClient/Domain/DirectDrawWrapperManager.cs
@@ -70,10 +70,9 @@ namespace DTAClient.Domain
             if (selectedRenderer != originalRenderer ||
                 !SafePath.GetFile(ProgramConstants.GamePath, selectedRenderer.ConfigFileName).Exists)
             {
-                foreach (var renderer in renderers)
+                foreach (var renderer in renderers.Where(renderer => renderer != selectedRenderer))
                 {
-                    if (renderer != selectedRenderer)
-                        renderer.Clean();
+                    renderer.Clean();
                 }
             }
 

--- a/DXMainClient/Domain/DirectDrawWrapperManager.cs
+++ b/DXMainClient/Domain/DirectDrawWrapperManager.cs
@@ -1,0 +1,89 @@
+﻿#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+
+using ClientCore;
+
+using ClientGUI;
+
+using Rampastring.Tools;
+
+namespace DTAClient.Domain
+{
+    public class DirectDrawWrapperManager
+    {
+        private const string RENDERERS_INI = "Renderers.ini";
+        private List<DirectDrawWrapper> renderers;
+
+        private string defaultRenderer;
+        private DirectDrawWrapper selectedRenderer;
+        public DirectDrawWrapper SelectedRenderer => selectedRenderer;
+
+        public DirectDrawWrapperManager()
+        {
+            RefreshRenderers();
+        }
+
+        public IEnumerable<DirectDrawWrapper> GetRenderers(OSVersion localOS)
+            => renderers.Where(r => r.IsCompatibleWithOS(localOS) && !r.Hidden);
+
+        private void RefreshRenderers()
+        {
+            renderers = new List<DirectDrawWrapper>();
+
+            var renderersIni = new IniFile(SafePath.CombineFilePath(ProgramConstants.GetBaseResourcePath(), RENDERERS_INI));
+
+            var keys = renderersIni.GetSectionKeys("Renderers");
+            if (keys == null)
+                throw new ClientConfigurationException("[Renderers] not found from Renderers.ini!");
+
+            foreach (string key in keys)
+            {
+                string internalName = renderersIni.GetStringValue("Renderers", key, string.Empty);
+
+                var ddWrapper = new DirectDrawWrapper(internalName, renderersIni);
+                renderers.Add(ddWrapper);
+            }
+
+            OSVersion osVersion = ClientConfiguration.Instance.GetOperatingSystemVersion();
+
+            defaultRenderer = renderersIni.GetStringValue("DefaultRenderer", osVersion.ToString(), string.Empty);
+
+            if (defaultRenderer == null)
+                throw new ClientConfigurationException("Invalid or missing default renderer for operating system: " + osVersion);
+
+            string renderer = UserINISettings.Instance.Renderer;
+
+            selectedRenderer = renderers.Find(r => r.InternalName == renderer)
+                ?? renderers.Find(r => r.InternalName == defaultRenderer)
+                ?? throw new ClientConfigurationException("Missing renderer: " + renderer);
+
+            GameProcessLogic.UseQres = selectedRenderer.UseQres;
+            GameProcessLogic.SingleCoreAffinity = selectedRenderer.SingleCoreAffinity;
+        }
+
+        public void Save(DirectDrawWrapper? newSelectedRenderer)
+        {
+            var originalRenderer = selectedRenderer;
+            selectedRenderer = newSelectedRenderer ?? originalRenderer;
+
+            if (selectedRenderer != originalRenderer ||
+                !SafePath.GetFile(ProgramConstants.GamePath, selectedRenderer.ConfigFileName).Exists)
+            {
+                foreach (var renderer in renderers)
+                {
+                    if (renderer != selectedRenderer)
+                        renderer.Clean();
+                }
+            }
+
+            selectedRenderer.Apply();
+
+            GameProcessLogic.UseQres = selectedRenderer.UseQres;
+            GameProcessLogic.SingleCoreAffinity = selectedRenderer.SingleCoreAffinity;
+
+            UserINISettings.Instance.Renderer.Value = selectedRenderer.InternalName;
+        }
+
+    }
+}

--- a/DXMainClient/Domain/DirectDrawWrapperManager.cs
+++ b/DXMainClient/Domain/DirectDrawWrapperManager.cs
@@ -19,10 +19,13 @@ namespace DTAClient.Domain
         private DirectDrawWrapper selectedRenderer;
         public DirectDrawWrapper SelectedRenderer => selectedRenderer;
 
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor
         public DirectDrawWrapperManager()
         {
+            // This method sets up `renderers`, `defaultRenderer`, and `selectedRenderer`
             RefreshRenderers();
         }
+#pragma warning restore CS8618
 
         public IEnumerable<DirectDrawWrapper> GetRenderers(OSVersion localOS)
             => renderers.Where(r => r.IsCompatibleWithOS(localOS) && !r.Hidden);

--- a/DXMainClient/PreStartup.cs
+++ b/DXMainClient/PreStartup.cs
@@ -291,12 +291,7 @@ namespace DTAClient
             DialogResult result = MessageBox.Show(error + "\n\n" + question, title, MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question, MessageBoxDefaultButton.Button2);
             if (result == DialogResult.Yes)
             {
-                using var _ = Process.Start(new ProcessStartInfo
-                {
-                    FileName = SafePath.CombineFilePath(ProgramConstants.StartupExecutable),
-                    Verb = "runas",
-                    UseShellExecute = true,
-                });
+                AdminRestarter.RestartAsAdmin();
             }
 #else
             MainClientConstants.DisplayErrorAction(title, error, true);

--- a/DXMainClient/Resources/ClientDefinitions.ini
+++ b/DXMainClient/Resources/ClientDefinitions.ini
@@ -19,6 +19,10 @@ GameExecutableNames=game.exe
 ; Game executable name for Linux/Mac systems
 UnixGameExecutableName=wine-ts.sh
 
+; List of executables to check for DirectDraw compatibility mode issues
+; Comma-separated list of executables in the execution chain
+;CompatibilityCheckExecutables=CnCNetYRLauncher.exe,gamemd.exe,gamemd-spawn.exe
+
 ; The main map file extension that is read by the client (e.g. map for TS/RA2, ini for Dune)
 MapFileExtension=map
 

--- a/DXMainClient/Startup.cs
+++ b/DXMainClient/Startup.cs
@@ -21,11 +21,6 @@ using System.Runtime.Versioning;
 using ClientCore.Settings;
 using ClientGUI;
 using Steamworks;
-using System.Diagnostics;
-
-#if WINFORMS
-using System.Windows.Forms;
-#endif
 
 namespace DTAClient
 {
@@ -45,10 +40,6 @@ namespace DTAClient
 
             if (!resourcesDirectory.Exists)
                 throw new DirectoryNotFoundException("Theme directory not found!" + Environment.NewLine + ProgramConstants.RESOURCES_DIR);
-
-#if ISWINDOWS
-            CheckDirectDrawCompatibility();
-#endif
 
             Logger.Log("Initializing updater.");
 
@@ -457,127 +448,5 @@ namespace DTAClient
             }
         }
 
-        /// <summary>
-        /// Checks for DirectDraw compatibility issues and prompts user to fix them.
-        /// </summary>
-        [SupportedOSPlatform("windows")]
-        private static void CheckDirectDrawCompatibility()
-        {
-            try
-            {
-                DirectDrawCompatibilityFixer.Examine(out bool requireFix, out bool requireAdmin);
-
-                if (requireFix)
-                {
-                    Logger.Log("DirectDraw compatibility issue detected.");
-
-                    string message = "Problematic Windows compatibility mode settings have been detected that may interfere with the game.\n\n" +
-                                   "Would you like to remove these compatibility settings now?";
-
-                    if (requireAdmin)
-                    {
-                        message += "\n\nNote: Administrator privileges are required to remove compatibility settings.";
-                    }
-
-#if WINFORMS
-                    DialogResult result = MessageBox.Show(message, "Compatibility Settings Detected",
-                        MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
-
-                    if (result == DialogResult.Yes)
-                    {
-                        if (requireAdmin && !IsRunningAsAdministrator())
-                        {
-                            Logger.Log("Administrator privileges required. Attempting to restart with elevated privileges.");
-
-                            DialogResult restartResult = MessageBox.Show(
-                                "Administrator privileges are required to fix compatibility settings.\n\n" +
-                                "Would you like to restart the application as administrator?",
-                                "Administrator Required",
-                                MessageBoxButtons.YesNo,
-                                MessageBoxIcon.Question);
-
-                            if (restartResult == DialogResult.Yes)
-                            {
-                                RestartWithAdminPrivileges();
-                                Environment.Exit(0);
-                            }
-                            else
-                            {
-                                Logger.Log("User declined to restart with admin privileges.");
-                            }
-                        }
-                        else
-                        {
-                            Logger.Log("Attempting to fix DirectDraw compatibility settings.");
-                            DirectDrawCompatibilityFixer.Fix();
-                            Logger.Log("DirectDraw compatibility settings fixed successfully.");
-
-                            MessageBox.Show("Compatibility settings have been removed successfully.",
-                                          "Fix Applied",
-                                          MessageBoxButtons.OK,
-                                          MessageBoxIcon.Information);
-                        }
-                    }
-                    else
-                    {
-                        Logger.Log("User declined to fix DirectDraw compatibility settings.");
-                    }
-#endif
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger.Log("Error checking DirectDraw compatibility: " + ex.ToString());
-            }
-        }
-
-        /// <summary>
-        /// Checks if the application is running with administrator privileges.
-        /// </summary>
-        /// <returns>True if running as administrator, false otherwise.</returns>
-        [SupportedOSPlatform("windows")]
-        private static bool IsRunningAsAdministrator()
-        {
-            try
-            {
-                using WindowsIdentity identity = WindowsIdentity.GetCurrent();
-                WindowsPrincipal principal = new WindowsPrincipal(identity);
-                return principal.IsInRole(WindowsBuiltInRole.Administrator);
-            }
-            catch
-            {
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Restarts the application with administrator privileges.
-        /// </summary>
-        [SupportedOSPlatform("windows")]
-        private static void RestartWithAdminPrivileges()
-        {
-            try
-            {
-                ProcessStartInfo startInfo = new ProcessStartInfo
-                {
-                    FileName = Process.GetCurrentProcess().MainModule.FileName,
-                    UseShellExecute = true,
-                    Verb = "runas"
-                };
-
-                Process.Start(startInfo);
-            }
-            catch (Exception ex)
-            {
-                Logger.Log("Failed to restart with admin privileges: " + ex.ToString());
-#if WINFORMS
-                MessageBox.Show("Failed to restart with administrator privileges.\n\n" +
-                              "Please manually run the CnCNet Client as administrator.",
-                              "Error",
-                              MessageBoxButtons.OK,
-                              MessageBoxIcon.Error);
-#endif
-            }
-        }
     }
 }

--- a/DXMainClient/Startup.cs
+++ b/DXMainClient/Startup.cs
@@ -21,6 +21,11 @@ using System.Runtime.Versioning;
 using ClientCore.Settings;
 using ClientGUI;
 using Steamworks;
+using System.Diagnostics;
+
+#if WINFORMS
+using System.Windows.Forms;
+#endif
 
 namespace DTAClient
 {
@@ -40,6 +45,10 @@ namespace DTAClient
 
             if (!resourcesDirectory.Exists)
                 throw new DirectoryNotFoundException("Theme directory not found!" + Environment.NewLine + ProgramConstants.RESOURCES_DIR);
+
+#if ISWINDOWS
+            CheckDirectDrawCompatibility();
+#endif
 
             Logger.Log("Initializing updater.");
 
@@ -445,6 +454,129 @@ namespace DTAClient
             catch
             {
                 Logger.Log("Failed to write installation path to the Windows registry");
+            }
+        }
+
+        /// <summary>
+        /// Checks for DirectDraw compatibility issues and prompts user to fix them.
+        /// </summary>
+        [SupportedOSPlatform("windows")]
+        private static void CheckDirectDrawCompatibility()
+        {
+            try
+            {
+                DirectDrawCompatibilityFixer.Examine(out bool requireFix, out bool requireAdmin);
+
+                if (requireFix)
+                {
+                    Logger.Log("DirectDraw compatibility issue detected.");
+
+                    string message = "Problematic Windows compatibility mode settings have been detected that may interfere with the game.\n\n" +
+                                   "Would you like to remove these compatibility settings now?";
+
+                    if (requireAdmin)
+                    {
+                        message += "\n\nNote: Administrator privileges are required to remove compatibility settings.";
+                    }
+
+#if WINFORMS
+                    DialogResult result = MessageBox.Show(message, "Compatibility Settings Detected",
+                        MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+
+                    if (result == DialogResult.Yes)
+                    {
+                        if (requireAdmin && !IsRunningAsAdministrator())
+                        {
+                            Logger.Log("Administrator privileges required. Attempting to restart with elevated privileges.");
+
+                            DialogResult restartResult = MessageBox.Show(
+                                "Administrator privileges are required to fix compatibility settings.\n\n" +
+                                "Would you like to restart the application as administrator?",
+                                "Administrator Required",
+                                MessageBoxButtons.YesNo,
+                                MessageBoxIcon.Question);
+
+                            if (restartResult == DialogResult.Yes)
+                            {
+                                RestartWithAdminPrivileges();
+                                Environment.Exit(0);
+                            }
+                            else
+                            {
+                                Logger.Log("User declined to restart with admin privileges.");
+                            }
+                        }
+                        else
+                        {
+                            Logger.Log("Attempting to fix DirectDraw compatibility settings.");
+                            DirectDrawCompatibilityFixer.Fix();
+                            Logger.Log("DirectDraw compatibility settings fixed successfully.");
+
+                            MessageBox.Show("Compatibility settings have been removed successfully.",
+                                          "Fix Applied",
+                                          MessageBoxButtons.OK,
+                                          MessageBoxIcon.Information);
+                        }
+                    }
+                    else
+                    {
+                        Logger.Log("User declined to fix DirectDraw compatibility settings.");
+                    }
+#endif
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Log("Error checking DirectDraw compatibility: " + ex.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Checks if the application is running with administrator privileges.
+        /// </summary>
+        /// <returns>True if running as administrator, false otherwise.</returns>
+        [SupportedOSPlatform("windows")]
+        private static bool IsRunningAsAdministrator()
+        {
+            try
+            {
+                using WindowsIdentity identity = WindowsIdentity.GetCurrent();
+                WindowsPrincipal principal = new WindowsPrincipal(identity);
+                return principal.IsInRole(WindowsBuiltInRole.Administrator);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Restarts the application with administrator privileges.
+        /// </summary>
+        [SupportedOSPlatform("windows")]
+        private static void RestartWithAdminPrivileges()
+        {
+            try
+            {
+                ProcessStartInfo startInfo = new ProcessStartInfo
+                {
+                    FileName = Process.GetCurrentProcess().MainModule.FileName,
+                    UseShellExecute = true,
+                    Verb = "runas"
+                };
+
+                Process.Start(startInfo);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log("Failed to restart with admin privileges: " + ex.ToString());
+#if WINFORMS
+                MessageBox.Show("Failed to restart with administrator privileges.\n\n" +
+                              "Please manually run the CnCNet Client as administrator.",
+                              "Error",
+                              MessageBoxButtons.OK,
+                              MessageBoxIcon.Error);
+#endif
             }
         }
     }

--- a/Docs/INISystem.md
+++ b/Docs/INISystem.md
@@ -544,6 +544,15 @@ In `ClientDefinitions.ini`:
 TrustedDomains=                ; comma-separated list of strings,
                                ; domain names to match links and prevent the message box from appearing before they open by default browser
                                ; example: cncnet.org,github.com,moddb.com
+```
+
+```ini
+[Settings]
 SaveSkirmishGameOptions=false  ; boolean, whether or not previously used game options in skirmish are saved across client sessions
 SaveCampaignGameOptions=false  ; boolean, whether or not previously used game options in campaign are saved across client sessions
+```
+
+```ini
+[Settings]
+CompatibilityCheckExecutables=CnCNetYRLauncher.exe,gamemd.exe,gamemd-spawn.exe ; comma-separated list of strings, to check for DirectDraw compatibility mode issues
 ```


### PR DESCRIPTION
Recently, a de-sync issue was confirmed in a machine with cnc-ddraw and win7 compatibility, and removing the OS compatibility setting is suggested.

This PR adds a fix for the OS compatibility registry setting on game files defined by `CompatibilityCheckExecutables` as well as the client itself. The client will prompt an XNA message box before applying the removal, and restarts as admin if necessary.

This PR also de-couples some ddraw management from `DisplayOptionsPanel` to `DirectDrawWrapperManager` (`DirectDrawWrapperManager` mainly handles the renderers list, the current selected renderer, and basic renderer switching logic. The `renderer.UsesCustomWindowedOption` things are kept in `DisplayOptionsPanel` since they are tightly coupled). By doing this, we can call this OS compatibility fix on client startup only if a non-dummy ddraw is selected (Note: it is difficult to access `DisplayOptionsPanel` from `MainMenu` class).

## Usage
`ClientDefinitions.ini`


```ini
[Settings]
CompatibilityCheckExecutables=CnCNetYRLauncher.exe,gamemd.exe,gamemd-spawn.exe ; comma-separated list of strings, to check for DirectDraw compatibility mode issues
```