### PR TITLE
Fix channel name not updating when lobby name changed

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -439,6 +439,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             string oldGameRoomName = gameRoomName;
             bool oldIsCustomPassword = isCustomPassword;
             gameRoomName = newGameRoomName;
+            channel.UIName = newGameRoomName;
             playerLimit = newMaxPlayers;
             skillLevel = newSkillLevel;
 
@@ -533,6 +534,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             bool skillLevelChanged = skillLevel != newSkillLevel;
 
             gameRoomName = newGameRoomName;
+            channel.UIName = newGameRoomName;
             playerLimit = newMaxPlayers;
             skillLevel = newSkillLevel;
             isCustomPassword = newIsCustomPassword;

--- a/DXMainClient/Online/Channel.cs
+++ b/DXMainClient/Online/Channel.cs
@@ -64,7 +64,7 @@ namespace DTAClient.Online
 
         #region Public members
 
-        public string UIName { get; }
+        public string UIName { get; set; }
 
         public string ChannelName { get; }
 


### PR DESCRIPTION
Fixes an issue where when a game lobby's name has changed, it would still show the old name when players joined.

Will merge in a day or two.