### PR TITLE
Fix blocking of start positions

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -593,6 +593,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         protected virtual void OnGameOptionChanged()
         {
             CheckDisallowedSides();
+            CheckBlockedStarts();
 
             btnLaunchGame.SetRank(GetRank());
         }
@@ -1145,6 +1146,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             }
 
             CheckDisallowedSides();
+            CheckBlockedStarts();
         }
 
         private XNALabel GeneratePlayerOptionCaption(string name, string text, int x, int y)
@@ -1175,6 +1177,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             for (int i = 0; i < ddPlayerStarts.Length; i++)
                 EnablePlayerOptionDropDown(ddPlayerStarts[i], i, !playerExtraOptions.IsForceRandomStarts);
 
+            CheckBlockedStarts();
             UpdateMapPreviewBoxEnabledStatus();
             RefreshBtnPlayerExtraOptionsOpenTexture();
         }
@@ -1416,6 +1419,65 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         {
             CheckDisallowedSidesForGroup(forHumanPlayers:false);
             CheckDisallowedSidesForGroup(forHumanPlayers:true);
+        }
+
+        /// <summary>
+        /// Applies blocked starting location indexes to the starting location drop-downs
+        /// and player options based on Auto Ally team start mappings.
+        /// </summary>
+        protected void CheckBlockedStarts()
+        {
+            if (PlayerExtraOptionsPanel == null)
+                return;
+
+            var teamStartMappings = PlayerExtraOptionsPanel.GetTeamStartMappings();
+            var blockedStarts = new List<int>();
+
+            foreach (var mapping in teamStartMappings)
+            {
+                if (mapping.IsBlock)
+                    blockedStarts.Add(mapping.Start);
+            }
+
+            // Enable/disable dropdown items
+            for (int pId = 0; pId < MAX_PLAYER_COUNT; pId++)
+            {
+                for (int i = 0; i < ddPlayerStarts[pId].Items.Count; i++)
+                {
+                    ddPlayerStarts[pId].Items[i].Selectable = !blockedStarts.Contains(i);
+                }
+            }
+
+            UpdateMapPreviewBlockedStarts(blockedStarts);
+
+            // Reset any player who has a blocked position selected
+            for (int pId = 0; pId < Players.Count; pId++)
+            {
+                if (blockedStarts.Contains(Players[pId].StartingLocation))
+                {
+                    Players[pId].StartingLocation = 0; // Set to random
+                    ddPlayerStarts[pId].SelectedIndex = 0;
+                }
+            }
+
+            for (int aiId = 0; aiId < AIPlayers.Count; aiId++)
+            {
+                int index = Players.Count + aiId;
+                if (blockedStarts.Contains(AIPlayers[aiId].StartingLocation))
+                {
+                    AIPlayers[aiId].StartingLocation = 0; // Set to random
+                    ddPlayerStarts[index].SelectedIndex = 0;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Updates the map preview box to disable blocked starting location indicators.
+        /// </summary>
+        /// <param name="blockedStarts">List of blocked starting locations (1-based).</param>
+        protected virtual void UpdateMapPreviewBlockedStarts(List<int> blockedStarts)
+        {
+            // implemented in derived classes
         }
 
         /// <summary>
@@ -2314,6 +2376,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             UpdateMapPreviewBoxEnabledStatus();
 
             CheckDisallowedSides();
+            CheckBlockedStarts();
 
             PlayerUpdatingInProgress = false;
         }

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
@@ -310,6 +310,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             var indicator = (PlayerLocationIndicator)sender;
 
+            if (!indicator.Enabled) return;
+
             SoundPlayer.Play(sndClickSound);
 
             if (!EnableContextMenu)
@@ -600,6 +602,16 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 contextMenu.Disable();
                 contextMenu.Open(lastContextMenuPoint);
             }
+        }
+
+        /// <summary>
+        /// Sets which starting location indicators are enabled based on blocked starts.
+        /// </summary>
+        /// <param name="blockedStarts">List of blocked starting locations (1-based, 1-8).</param>
+        public void SetBlockedStartingLocations(List<int> blockedStarts)
+        {
+            for (int i = 0; i < startingLocationIndicators.Length; i++)
+                startingLocationIndicators[i].Enabled = !blockedStarts.Contains(i+1);
         }
 
         public override void OnMouseEnter()

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
@@ -1182,6 +1182,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             }
         }
 
+        protected override void UpdateMapPreviewBlockedStarts(List<int> blockedStarts) => MapPreviewBox.SetBlockedStartingLocations(blockedStarts);
+
         protected override bool UpdateLaunchGameButtonStatus()
         {
             if (IsHost)

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/SkirmishLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/SkirmishLobby.cs
@@ -503,6 +503,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             MapPreviewBox.EnableStartLocationSelection = MapPreviewBox.EnableContextMenu;
         }
 
+        protected override void UpdateMapPreviewBlockedStarts(List<int> blockedStarts) => MapPreviewBox.SetBlockedStartingLocations(blockedStarts);
+
         protected override bool UpdateLaunchGameButtonStatus()
         {
             btnLaunchGame.Enabled = base.UpdateLaunchGameButtonStatus() && GameMode != null && Map != null;


### PR DESCRIPTION
This PR enforces the auto ally "X" positions. If the host has set "X" on any starting locations, users will no longer be able to choose them from the dropdown or from the map position selectors. If a user is already in that spot, they will be reset to random [???]. 

Closes #796 