### PR TITLE
Various LAN Lobby fixes

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
@@ -65,6 +65,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             {
                 new ClientStringCommandHandler(CHAT_COMMAND, Player_HandleChatCommand),
                 new ClientNoParamCommandHandler(GET_READY_COMMAND, HandleGetReadyCommand),
+                new ClientNoParamCommandHandler(PLAYER_QUIT_COMMAND, HandleHostQuit),
                 new ClientStringCommandHandler(RETURN_COMMAND, Player_HandleReturnCommand),
                 new ClientStringCommandHandler(PLAYER_OPTIONS_BROADCAST_COMMAND, HandlePlayerOptionsBroadcast),
                 new ClientStringCommandHandler(PlayerExtraOptions.LAN_MESSAGE_KEY, HandlePlayerExtraOptionsBroadcast),
@@ -107,6 +108,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         private TcpListener listener;
         private TcpClient client;
         private volatile bool leaving;
+        private int sessionId;
 
         private IPEndPoint hostEndPoint;
         private LANColor[] chatColors;
@@ -139,6 +141,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             IPEndPoint hostEndPoint, TcpClient client)
         {
             leaving = false;
+            sessionId++;
             Refresh(isHost);
 
             this.hostEndPoint = hostEndPoint;
@@ -363,6 +366,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             int bytesRead = 0;
 
+            int mySessionId = sessionId;
+
             if (!client.Connected)
                 return;
 
@@ -391,7 +396,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                         "Reading data from the server failed! Server address: {0}. Exception: {1}".L10N("Client:Main:LanServerReadError"),
                          hostEndPoint.Address.ToString(), ex.Message);
 
-                    LeaveGame(localizedMessage);
+                    AddCallback(() => { if (sessionId == mySessionId) LeaveGame(localizedMessage); });
                     break;
                 }
 
@@ -420,13 +425,17 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
                     foreach (string cmd in commands)
                     {
-                        AddCallback(new Action<string>(HandleMessageFromServer), cmd);
+                        string capturedCmd = cmd;
+                        AddCallback(() => { if (sessionId == mySessionId) HandleMessageFromServer(capturedCmd); });
                     }
 
                     continue;
                 }
 
                 // Disconnect from server
+                if (leaving)
+                    break;
+
                 {
                     Logger.Log(string.Format(
                         "Reading data from the server failed (0 bytes received)! Server address: {0}", hostEndPoint.Address.ToString()));
@@ -435,7 +444,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                         "Reading data from the server failed (0 bytes received)! Server address: {0}".L10N("Client:Main:LanServerReadZero"),
                          hostEndPoint.Address.ToString());
 
-                    LeaveGame(localizedMessage);
+                    AddCallback(() => { if (sessionId == mySessionId) LeaveGame(localizedMessage); });
                 }
 
                 break;
