### PR TITLE
Add "Show in folder" context menu items for maps

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -285,8 +285,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             mapContextMenu.AddItem("Delete Map".L10N("Client:Main:DeleteMap"),
                 selectAction: DeleteMapConfirmation,
                 visibilityChecker: CanDeleteMap);
-            mapContextMenu.AddItem("Reveal in Explorer".L10N("Client:Main:RevealInExplorer"),
-                selectAction: RevealInExplorer);
+            mapContextMenu.AddItem("Show in folder".L10N("Client:Main:ShowInFolder"),
+                selectAction: ShowInFolder);
 
             AddChild(mapContextMenu);
 
@@ -825,7 +825,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             messageBox.YesClickedAction = DeleteSelectedMap;
         }
 
-        private void RevealInExplorer() => Map?.OpenContainingFolder();
+        private void ShowInFolder() => Map?.OpenContainingFolder();
 
         private void MapPreviewBox_ToggleFavorite(object sender, EventArgs e) =>
             ToggleFavoriteMap();

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -285,6 +285,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             mapContextMenu.AddItem("Delete Map".L10N("Client:Main:DeleteMap"),
                 selectAction: DeleteMapConfirmation,
                 visibilityChecker: CanDeleteMap);
+            mapContextMenu.AddItem("Open Map Folder".L10N("Client:Main:OpenMapFolder"),
+                selectAction: OpenMapFolder);
 
             AddChild(mapContextMenu);
 
@@ -822,6 +824,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 string.Format("Are you sure you wish to delete the custom map {0}?".L10N("Client:Main:DeleteMapConfirmText"), Map.Name));
             messageBox.YesClickedAction = DeleteSelectedMap;
         }
+
+        private void OpenMapFolder() => Map?.OpenContainingFolder();
 
         private void MapPreviewBox_ToggleFavorite(object sender, EventArgs e) =>
             ToggleFavoriteMap();

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -285,8 +285,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             mapContextMenu.AddItem("Delete Map".L10N("Client:Main:DeleteMap"),
                 selectAction: DeleteMapConfirmation,
                 visibilityChecker: CanDeleteMap);
-            mapContextMenu.AddItem("Open Map Folder".L10N("Client:Main:OpenMapFolder"),
-                selectAction: OpenMapFolder);
+            mapContextMenu.AddItem("Reveal in Explorer".L10N("Client:Main:RevealInExplorer"),
+                selectAction: RevealInExplorer);
 
             AddChild(mapContextMenu);
 
@@ -825,7 +825,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             messageBox.YesClickedAction = DeleteSelectedMap;
         }
 
-        private void OpenMapFolder() => Map?.OpenContainingFolder();
+        private void RevealInExplorer() => Map?.OpenContainingFolder();
 
         private void MapPreviewBox_ToggleFavorite(object sender, EventArgs e) =>
             ToggleFavoriteMap();

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
@@ -149,6 +149,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         private XNAContextMenu mapContextMenu;
         private XNAContextMenuItem toggleFavoriteMapItem;
         private XNAContextMenuItem toggleExtraTexturesItem;
+        private XNAContextMenuItem openMapFolderItem;
         private XNAClientButton btnToggleFavoriteMap;
         private XNAClientButton btnToggleExtraTextures;
 
@@ -207,10 +208,17 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 SelectableChecker = () => GameModeMap != null,
                 VisibilityChecker = () => extraTextures.Any(x => x.Toggleable)
             };
+            openMapFolderItem = new XNAContextMenuItem()
+            {
+                Text = "Open Map Folder".L10N("Client:Main:OpenMapFolder"),
+                SelectAction = OpenMapFolder,
+                SelectableChecker = () => GameModeMap != null
+            };
             mapContextMenu = new XNAContextMenu(WindowManager);
             mapContextMenu.ClientRectangle = new Rectangle(0, 0, 120, 2);
             mapContextMenu.AddItem(toggleFavoriteMapItem);
             mapContextMenu.AddItem(toggleExtraTexturesItem);
+            mapContextMenu.AddItem(openMapFolderItem);
 
             btnToggleFavoriteMap = new XNAClientButton(WindowManager);
             btnToggleFavoriteMap.IdleTexture = AssetLoader.LoadTexture("favInactive.png");
@@ -268,6 +276,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             RefreshExtraTexturesBtn();
         }
+
+        private void OpenMapFolder() => GameModeMap?.Map.OpenContainingFolder();
 
         private void ContextMenu_OptionSelected(int index)
         {

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
@@ -149,7 +149,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         private XNAContextMenu mapContextMenu;
         private XNAContextMenuItem toggleFavoriteMapItem;
         private XNAContextMenuItem toggleExtraTexturesItem;
-        private XNAContextMenuItem RevealInExplorerItem;
+        private XNAContextMenuItem showInFolderItem;
         private XNAClientButton btnToggleFavoriteMap;
         private XNAClientButton btnToggleExtraTextures;
 
@@ -208,17 +208,17 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 SelectableChecker = () => GameModeMap != null,
                 VisibilityChecker = () => extraTextures.Any(x => x.Toggleable)
             };
-            RevealInExplorerItem = new XNAContextMenuItem()
+            showInFolderItem = new XNAContextMenuItem()
             {
-                Text = "Reveal in Explorer".L10N("Client:Main:RevealInExplorer"),
-                SelectAction = RevealInExplorer,
+                Text = "Show in folder".L10N("Client:Main:ShowInFolder"),
+                SelectAction = ShowInFolder,
                 SelectableChecker = () => GameModeMap != null
             };
             mapContextMenu = new XNAContextMenu(WindowManager);
             mapContextMenu.ClientRectangle = new Rectangle(0, 0, 120, 2);
             mapContextMenu.AddItem(toggleFavoriteMapItem);
             mapContextMenu.AddItem(toggleExtraTexturesItem);
