### PR TITLE
Speed up game start in online lobby

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -868,6 +868,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                     return;
                 }
 
+                channel.FlushGameSettingsMessages();
+
                 StringBuilder sb = new StringBuilder("START ");
                 sb.Append(UniqueGameID);
                 for (int pId = 0; pId < Players.Count; pId++)

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -879,7 +879,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                     sb.Append(tunnelHandler.CurrentTunnel.Address + ":");
                     sb.Append(playerPorts[pId]);
                 }
-                channel.SendCTCPMessage(sb.ToString(), QueuedMessageType.SYSTEM_MESSAGE, 10);
+                channel.SendCTCPMessage(sb.ToString(), QueuedMessageType.INSTANT_MESSAGE, 10);
             }
             else
             {

--- a/DXMainClient/Online/Channel.cs
+++ b/DXMainClient/Online/Channel.cs
@@ -285,6 +285,12 @@ namespace DTAClient.Online
                 "NOTICE " + ChannelName + " " + CTCPChar1 + CTCPChar2 + message + CTCPChar2, replace);
         }
 
+        public void FlushGameSettingsMessages()
+            => connection.FlushMessagesOfTypes(
+                QueuedMessageType.GAME_SETTINGS_MESSAGE,
+                QueuedMessageType.GAME_PLAYERS_MESSAGE,
+                QueuedMessageType.GAME_PLAYERS_EXTRA_MESSAGE);
+
         /// <summary>
         /// Sends a "kick user" message to the channel.
         /// </summary>

--- a/DXMainClient/Online/Connection.cs
+++ b/DXMainClient/Online/Connection.cs
@@ -953,6 +953,21 @@ namespace DTAClient.Online
             SendMessage("NICK " + ProgramConstants.PLAYERNAME);
         }
 
+        public void FlushMessagesOfTypes(params QueuedMessageType[] types)
+        {
+            List<string> toSend;
+            lock (messageQueueLocker)
+            {
+                toSend = MessageQueue
+                    .Where(m => types.Contains(m.MessageType))
+                    .Select(m => m.Command)
+                    .ToList();
+                MessageQueue.RemoveAll(m => types.Contains(m.MessageType));
+            }
+            foreach (string message in toSend)
+                SendMessage(message);
+        }
+
         public void QueueMessage(QueuedMessageType type, int priority, string message, bool replace = false)
         {
             QueuedMessage qm = new QueuedMessage(message, type, priority, replace);


### PR DESCRIPTION
Since we added the STRTD message, game starts have gotten a bit slower to arrive due to the queue delay.  This PR changes the game start message to instant so it arrives first and much quicker. We also ensure that game options messages are sent before the game start message to ensure everyone starts with the same settings. 

In this PR, when we flush queued options messages, there is no delay between them being sent. I don't anticipate there being any flooding issues but we can revisit if there are reports.