@@ -459,6 +468,9 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
         protected void LeaveGame(string message = null)
         {
+            if (leaving)
+                return;
+
             Clear();
             GameLeft?.Invoke(this, new GameLeftEventArgs() { Message = message });
             PlayerExtraOptionsPanel?.Disable();
@@ -486,19 +498,19 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
         public override void Clear()
         {
-            base.Clear();
-
             if (IsHost)
             {
+                GameBroadcast?.Invoke(this, new GameBroadcastEventArgs("GAMECLOSED"));
                 BroadcastMessage(PLAYER_QUIT_COMMAND);
                 Players.ForEach(p => CleanUpPlayer((LANPlayerInfo)p));
-                Players.Clear();
                 listener.Stop();
             }
             else
             {
                 SendMessageToHost(PLAYER_QUIT_COMMAND);
             }
+
+            base.Clear();
 
             leaving = true;
 
@@ -849,6 +861,12 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         {
             if (!IsHost)
                 GetReadyNotification();
+        }
+
+        private void HandleHostQuit()
+        {
+            if (!IsHost && !leaving)
+                LeaveGame();
         }
 
         private void HandlePlayerOptionsRequest(string sender, string data)

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
@@ -308,7 +308,11 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
         private void LpInfo_ConnectionLost(object sender, EventArgs e)
         {
-            var lpInfo = (LANPlayerInfo)sender;
+            AddCallback(new Action<LANPlayerInfo>(HandleConnectionLost), (LANPlayerInfo)sender);
+        }
+
+        private void HandleConnectionLost(LANPlayerInfo lpInfo)
+        {
             CleanUpPlayer(lpInfo);
             Players.Remove(lpInfo);
 

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
@@ -27,7 +27,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         private const int GAME_OPTION_SPECIAL_FLAG_COUNT = 5;
 
         private const double DROPOUT_TIMEOUT = 20.0;
-        private const double GAME_BROADCAST_INTERVAL = 10.0;
+        private const double GAME_BROADCAST_INTERVAL = 2.0;
 
         private const string CHAT_COMMAND = "GLCHAT";
         private const string RETURN_COMMAND = "RETURN";

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
@@ -106,6 +106,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
         private TcpListener listener;
         private TcpClient client;
+        private volatile bool leaving;
 
         private IPEndPoint hostEndPoint;
         private LANColor[] chatColors;
@@ -137,6 +138,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         public void SetUp(bool isHost,
             IPEndPoint hostEndPoint, TcpClient client)
         {
+            leaving = false;
             Refresh(isHost);
 
             this.hostEndPoint = hostEndPoint;
@@ -374,6 +376,9 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 {
                     // Disconnect from server
 
+                    if (leaving)
+                        break;
+
                     Logger.Log(string.Format(
                         "Reading data from the server failed! Server address: {0}. Exception: {1}",
                         hostEndPoint.Address.ToString(), ex.ToString()));
@@ -490,6 +495,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             {
                 SendMessageToHost(PLAYER_QUIT_COMMAND);
             }
+
+            leaving = true;
 
             if (this.client.Connected)
                 this.client.Close();

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
@@ -396,7 +396,11 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                         "Reading data from the server failed! Server address: {0}. Exception: {1}".L10N("Client:Main:LanServerReadError"),
                          hostEndPoint.Address.ToString(), ex.Message);
 
-                    AddCallback(() => { if (sessionId == mySessionId) LeaveGame(localizedMessage); });
+                    AddCallback(() =>
+                    {
+                        if (sessionId == mySessionId)
+                            LeaveGame(localizedMessage);
+                    });
                     break;
                 }
 
@@ -426,7 +430,11 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                     foreach (string cmd in commands)
                     {
                         string capturedCmd = cmd;
-                        AddCallback(() => { if (sessionId == mySessionId) HandleMessageFromServer(capturedCmd); });
+                        AddCallback(() =>
+                        {
+                            if (sessionId == mySessionId)
+                                HandleMessageFromServer(capturedCmd);
+                        });
                     }
 
                     continue;
@@ -444,7 +452,11 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                         "Reading data from the server failed (0 bytes received)! Server address: {0}".L10N("Client:Main:LanServerReadZero"),
                          hostEndPoint.Address.ToString());
 
-                    AddCallback(() => { if (sessionId == mySessionId) LeaveGame(localizedMessage); });
+                    AddCallback(() =>
+                    {
+                        if (sessionId == mySessionId)
+                            LeaveGame(localizedMessage);
+                    });
                 }
 
                 break;

--- a/DXMainClient/DXGUI/Multiplayer/LANGameLoadingLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/LANGameLoadingLobby.cs
@@ -344,7 +344,11 @@ namespace DTAClient.DXGUI.Multiplayer
                         break;
 
                     Logger.Log("Reading data from the server failed! Message: " + ex.ToString());
-                    AddCallback(() => { if (sessionId == mySessionId) LeaveGame(); });
+                    AddCallback(() =>
+                    {
+                        if (sessionId == mySessionId)
+                            LeaveGame();
+                    });
                     break;
                 }
 