-            mapContextMenu.AddItem(RevealInExplorerItem);
+            mapContextMenu.AddItem(showInFolderItem);
 
             btnToggleFavoriteMap = new XNAClientButton(WindowManager);
             btnToggleFavoriteMap.IdleTexture = AssetLoader.LoadTexture("favInactive.png");
@@ -277,7 +277,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             RefreshExtraTexturesBtn();
         }
 
-        private void RevealInExplorer() => GameModeMap?.Map.OpenContainingFolder();
+        private void ShowInFolder() => GameModeMap?.Map.OpenContainingFolder();
 
         private void ContextMenu_OptionSelected(int index)
         {

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
@@ -149,7 +149,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         private XNAContextMenu mapContextMenu;
         private XNAContextMenuItem toggleFavoriteMapItem;
         private XNAContextMenuItem toggleExtraTexturesItem;
-        private XNAContextMenuItem openMapFolderItem;
+        private XNAContextMenuItem RevealInExplorerItem;
         private XNAClientButton btnToggleFavoriteMap;
         private XNAClientButton btnToggleExtraTextures;
 
@@ -208,17 +208,17 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 SelectableChecker = () => GameModeMap != null,
                 VisibilityChecker = () => extraTextures.Any(x => x.Toggleable)
             };
-            openMapFolderItem = new XNAContextMenuItem()
+            RevealInExplorerItem = new XNAContextMenuItem()
             {
-                Text = "Open Map Folder".L10N("Client:Main:OpenMapFolder"),
-                SelectAction = OpenMapFolder,
+                Text = "Reveal in Explorer".L10N("Client:Main:RevealInExplorer"),
+                SelectAction = RevealInExplorer,
                 SelectableChecker = () => GameModeMap != null
             };
             mapContextMenu = new XNAContextMenu(WindowManager);
             mapContextMenu.ClientRectangle = new Rectangle(0, 0, 120, 2);
             mapContextMenu.AddItem(toggleFavoriteMapItem);
             mapContextMenu.AddItem(toggleExtraTexturesItem);
-            mapContextMenu.AddItem(openMapFolderItem);
+            mapContextMenu.AddItem(RevealInExplorerItem);
 
             btnToggleFavoriteMap = new XNAClientButton(WindowManager);
             btnToggleFavoriteMap.IdleTexture = AssetLoader.LoadTexture("favInactive.png");
@@ -277,7 +277,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             RefreshExtraTexturesBtn();
         }
 
-        private void OpenMapFolder() => GameModeMap?.Map.OpenContainingFolder();
+        private void RevealInExplorer() => GameModeMap?.Map.OpenContainingFolder();
 
         private void ContextMenu_OptionSelected(int index)
         {

--- a/DXMainClient/Domain/Multiplayer/Map.cs
+++ b/DXMainClient/Domain/Multiplayer/Map.cs
@@ -15,6 +15,7 @@ using Point = Microsoft.Xna.Framework.Point;
 using Utilities = Rampastring.Tools.Utilities;
 using static System.Collections.Specialized.BitVector32;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Text;
 using ClientCore.PlatformShim;
 using DTAClient.DXGUI.Multiplayer.GameLobby;
@@ -935,15 +936,28 @@ namespace DTAClient.Domain.Multiplayer
         }
 
         /// <summary>
-        /// Opens the folder containing this map in Explorer and selects the map file.
+        /// Opens the folder containing this map in the system file manager and selects the map file.
         /// </summary>
         public void OpenContainingFolder()
         {
             FileInfo mapFileInfo = SafePath.GetFile(CompleteFilePath);
-            if (mapFileInfo.Exists)
+            if (!mapFileInfo.Exists)
+                return;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // https://stackoverflow.com/questions/13680415/how-to-open-explorer-with-a-specific-file-selected
                 ProcessLauncher.StartShellProcess("explorer.exe", $"/select,\"{mapFileInfo.FullName}\"");
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                // https://stackoverflow.com/questions/39214539/opening-finder-from-terminal-with-file-selected
+                ProcessLauncher.StartShellProcess("open", $"-R \"{mapFileInfo.FullName}\"");
+            }
+            else
+            {
+                // Linux: no standard way to select a file, just open the folder
+                ProcessLauncher.StartShellProcess(mapFileInfo.Directory?.FullName);
             }
         }
 

--- a/DXMainClient/Domain/Multiplayer/Map.cs
+++ b/DXMainClient/Domain/Multiplayer/Map.cs
@@ -934,6 +934,19 @@ namespace DTAClient.Domain.Multiplayer
             return new Point(pixelX, pixelY);
         }
 
+        /// <summary>
+        /// Opens the folder containing this map in Explorer and selects the map file.
+        /// </summary>
+        public void OpenContainingFolder()
+        {
+            FileInfo mapFileInfo = SafePath.GetFile(CompleteFilePath);
+            if (mapFileInfo.Exists)
+            {
+                // https://stackoverflow.com/questions/13680415/how-to-open-explorer-with-a-specific-file-selected
+                ProcessLauncher.StartShellProcess("explorer.exe", $"/select,\"{mapFileInfo.FullName}\"");
+            }
+        }
+
         protected bool Equals(Map other) => string.Equals(SHA1, other?.SHA1, StringComparison.InvariantCultureIgnoreCase);
 
         public override int GetHashCode() => SHA1 != null ? SHA1.GetHashCode() : 0;


### PR DESCRIPTION
Adds a context menu item to the map list box and map thumbnail to open the map's folder. The map gets selected in explorer automatically. 

Relatively simple change - will merge in a couple days if no feedback.

Closes #906