### PR TITLE
Extend MainMenuTheme to support random playlists

### DIFF
--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -98,20 +98,13 @@ namespace ClientCore
         /// <summary>
         /// Support list, random selection and caching to ensure consistency across runs.
         /// </summary>
-        public string MainMenuMusicName
-        {
-            get
-            {
-                if (!string.IsNullOrEmpty(_cachedMainMenuMusicName))
-                    return _cachedMainMenuMusicName;
-
+       private string _mainMenuMusicName = null;
+       public string MainMenuMusicName => _mainMenuMusicName ??= GetMainMenuMusicName();
+        
+       private string GetMainMenuMusicName()
+       {
                 string raw = DTACnCNetClient_ini.GetStringValue(GENERAL, "MainMenuTheme", "mainmenu") ?? "mainmenu";
-
-                // Support comma/semicolon/pipe separated lists
-                string[] parts = raw.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
-                                    .Select(p => p.Trim())
-                                    .Where(p => p.Length > 0)
-                                    .ToArray();
+                string[] parts = raw.SplitWithCleanup(new[] { ',' });
 
                 string chosen;
                 if (parts.Length == 0)
@@ -132,10 +125,8 @@ namespace ClientCore
                     chosen = parts[idx];
                 }
 
-                // Maintain compatibility with the original implementation
-                _cachedMainMenuMusicName = SafePath.CombineFilePath(chosen);
-                return _cachedMainMenuMusicName;
-            }
+                return SafePath.CombineFilePath(chosen);
+        
         }
 
         public float DefaultAlphaRate => DTACnCNetClient_ini.GetSingleValue(GENERAL, "AlphaRate", 0.005f);
@@ -168,13 +159,13 @@ namespace ClientCore
 
         public string WindowBorderColor => DTACnCNetClient_ini.GetStringValue(GENERAL, "WindowBorderColor", "128,128,128");
 
-        public string PanelBorderColor => DTACnCNetClient_ini.GetStringValue(GENERAL, "PanelBorderColor", "255,255,255");
+        公共 string PanelBorderColor => DTACnCNetClient_ini.GetStringValue(GENERAL, "PanelBorderColor"， "255,255,255");
 
-        public string ListBoxHeaderColor => DTACnCNetClient_ini.GetStringValue(GENERAL, "ListBoxHeaderColor", "255,255,255");
+        公共 string ListBoxHeaderColor => DTACnCNetClient_ini.GetStringValue(GENERAL, "ListBoxHeaderColor"， "255,255,255");
 
         public string DefaultChatColor => DTACnCNetClient_ini.GetStringValue(GENERAL, "DefaultChatColor", "0,255,0");
 
-        public string AdminNameColor => DTACnCNetClient_ini.GetStringValue(GENERAL, "AdminNameColor", "255,0,0");
+        公共 string AdminNameColor => DTACnCNetClient_ini.GetStringValue(GENERAL, "AdminNameColor", "255,0,0");
 
         public string ReceivedPMColor => DTACnCNetClient_ini.GetStringValue(GENERAL, "PrivateMessageOtherUserColor", "196,196,196");
 
@@ -192,7 +183,7 @@ namespace ClientCore
 
         #region Tool tip settings
 
-        public int ToolTipFontIndex => DTACnCNetClient_ini.GetIntValue(GENERAL, "ToolTipFontIndex", 0);
+        公共 int ToolTipFontIndex => DTACnCNetClient_ini.GetIntValue(GENERAL, "ToolTipFontIndex", 0);
 
         public int ToolTipOffsetX => DTACnCNetClient_ini.GetIntValue(GENERAL, "ToolTipOffsetX", 0);
 

--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -235,7 +235,7 @@ namespace ClientCore
 
         public int SendSleep => clientDefinitionsIni.GetIntValue(SETTINGS, "SendSleep", 2500);
 
-        public int LoadingScreenCount => clientDefinitionsIni.GetIntValue(SETTINGS, "LoadingScreenCount", 2);
+        公共 int LoadingScreenCount => clientDefinitionsIni.GetIntValue(SETTINGS, "LoadingScreenCount", 2);
 
         public int ThemeCount => clientDefinitionsIni.GetSectionKeys("Themes").Count;
 
