### PR TITLE
Make the no-game prompt less verbose

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
@@ -1378,6 +1378,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
             lbChatMessages.TopIndex = 0;
             lbChatMessages.Clear();
+            OnChatMessagesCleared();
             currentChatChannel.Messages.ForEach(msg => AddMessageToChat(msg));
 
             RefreshPlayerList(this, EventArgs.Empty);
@@ -1474,6 +1475,13 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
         private bool ctcpInvalidGameMessageShown = false;
         private bool ctcpNoTunnelMessageShown = false;
         private bool ctcpNoTunnelForGamesMessageShown = false;
+
+        private void OnChatMessagesCleared()
+        {
+            ctcpInvalidGameMessageShown = false;
+            ctcpNoTunnelMessageShown = false;
+            ctcpNoTunnelForGamesMessageShown = false;
+        }
 
         private void GameBroadcastChannel_CTCPReceived(object sender, ChannelCTCPEventArgs e)
         {

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
@@ -142,6 +142,10 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
         private Random random;
 
+        private bool ctcpInvalidGameMessageShown = false;
+        private bool ctcpNoTunnelMessageShown = false;
+        private bool ctcpNoTunnelForGamesMessageShown = false;
+
         private void GameList_ClientRectangleUpdated(object sender, EventArgs e)
         {
             panelGameFilters.ClientRectangle = lbGameList.ClientRectangle;
@@ -1438,6 +1442,13 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 item.Texture = gameCollection.GameList[ircUser.GameID].Texture;
         }
 
+        private void OnChatMessagesCleared()
+        {
+            ctcpInvalidGameMessageShown = false;
+            ctcpNoTunnelMessageShown = false;
+            ctcpNoTunnelForGamesMessageShown = false;
+        }
+
         private void AddMessageToChat(ChatMessage message)
         {
             if (!string.IsNullOrEmpty(message.SenderIdent) &&
@@ -1470,17 +1481,6 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 // dismiss any outstanding invitations that are no longer valid
                 DismissInvalidInvitations();
             }
-        }
-
-        private bool ctcpInvalidGameMessageShown = false;
-        private bool ctcpNoTunnelMessageShown = false;
-        private bool ctcpNoTunnelForGamesMessageShown = false;
-
-        private void OnChatMessagesCleared()
-        {
-            ctcpInvalidGameMessageShown = false;
-            ctcpNoTunnelMessageShown = false;
-            ctcpNoTunnelForGamesMessageShown = false;
         }
 
         private void GameBroadcastChannel_CTCPReceived(object sender, ChannelCTCPEventArgs e)

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
@@ -1471,9 +1471,9 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             }
         }
 
