### PR TITLE
Add processor affinity argument for Ares

### DIFF
--- a/ClientGUI/GameProcessLogic.cs
+++ b/ClientGUI/GameProcessLogic.cs
@@ -2,12 +2,15 @@
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
-using ClientCore;
-using Rampastring.Tools;
-using ClientCore.INIProcessing;
 using System.Threading;
-using Rampastring.XNAUI;
+
+using ClientCore;
+using ClientCore.Enums;
 using ClientCore.Extensions;
+using ClientCore.INIProcessing;
+
+using Rampastring.Tools;
+using Rampastring.XNAUI;
 
 namespace ClientGUI
 {
@@ -83,6 +86,8 @@ namespace ClientGUI
 
             GameProcessStarting?.Invoke();
 
+            bool processorAffinityOverride = Environment.ProcessorCount > 1 && SingleCoreAffinity && (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
+
             if (UserINISettings.Instance.WindowedMode && UseQres && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 Logger.Log("Windowed mode is enabled - using QRes.");
@@ -112,7 +117,7 @@ namespace ClientGUI
                     return;
                 }
 
-                if (Environment.ProcessorCount > 1 && SingleCoreAffinity)
+                if (processorAffinityOverride)
                     QResProcess.ProcessorAffinity = (IntPtr)2;
             }
             else
@@ -123,6 +128,9 @@ namespace ClientGUI
                     arguments = " " + additionalExecutableName + "-SPAWN " + extraCommandLine;
                 else
                     arguments = additionalExecutableName + "-SPAWN";
+
+                if (processorAffinityOverride && ClientConfiguration.Instance.ClientGameType == ClientType.Ares)
+                    arguments += " " + "-AFFINITY:2";
 
                 FileInfo gameFileInfo = SafePath.GetFile(ProgramConstants.GamePath, gameExecutableName);
 
@@ -151,11 +159,8 @@ namespace ClientGUI
                     return;
                 }
 
-                if ((RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                    && Environment.ProcessorCount > 1 && SingleCoreAffinity)
-                {
+                if (processorAffinityOverride)
                     gameProcess.ProcessorAffinity = (IntPtr)2;
-                }
             }
 
             GameProcessStarted?.Invoke();

--- a/ClientGUI/GameProcessLogic.cs
+++ b/ClientGUI/GameProcessLogic.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -27,6 +28,35 @@ namespace ClientGUI
 
         public static bool UseQres { get; set; }
         public static bool SingleCoreAffinity { get; set; }
+
+        public static bool GetProcessorAffinityValue(out int affinity)
+        {
+            if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux)))
+            {
+                affinity = 0;
+                return false;
+            }
+
+            if (Environment.ProcessorCount <= 1)
+            {
+                affinity = 1; // Only one CPU core available
+                return true;
+            }
+
+
+            if (SingleCoreAffinity)
+            {
+                affinity = 2; // Use only CPU 1
+                return true;
+            }
+            else
+            {
+                int maximumCpuCountPerProcessorGroup = 64;
+                int cpuCount = Math.Min(Environment.ProcessorCount, maximumCpuCountPerProcessorGroup);
+                affinity = (1 << cpuCount) - 2; // All but CPU 0
+                return true;
+            }
+        }
 
         /// <summary>
         /// Starts the main game process.
@@ -86,7 +116,7 @@ namespace ClientGUI
 
             GameProcessStarting?.Invoke();
 
-            bool processorAffinityOverride = Environment.ProcessorCount > 1 && SingleCoreAffinity && (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
+            bool overrideProcessorAffinity = GetProcessorAffinityValue(out int processorAffinity);
 
             if (UserINISettings.Instance.WindowedMode && UseQres && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -117,8 +147,8 @@ namespace ClientGUI
                     return;
                 }
 
-                if (processorAffinityOverride)
-                    QResProcess.ProcessorAffinity = (IntPtr)2;
+                if (overrideProcessorAffinity)
+                    QResProcess.ProcessorAffinity = (IntPtr)processorAffinity;
             }
             else
             {
@@ -129,8 +159,11 @@ namespace ClientGUI
                 else
                     arguments = additionalExecutableName + "-SPAWN";
 
-                if (processorAffinityOverride && ClientConfiguration.Instance.ClientGameType == ClientType.Ares)
-                    arguments += " " + "-AFFINITY:2";
+                if (overrideProcessorAffinity && ClientConfiguration.Instance.ClientGameType == ClientType.Ares)
+                {
+                    // Ares defaults to use CPU 0 exclusively, unless explicitly overridden.
+                    arguments += " " + "-AFFINITY:" + processorAffinity.ToString(CultureInfo.InvariantCulture);
+                }
 
                 FileInfo gameFileInfo = SafePath.GetFile(ProgramConstants.GamePath, gameExecutableName);
 
@@ -159,8 +192,8 @@ namespace ClientGUI
                     return;
                 }
 
-                if (processorAffinityOverride)
-                    gameProcess.ProcessorAffinity = (IntPtr)2;
+                if (overrideProcessorAffinity)
+                    gameProcess.ProcessorAffinity = (IntPtr)processorAffinity;
             }
 
             GameProcessStarted?.Invoke();


### PR DESCRIPTION
Implements https://github.com/CnCNet/cncnet-yr-client-package/pull/793

Ref:

- what's broken now: https://github.com/CnCNet/cncnet-yr-client-package/pull/793#issuecomment-3706774421
> In CnCNetYR before version 9.0.0, ProcessorAffinity was set to 2 via SingleCoreAffinity to make it run on cpu1 (the second processor). Since version 9.0.0, the Ares extension has been introduced, which has a -AFFINITY parameter that also controls ProcessorAffinity and defaults to 1, meaning the game will run on cpu0, the first processor only. Therefore, here we explicitly set the value of this command-line parameter to make it consistent with the behavior before 9.0.0.
- why CPU 1: https://github.com/CnCNet/cncnet-yr-client-package/pull/793#issuecomment-3707370526
> The current issue: running game on CPU 0 exclusively results in a bad performance because of driver implementation and system interrupts etc., which varies from machines to machines
>
> Reference 1: <https://www.reddit.com/r/GlobalOffensive/comments/1dzci78/disabling_core_0_fps_boost/>
> Reference 2: ~3 years ago, my previous PC playing MO 3.3.6 with cnc-ddraw (old version), Windows 10, E5 2666v3, RX 580. With CPU 0 assigned: the game renderers literally like a PowerPoint slide show. With other CPU thread assigned (I made a tool to automatically do it), the game plays smoothly. Note that this observation might differs a lot upon different kinds of hardware.