@@ -261,13 +261,13 @@ namespace ClientCore
 
         public string CnCNetLiveStatusIdentifier => clientDefinitionsIni.GetStringValue(SETTINGS, "CnCNetLiveStatusIdentifier", "cncnet5_ts");
 
-        public string BattleFSFileName => clientDefinitionsIni.GetStringValue(SETTINGS, "BattleFSFileName", "BattleFS.ini");
+        公共 string BattleFSFileName => clientDefinitionsIni.GetStringValue(SETTINGS, "BattleFSFileName", "BattleFS.ini");
 
         public string MapEditorExePath => SafePath.CombineFilePath(clientDefinitionsIni.GetStringValue(SETTINGS, "MapEditorExePath", SafePath.CombineFilePath("FinalSun", "FinalSun.exe")));
 
-        公共 string UnixMapEditorExePath => clientDefinitionsIni.GetStringValue(SETTINGS, "UnixMapEditorExePath", Instance.MapEditorExePath);
+        public string UnixMapEditorExePath => clientDefinitionsIni.GetStringValue(SETTINGS, "UnixMapEditorExePath", Instance.MapEditorExePath);
 
-        公共 bool ModMode => clientDefinitionsIni.GetBooleanValue(SETTINGS, "ModMode"， false);
+        public bool ModMode => clientDefinitionsIni.GetBooleanValue(SETTINGS, "ModMode"， false);
 
         public string LongGameName => clientDefinitionsIni.GetStringValue(SETTINGS, "LongGameName", "Tiberian Sun");
 

--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -90,8 +90,8 @@ namespace ClientCore
 
         #region Client settings
 