-        private bool CTCPInvalidGameMessageShown = false;
-        private bool CTCPNoTunnelMessageShown = false;
-        private bool CTCPNoTunnelForGamesMessageShown = false;
+        private bool ctcpInvalidGameMessageShown = false;
+        private bool ctcpNoTunnelMessageShown = false;
+        private bool ctcpNoTunnelForGamesMessageShown = false;
 
         private void GameBroadcastChannel_CTCPReceived(object sender, ChannelCTCPEventArgs e)
         {
@@ -1513,9 +1513,9 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 Logger.Log("Ignoring CTCP game message because of an invalid amount of parameters.");
 
                 // Remind users that the network is good but the client is outdated or newer
-                if (lbGameList.Items.Count == 0 && lbGameList.HostedGames.Count == 0 && !CTCPInvalidGameMessageShown)
+                if (lbGameList.Items.Count == 0 && lbGameList.HostedGames.Count == 0 && !ctcpInvalidGameMessageShown)
                 {
-                    CTCPInvalidGameMessageShown = true;
+                    ctcpInvalidGameMessageShown = true;
 
                     string message = ("There are no games listed but you are indeed connected. The client did receive a game message but can't add it to the list because the message is invalid. " +
                         "You can ignore this prompt if there are games listed later. " +
@@ -1566,9 +1566,9 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                     Logger.Log("Ignoring CTCP game message because there are no tunnels at all. Available tunnel count: 0. Is the connection to CnCNet HTTP service broken?");
 
                     // Remind users that the game is ignored because of no tunnel
-                    if (lbGameList.Items.Count == 0 && lbGameList.HostedGames.Count == 0 && !CTCPNoTunnelMessageShown)
+                    if (lbGameList.Items.Count == 0 && lbGameList.HostedGames.Count == 0 && !ctcpNoTunnelMessageShown)
                     {
-                        CTCPNoTunnelMessageShown = true;
+                        ctcpNoTunnelMessageShown = true;
                         string message = ("There are no games listed. The client did receive a valid game message but can't add it to the list because there are no available tunnels. " +
                             "You can ignore this prompt if there are games listed later. Otherwise, it might indicate a network problem to CnCNet HTTP service.").L10N("Client:Main:NoTunnels");
 
@@ -1586,9 +1586,9 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                         tunnelAddress, tunnelPort, tunnelHandler.Tunnels.Count));
 
                     // Remind users that the game is ignored because of no specified tunnel
-                    if (lbGameList.Items.Count == 0 && lbGameList.HostedGames.Count == 0 && !CTCPNoTunnelForGamesMessageShown)
+                    if (lbGameList.Items.Count == 0 && lbGameList.HostedGames.Count == 0 && !ctcpNoTunnelForGamesMessageShown)
                     {
-                        CTCPNoTunnelForGamesMessageShown = true;
+                        ctcpNoTunnelForGamesMessageShown = true;
 
                         string message = string.Format(("There are no games listed. The client did receive a valid game message but can't add it to the list because the specified tunnel is not available. " +
                             "You can ignore this prompt if there are games listed later. Otherwise, please contact support at {0}.").L10N("Client:Main:NoTunnelForGames"), ClientConfiguration.Instance.LongSupportURL);

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
@@ -1471,6 +1471,10 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             }
         }
 
+        private bool CTCPInvalidGameMessageShown = false;
+        private bool CTCPNoTunnelMessageShown = false;
+        private bool CTCPNoTunnelForGamesMessageShown = false;
+
         private void GameBroadcastChannel_CTCPReceived(object sender, ChannelCTCPEventArgs e)
         {
             var channel = (Channel)sender;
@@ -1509,16 +1513,15 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 Logger.Log("Ignoring CTCP game message because of an invalid amount of parameters.");
 
                 // Remind users that the network is good but the client is outdated or newer
-                if (lbGameList.Items.Count == 0 && lbGameList.HostedGames.Count == 0)
+                if (lbGameList.Items.Count == 0 && lbGameList.HostedGames.Count == 0 && !CTCPInvalidGameMessageShown)
                 {
+                    CTCPInvalidGameMessageShown = true;
+
                     string message = ("There are no games listed but you are indeed connected. The client did receive a game message but can't add it to the list because the message is invalid. " +
                         "You can ignore this prompt if there are games listed later. " +
                         "Otherwise, this usually means that your client is outdated, or, in a rare case, newer than others. Please check for updates.").L10N("Client:Main:InvalidGameMessage");
 
-                    if ((lbChatMessages.Items.LastOrDefault()?.Tag as ChatMessage)?.Message != message)
-                    {
-                        lbChatMessages.AddMessage(new ChatMessage(Color.Gray, message));
-                    }
+                    lbChatMessages.AddMessage(new ChatMessage(Color.Gray, message));
                 }
 
                 return;
@@ -1563,15 +1566,13 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                     Logger.Log("Ignoring CTCP game message because there are no tunnels at all. Available tunnel count: 0. Is the connection to CnCNet HTTP service broken?");
 
                     // Remind users that the game is ignored because of no tunnel
-                    if (lbGameList.Items.Count == 0 && lbGameList.HostedGames.Count == 0)
+                    if (lbGameList.Items.Count == 0 && lbGameList.HostedGames.Count == 0 && !CTCPNoTunnelMessageShown)
                     {
+                        CTCPNoTunnelMessageShown = true;
                         string message = ("There are no games listed. The client did receive a valid game message but can't add it to the list because there are no available tunnels. " +
                             "You can ignore this prompt if there are games listed later. Otherwise, it might indicate a network problem to CnCNet HTTP service.").L10N("Client:Main:NoTunnels");
 
-                        if ((lbChatMessages.Items.LastOrDefault()?.Tag as ChatMessage)?.Message != message)
-                        {
-                            lbChatMessages.AddMessage(new ChatMessage(Color.Gray, message));
-                        }
+                        lbChatMessages.AddMessage(new ChatMessage(Color.Gray, message));
                     }
 
                     return;
@@ -1585,15 +1586,14 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                         tunnelAddress, tunnelPort, tunnelHandler.Tunnels.Count));
 
                     // Remind users that the game is ignored because of no specified tunnel
-                    if (lbGameList.Items.Count == 0 && lbGameList.HostedGames.Count == 0)
+                    if (lbGameList.Items.Count == 0 && lbGameList.HostedGames.Count == 0 && !CTCPNoTunnelForGamesMessageShown)
                     {
+                        CTCPNoTunnelForGamesMessageShown = true;
+
                         string message = string.Format(("There are no games listed. The client did receive a valid game message but can't add it to the list because the specified tunnel is not available. " +
                             "You can ignore this prompt if there are games listed later. Otherwise, please contact support at {0}.").L10N("Client:Main:NoTunnelForGames"), ClientConfiguration.Instance.LongSupportURL);
 
-                        if ((lbChatMessages.Items.LastOrDefault()?.Tag as ChatMessage)?.Message != message)
-                        {
-                            lbChatMessages.AddMessage(new ChatMessage(Color.Gray, message));
-                        }
+                        lbChatMessages.AddMessage(new ChatMessage(Color.Gray, message));
                     }
 
                     return;


### PR DESCRIPTION
Previously this no game prompt shows as long as the last message is not itself. But since there are 3 kinds of messages, the no game prompt might still show frequently. This PR make each type of no game prompt shows up for only once.