@@ -374,7 +378,11 @@ namespace DTAClient.DXGUI.Multiplayer
                     foreach (string cmd in commands)
                     {
                         string capturedCmd = cmd;
-                        AddCallback(() => { if (sessionId == mySessionId) HandleMessageFromServer(capturedCmd); });
+                        AddCallback(() =>
+                        {
+                            if (sessionId == mySessionId)
+                                HandleMessageFromServer(capturedCmd);
+                        });
                     }
 
                     continue;

--- a/DXMainClient/DXGUI/Multiplayer/LANGameLoadingLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/LANGameLoadingLobby.cs
@@ -55,7 +55,8 @@ namespace DTAClient.DXGUI.Multiplayer
             {
                 new ClientStringCommandHandler(CHAT_COMMAND, Client_HandleChatMessage),
                 new ClientStringCommandHandler(OPTIONS_COMMAND, Client_HandleOptionsMessage),
-                new ClientNoParamCommandHandler(GAME_LAUNCH_COMMAND, Client_HandleStartCommand)
+                new ClientNoParamCommandHandler(GAME_LAUNCH_COMMAND, Client_HandleStartCommand),
+                new ClientNoParamCommandHandler(PLAYER_QUIT_COMMAND, HandleHostQuit),
             };
 
             WindowManager.GameClosing += WindowManager_GameClosing;
@@ -98,12 +99,14 @@ namespace DTAClient.DXGUI.Multiplayer
 
         private bool started = false;
         private volatile bool leaving;
+        private int sessionId;
 
         public void SetUp(bool isHost,
             IPEndPoint hostEndPoint, TcpClient client,
             int loadedGameId)
         {
             leaving = false;
+            sessionId++;
             Refresh(isHost);
 
             this.hostEndPoint = hostEndPoint;
@@ -320,6 +323,8 @@ namespace DTAClient.DXGUI.Multiplayer
 
             int bytesRead = 0;
 
+            int mySessionId = sessionId;
+
             if (!client.Connected)
                 return;
 
@@ -339,7 +344,7 @@ namespace DTAClient.DXGUI.Multiplayer
                         break;
 
                     Logger.Log("Reading data from the server failed! Message: " + ex.ToString());
-                    LeaveGame();
+                    AddCallback(() => { if (sessionId == mySessionId) LeaveGame(); });
                     break;
                 }
 
@@ -368,14 +373,18 @@ namespace DTAClient.DXGUI.Multiplayer
 
                     foreach (string cmd in commands)
                     {
-                        AddCallback(new Action<string>(HandleMessageFromServer), cmd);
+                        string capturedCmd = cmd;
+                        AddCallback(() => { if (sessionId == mySessionId) HandleMessageFromServer(capturedCmd); });
                     }
 
                     continue;
                 }
 
+                if (leaving)
+                    break;
+
                 Logger.Log("Reading data from the server failed (0 bytes received)!");
-                LeaveGame();
+                AddCallback(() => { if (sessionId == mySessionId) LeaveGame(); });
                 break;
             }
         }
@@ -393,8 +402,17 @@ namespace DTAClient.DXGUI.Multiplayer
             Logger.Log("Unknown LAN command from the server: " + message);
         }
 