-        private string _MainMenuMusicName = null;
-        public string MainMenuMusicName => _MainMenuMusicName ??= GetMainMenuMusicName();
+        private string _mainMenuMusicName = null;
+        public string MainMenuMusicName => _mainMenuMusicName ??= GetMainMenuMusicName();
         private string GetMainMenuMusicName()
         {
             string raw = DTACnCNetClient_ini.GetStringValue(GENERAL, "MainMenuTheme", "mainmenu");

--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -199,7 +199,7 @@ namespace ClientCore
 
         #region Audio options
 
-        公共 float SoundGameLobbyJoinCooldown => DTACnCNetClient_ini.GetSingleValue(AUDIO, "SoundGameLobbyJoinCooldown", 0.25f);
+        public float SoundGameLobbyJoinCooldown => DTACnCNetClient_ini.GetSingleValue(AUDIO, "SoundGameLobbyJoinCooldown", 0.25f);
 
         public float SoundGameLobbyLeaveCooldown => DTACnCNetClient_ini.GetSingleValue(AUDIO, "SoundGameLobbyLeaveCooldown", 0.25f);
 
@@ -341,7 +341,7 @@ namespace ClientCore
         /// <summary>
         /// Force a refresh of the translation game files list.
         /// </summary>
-        公共 void RefreshTranslationGameFiles()
+        public void RefreshTranslationGameFiles()
         {
             _translationGameFiles = ParseTranslationGameFiles();
         }

--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -199,7 +199,7 @@ namespace ClientCore
 
         #region Audio options
 
-        public float SoundGameLobbyJoinCooldown => DTACnCNetClient_ini.GetSingleValue(AUDIO, "SoundGameLobbyJoinCooldown", 0.25f);
+        公共 float SoundGameLobbyJoinCooldown => DTACnCNetClient_ini.GetSingleValue(AUDIO, "SoundGameLobbyJoinCooldown", 0.25f);
 
         public float SoundGameLobbyLeaveCooldown => DTACnCNetClient_ini.GetSingleValue(AUDIO, "SoundGameLobbyLeaveCooldown", 0.25f);
 
@@ -235,7 +235,7 @@ namespace ClientCore
 
         public int SendSleep => clientDefinitionsIni.GetIntValue(SETTINGS, "SendSleep", 2500);
 
-        公共 int LoadingScreenCount => clientDefinitionsIni.GetIntValue(SETTINGS, "LoadingScreenCount", 2);
+        public int LoadingScreenCount => clientDefinitionsIni.GetIntValue(SETTINGS, "LoadingScreenCount", 2);
 
         public int ThemeCount => clientDefinitionsIni.GetSectionKeys("Themes").Count;
 
@@ -261,7 +261,7 @@ namespace ClientCore
 
         public string CnCNetLiveStatusIdentifier => clientDefinitionsIni.GetStringValue(SETTINGS, "CnCNetLiveStatusIdentifier", "cncnet5_ts");
 
-        公共 string BattleFSFileName => clientDefinitionsIni.GetStringValue(SETTINGS, "BattleFSFileName", "BattleFS.ini");
+        public string BattleFSFileName => clientDefinitionsIni.GetStringValue(SETTINGS, "BattleFSFileName", "BattleFS.ini");
 
         public string MapEditorExePath => SafePath.CombineFilePath(clientDefinitionsIni.GetStringValue(SETTINGS, "MapEditorExePath", SafePath.CombineFilePath("FinalSun", "FinalSun.exe")));
 
@@ -341,7 +341,7 @@ namespace ClientCore
         /// <summary>
         /// Force a refresh of the translation game files list.
         /// </summary>
-        public void RefreshTranslationGameFiles()
+        公共 void RefreshTranslationGameFiles()
         {
             _translationGameFiles = ParseTranslationGameFiles();
         }

--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -95,7 +95,7 @@ namespace ClientCore
         private string GetMainMenuMusicName()
         {
             string raw = DTACnCNetClient_ini.GetStringValue(GENERAL, "MainMenuTheme", "mainmenu");
-            string[] parts = raw.SplitWithCleanup(new[] { ',' });
+            string[] parts = raw.SplitWithCleanup();
             string chosen = parts.Length > 0
                 ? parts[new Random().Next(parts.Length)]
                 : "mainmenu";

--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -90,8 +90,8 @@ namespace ClientCore
 
         #region Client settings
 
-        private string _cachedMainMenuMusicName = null;
-        public string MainMenuMusicName => _cachedMainMenuMusicName ??= GetMainMenuMusicName();
+        private string _MainMenuMusicName = null;
+        public string MainMenuMusicName => _MainMenuMusicName ??= GetMainMenuMusicName();
         private string GetMainMenuMusicName()
         {
             string raw = DTACnCNetClient_ini.GetStringValue(GENERAL, "MainMenuTheme", "mainmenu");

--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -159,13 +159,13 @@ namespace ClientCore
 
         public string WindowBorderColor => DTACnCNetClient_ini.GetStringValue(GENERAL, "WindowBorderColor", "128,128,128");
 
-        公共 string PanelBorderColor => DTACnCNetClient_ini.GetStringValue(GENERAL, "PanelBorderColor"， "255,255,255");
+        public string PanelBorderColor => DTACnCNetClient_ini.GetStringValue(GENERAL, "PanelBorderColor"， "255,255,255");
 
-        公共 string ListBoxHeaderColor => DTACnCNetClient_ini.GetStringValue(GENERAL, "ListBoxHeaderColor"， "255,255,255");
+        public string ListBoxHeaderColor => DTACnCNetClient_ini.GetStringValue(GENERAL, "ListBoxHeaderColor"， "255,255,255");
 
         public string DefaultChatColor => DTACnCNetClient_ini.GetStringValue(GENERAL, "DefaultChatColor", "0,255,0");
 
-        公共 string AdminNameColor => DTACnCNetClient_ini.GetStringValue(GENERAL, "AdminNameColor", "255,0,0");
+        public string AdminNameColor => DTACnCNetClient_ini.GetStringValue(GENERAL, "AdminNameColor", "255,0,0");
 
         public string ReceivedPMColor => DTACnCNetClient_ini.GetStringValue(GENERAL, "PrivateMessageOtherUserColor", "196,196,196");
 
@@ -183,7 +183,7 @@ namespace ClientCore
 
         #region Tool tip settings
 
-        公共 int ToolTipFontIndex => DTACnCNetClient_ini.GetIntValue(GENERAL, "ToolTipFontIndex", 0);
+        public int ToolTipFontIndex => DTACnCNetClient_ini.GetIntValue(GENERAL, "ToolTipFontIndex", 0);
 
         public int ToolTipOffsetX => DTACnCNetClient_ini.GetIntValue(GENERAL, "ToolTipOffsetX", 0);
 
@@ -265,9 +265,9 @@ namespace ClientCore
 
         public string MapEditorExePath => SafePath.CombineFilePath(clientDefinitionsIni.GetStringValue(SETTINGS, "MapEditorExePath", SafePath.CombineFilePath("FinalSun", "FinalSun.exe")));
 
-        public string UnixMapEditorExePath => clientDefinitionsIni.GetStringValue(SETTINGS, "UnixMapEditorExePath", Instance.MapEditorExePath);
+        公共 string UnixMapEditorExePath => clientDefinitionsIni.GetStringValue(SETTINGS, "UnixMapEditorExePath", Instance.MapEditorExePath);
 
-        public bool ModMode => clientDefinitionsIni.GetBooleanValue(SETTINGS, "ModMode", false);
+        公共 bool ModMode => clientDefinitionsIni.GetBooleanValue(SETTINGS, "ModMode"， false);
 
         public string LongGameName => clientDefinitionsIni.GetStringValue(SETTINGS, "LongGameName", "Tiberian Sun");
 

--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -99,6 +99,7 @@ namespace ClientCore
             string chosen = parts.Length > 0
                 ? parts[new Random().Next(parts.Length)]
                 : "mainmenu";
+
             return SafePath.CombineFilePath(chosen);
         }
 

--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -86,47 +86,20 @@ namespace ClientCore
         public void RefreshSettings()
         {
             DTACnCNetClient_ini = new IniFile(SafePath.CombineFilePath(ProgramConstants.GetResourcePath(), CLIENT_SETTINGS));
-            _cachedMainMenuMusicName = null;
         }
 
         #region Client settings
 
         private string _cachedMainMenuMusicName = null;
-        private static readonly Random _random = new Random();
-        private static readonly object _randomLock = new object();
-
-        /// <summary>
-        /// Support list, random selection and caching to ensure consistency across runs.
-        /// </summary>
-       private string _mainMenuMusicName = null;
-       public string MainMenuMusicName => _mainMenuMusicName ??= GetMainMenuMusicName();
-        
-       private string GetMainMenuMusicName()
-       {
-                string raw = DTACnCNetClient_ini.GetStringValue(GENERAL, "MainMenuTheme", "mainmenu") ?? "mainmenu";
-                string[] parts = raw.SplitWithCleanup(new[] { ',' });
-
-                string chosen;
-                if (parts.Length == 0)
-                {
-                    chosen = "mainmenu";
-                }
-                else if (parts.Length == 1)
-                {
-                    chosen = parts[0];
-                }
-                else
-                {
-                    int idx;
-                    lock (_randomLock)
-                    {
-                        idx = _random.Next(parts.Length);
-                    }
-                    chosen = parts[idx];
-                }
-
-                return SafePath.CombineFilePath(chosen);
-        
+        public string MainMenuMusicName => _cachedMainMenuMusicName ??= GetMainMenuMusicName();
+        private string GetMainMenuMusicName()
+        {
+            string raw = DTACnCNetClient_ini.GetStringValue(GENERAL, "MainMenuTheme", "mainmenu") ?? "mainmenu";
+            string[] parts = raw.SplitWithCleanup(new[] { ',' });
+            string chosen = parts.Length > 0
+                ? parts[new Random().Next(parts.Length)]
+                : "mainmenu";
+            return SafePath.CombineFilePath(chosen);
         }
 
         public float DefaultAlphaRate => DTACnCNetClient_ini.GetSingleValue(GENERAL, "AlphaRate", 0.005f);
@@ -159,9 +132,9 @@ namespace ClientCore
 
         public string WindowBorderColor => DTACnCNetClient_ini.GetStringValue(GENERAL, "WindowBorderColor", "128,128,128");
 
-        public string PanelBorderColor => DTACnCNetClient_ini.GetStringValue(GENERAL, "PanelBorderColor"， "255,255,255");
+        public string PanelBorderColor => DTACnCNetClient_ini.GetStringValue(GENERAL, "PanelBorderColor", "255,255,255");
 
-        public string ListBoxHeaderColor => DTACnCNetClient_ini.GetStringValue(GENERAL, "ListBoxHeaderColor"， "255,255,255");
+        public string ListBoxHeaderColor => DTACnCNetClient_ini.GetStringValue(GENERAL, "ListBoxHeaderColor", "255,255,255");
 
         public string DefaultChatColor => DTACnCNetClient_ini.GetStringValue(GENERAL, "DefaultChatColor", "0,255,0");
 
@@ -267,7 +240,7 @@ namespace ClientCore
 
         public string UnixMapEditorExePath => clientDefinitionsIni.GetStringValue(SETTINGS, "UnixMapEditorExePath", Instance.MapEditorExePath);
 
-        public bool ModMode => clientDefinitionsIni.GetBooleanValue(SETTINGS, "ModMode"， false);
+        public bool ModMode => clientDefinitionsIni.GetBooleanValue(SETTINGS, "ModMode", false);
 
         public string LongGameName => clientDefinitionsIni.GetStringValue(SETTINGS, "LongGameName", "Tiberian Sun");
 

--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -86,11 +86,57 @@ namespace ClientCore
         public void RefreshSettings()
         {
             DTACnCNetClient_ini = new IniFile(SafePath.CombineFilePath(ProgramConstants.GetResourcePath(), CLIENT_SETTINGS));
+            _cachedMainMenuMusicName = null;
         }
 
         #region Client settings
 
-        public string MainMenuMusicName => SafePath.CombineFilePath(DTACnCNetClient_ini.GetStringValue(GENERAL, "MainMenuTheme", "mainmenu"));
+        private string _cachedMainMenuMusicName = null;
+        private static readonly Random _random = new Random();
+        private static readonly object _randomLock = new object();
+
+        /// <summary>
+        /// Support list, random selection and caching to ensure consistency across runs.
+        /// </summary>
+        public string MainMenuMusicName
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(_cachedMainMenuMusicName))
+                    return _cachedMainMenuMusicName;
+
+                string raw = DTACnCNetClient_ini.GetStringValue(GENERAL, "MainMenuTheme", "mainmenu") ?? "mainmenu";
+
+                // Support comma/semicolon/pipe separated lists
+                string[] parts = raw.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                                    .Select(p => p.Trim())
+                                    .Where(p => p.Length > 0)
+                                    .ToArray();
+
+                string chosen;
+                if (parts.Length == 0)
+                {
+                    chosen = "mainmenu";
+                }
+                else if (parts.Length == 1)
+                {
+                    chosen = parts[0];
+                }
+                else
+                {
+                    int idx;
+                    lock (_randomLock)
+                    {
+                        idx = _random.Next(parts.Length);
+                    }
+                    chosen = parts[idx];
+                }
+
+                // Maintain compatibility with the original implementation
+                _cachedMainMenuMusicName = SafePath.CombineFilePath(chosen);
+                return _cachedMainMenuMusicName;
+            }
+        }
 
         public float DefaultAlphaRate => DTACnCNetClient_ini.GetSingleValue(GENERAL, "AlphaRate", 0.005f);
 

