### PR TITLE
Fix AI removal when lobby options change

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -2201,7 +2201,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             }
 
             AIPlayers.Clear();
-            for (int cmbId = Players.Count; cmbId < MaxPlayerCount; cmbId++)
+            for (int cmbId = Players.Count; cmbId < MAX_PLAYER_COUNT; cmbId++)
             {
                 XNADropDown dd = ddPlayerNames[cmbId];
                 dd.Items[0].Text = "-";


### PR DESCRIPTION
From feedback on Discord by Dctanxman.

> "Has anyone reported the bug of when game lobby is full with one AI (mostly for survival maps) then you as host change anything the AI gets removed and you can't add the AI back until you increase the max players in the lobby?"