+        private void HandleHostQuit()
+        {
+            if (!IsHost && !leaving)
+                LeaveGame();
+        }
+
         protected override void LeaveGame()
         {
+            if (leaving)
+                return;
+
             Clear();
             Disable();
 
@@ -405,6 +423,7 @@ namespace DTAClient.DXGUI.Multiplayer
         {
             if (IsHost)
             {
+                GameBroadcast?.Invoke(this, new GameBroadcastEventArgs("GAMECLOSED"));
                 BroadcastMessage(PLAYER_QUIT_COMMAND);
                 Players.ForEach(p => CleanUpPlayer((LANPlayerInfo)p));
                 Players.Clear();

--- a/DXMainClient/DXGUI/Multiplayer/LANGameLoadingLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/LANGameLoadingLobby.cs
@@ -21,7 +21,7 @@ namespace DTAClient.DXGUI.Multiplayer
     class LANGameLoadingLobby : GameLoadingLobbyBase
     {
         private const double DROPOUT_TIMEOUT = 20.0;
-        private const double GAME_BROADCAST_INTERVAL = 10.0;
+        private const double GAME_BROADCAST_INTERVAL = 2.0;
 
         private const string OPTIONS_COMMAND = "OPTS";
         private const string GAME_LAUNCH_COMMAND = "START";

--- a/DXMainClient/DXGUI/Multiplayer/LANGameLoadingLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/LANGameLoadingLobby.cs
@@ -267,7 +267,11 @@ namespace DTAClient.DXGUI.Multiplayer
 
         private void LpInfo_ConnectionLost(object sender, EventArgs e)
         {
-            var lpInfo = (LANPlayerInfo)sender;
+            AddCallback(new Action<LANPlayerInfo>(HandleConnectionLost), (LANPlayerInfo)sender);
+        }
+
+        private void HandleConnectionLost(LANPlayerInfo lpInfo)
+        {
             CleanUpPlayer(lpInfo);
             Players.Remove(lpInfo);
 
@@ -302,6 +306,7 @@ namespace DTAClient.DXGUI.Multiplayer
         private void CleanUpPlayer(LANPlayerInfo lpInfo)
         {
             lpInfo.MessageReceived -= LpInfo_MessageReceived;
+            lpInfo.ConnectionLost -= LpInfo_ConnectionLost;
             lpInfo.TcpClient.Close();
         }
 

--- a/DXMainClient/DXGUI/Multiplayer/LANGameLoadingLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/LANGameLoadingLobby.cs
@@ -97,11 +97,13 @@ namespace DTAClient.DXGUI.Multiplayer
         private int loadedGameId;
 
         private bool started = false;
+        private volatile bool leaving;
 
         public void SetUp(bool isHost,
             IPEndPoint hostEndPoint, TcpClient client,
             int loadedGameId)
         {
+            leaving = false;
             Refresh(isHost);
 
             this.hostEndPoint = hostEndPoint;
@@ -328,6 +330,9 @@ namespace DTAClient.DXGUI.Multiplayer
                 }
                 catch (Exception ex)
                 {
+                    if (leaving)
+                        break;
+
                     Logger.Log("Reading data from the server failed! Message: " + ex.ToString());
                     LeaveGame();
                     break;
@@ -404,6 +409,8 @@ namespace DTAClient.DXGUI.Multiplayer
             {
                 SendMessageToHost(PLAYER_QUIT_COMMAND);
             }
+
+            leaving = true;
 
             if (this.client.Connected)
                 this.client.Close();

--- a/DXMainClient/DXGUI/Multiplayer/LANLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/LANLobby.cs
@@ -473,6 +473,16 @@ namespace DTAClient.DXGUI.Multiplayer
 
                     break;
 
+                case "GAMECLOSED":
+                    int closedGameIndex = lbGameList.HostedGames.FindIndex(g => ((HostedLANGame)g).EndPoint.Equals(endPoint));
+                    if (closedGameIndex > -1)
+                    {
+                        lbGameList.HostedGames.RemoveAt(closedGameIndex);
+                        lbGameList.Refresh();
+                    }
+
+                    break;
+
                 case "GAME":
                     if (user == null)
                         return;


### PR DESCRIPTION
Fixes a few issues with the LAN lobbies.

-Fix error: `Reading data from the server failed! Server address: 127.0.0.1. Exception: Unable to  read data from the transport connection: A blocking operation was interrupted by a call to WSACancelBlockingCall.`

-Decrease game broadcast interval from 10 to 2 seconds.

-Add missing QUIT handler

-Fix Fix 0 byte error message on disconnect