--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -94,7 +94,7 @@ namespace ClientCore
         public string MainMenuMusicName => _cachedMainMenuMusicName ??= GetMainMenuMusicName();
         private string GetMainMenuMusicName()
         {
-            string raw = DTACnCNetClient_ini.GetStringValue(GENERAL, "MainMenuTheme", "mainmenu") ?? "mainmenu";
+            string raw = DTACnCNetClient_ini.GetStringValue(GENERAL, "MainMenuTheme", "mainmenu");
             string[] parts = raw.SplitWithCleanup(new[] { ',' });
             string chosen = parts.Length > 0
                 ? parts[new Random().Next(parts.Length)]


### PR DESCRIPTION
Since I used AI to program, I don’t have complete confidence in my abilities, and I lack relevant experience.

I’m sorry I wasn’t able to respond to @SadPencil  last year, but now I’m slowly learning how to take things seriously and know what to do.


The pull request for [#822](https://github.com/CnCNet/xna-cncnet-client/pull/822) has been reopened now.
I still used AI for the programming – mainly because I’m not very skilled in that area.
Reimplemented and added corresponding detailed explanations.

If there are any issues, please let me know.

The following are examples of how to use them, along with corresponding explanations.
**For example：**
```
;(1)
MainMenuTheme=ClientMusic1,ClientMusic2

;(2)
MainMenuTheme=Music/ClientMusic1,Music/ClientMusic2

;(3)
MainMenuTheme=ClientMusic1,Music/ClientMusic2
```

**Explanation：**
Within **_GlobalThemeSettings.ini_** Or **_DTACnCNetClient.ini_**
```
[General]
MainMenuTheme=  ;comma-separated list of strings,
                ;Used as a random file path for MainMenuTheme.
```