### PR TITLE
Add ResetToDefaultOnGameExit option to CampaignCheckBox

### DIFF
--- a/DXMainClient/DXGUI/Campaign/CampaignCheckBox.cs
+++ b/DXMainClient/DXGUI/Campaign/CampaignCheckBox.cs
@@ -14,6 +14,8 @@ public class CampaignCheckBox : GameSessionCheckBox
 {
     public CampaignCheckBox(WindowManager windowManager) : base (windowManager) { }
     
+    public bool ResetToDefaultOnGameExit { get; private set; }
+
     public override void Initialize()
     {
         // Find the campaign selector that this control belongs to and register ourselves as a game option.
@@ -41,6 +43,10 @@ public class CampaignCheckBox : GameSessionCheckBox
     {
         switch (key)
         {
+            case "ResetToDefaultOnGameExit":
+                ResetToDefaultOnGameExit = Conversions.BooleanFromString(value, false);
+                break;
+
             case "CustomIniPath" when !ClientConfiguration.Instance.CopyMissionsToSpawnmapINI:
                 throw new Exception($"Campaign settings can't affect map code if {nameof(ClientConfiguration.Instance.CopyMissionsToSpawnmapINI)} is disabled!\n\n"
                     + $"Offending setting control: {Name}");

--- a/DXMainClient/DXGUI/Campaign/CampaignCheckBox.cs
+++ b/DXMainClient/DXGUI/Campaign/CampaignCheckBox.cs
@@ -45,7 +45,7 @@ public class CampaignCheckBox : GameSessionCheckBox
         {
             case "ResetToDefaultOnGameExit":
                 ResetToDefaultOnGameExit = Conversions.BooleanFromString(value, false);
-                break;
+                return;
 
             case "CustomIniPath" when !ClientConfiguration.Instance.CopyMissionsToSpawnmapINI:
                 throw new Exception($"Campaign settings can't affect map code if {nameof(ClientConfiguration.Instance.CopyMissionsToSpawnmapINI)} is disabled!\n\n"

--- a/DXMainClient/DXGUI/Campaign/CampaignSelector.cs
+++ b/DXMainClient/DXGUI/Campaign/CampaignSelector.cs
@@ -556,24 +556,36 @@ namespace DTAClient.DXGUI.Campaign
             if (!ClientConfiguration.Instance.ReturnToMainMenuOnMissionLaunch)
                 ToggleControls(true);
 
-            bool altered = false;
-
-            foreach (IUserSetting setting in userSettings)
+            // Handle ResetToDefaultOnGameExit
             {
-                if (!setting.ResetToDefaultOnGameExit)
-                    continue;
+                // Reset campaign checkboxes
+                foreach (CampaignCheckBox cb in CheckBoxes)
+                {
+                    if (cb.ResetToDefaultOnGameExit)
+                        cb.ResetToDefault();
+                }
 
-                if (setting is SettingCheckBoxBase cb)
-                    cb.Checked = cb.DefaultValue;
-                else if (setting is SettingDropDownBase dd)
-                    dd.SelectedIndex = dd.DefaultValue;
+                // Reset user settings
+                bool userSettingsAltered = false;
 
-                setting.Save();
-                altered = true;
+                foreach (IUserSetting setting in userSettings)
+                {
+                    if (!setting.ResetToDefaultOnGameExit)
+                        continue;
+
+                    if (setting is SettingCheckBoxBase cb)
+                        cb.Checked = cb.DefaultValue;
+                    else if (setting is SettingDropDownBase dd)
+                        dd.SelectedIndex = dd.DefaultValue;
+
+                    setting.Save();
+                    userSettingsAltered = true;
+                }
+
+                if (userSettingsAltered)
+                    UserINISettings.Instance.SaveSettings();
             }
 
-            if (altered)
-                UserINISettings.Instance.SaveSettings();
         }
 
         private void ReadMissionList()

--- a/DXMainClient/DXGUI/Campaign/CampaignSelector.cs
+++ b/DXMainClient/DXGUI/Campaign/CampaignSelector.cs
@@ -58,10 +58,10 @@ namespace DTAClient.DXGUI.Campaign
         private List<IUserSetting> userSettings = new List<IUserSetting>();
 
         private CheaterWindow cheaterWindow;
-        
+
         public List<CampaignCheckBox> CheckBoxes { get; } = new();
         public List<CampaignDropDown> DropDowns { get; } = new();
-        
+
         private IniFile gameOptionsIni;
 
         private string[] filesToCheck = new string[]
@@ -240,11 +240,6 @@ namespace DTAClient.DXGUI.Campaign
 
             userSettings.AddRange(Children.OfType<IUserSetting>());
 
-            foreach (var cb in userSettings)
-            {
-                cb.Load();
-            }
-
             ReadMissionList();
 
             cheaterWindow = new CheaterWindow(WindowManager);
@@ -255,7 +250,7 @@ namespace DTAClient.DXGUI.Campaign
             cheaterWindow.CenterOnParent();
             cheaterWindow.YesClicked += CheaterWindow_YesClicked;
             cheaterWindow.Disable();
-            
+
             LoadSettings();
         }
 
@@ -301,11 +296,8 @@ namespace DTAClient.DXGUI.Campaign
 
         private void BtnLaunch_LeftClick(object sender, EventArgs e)
         {
-            // Save user settings before launching the mission
-            userSettings.ForEach(c => c.Save());
-
             SaveSettings();
-            
+
             int selectedMissionId = lbCampaignList.SelectedIndex;
 
             Mission mission = selectedMissions[selectedMissionId];
@@ -350,7 +342,7 @@ namespace DTAClient.DXGUI.Campaign
             CustomMissionHelper.CopySupplementalMissionFiles(mission);
 
             string scenario = mission.Scenario;
-            
+
             FileInfo spawnerSettingsFile = SafePath.GetFile(ProgramConstants.GamePath, ProgramConstants.SPAWNER_SETTINGS);
 
             spawnerSettingsFile.Delete();
@@ -434,15 +426,15 @@ namespace DTAClient.DXGUI.Campaign
             if (copyMapsToSpawnmapINI)
             {
                 var mapIni = new IniFile(SafePath.CombineFilePath(ProgramConstants.GamePath, mission.Scenario));
-                
+
                 IniFile.ConsolidateIniFiles(mapIni, difficultyIni);
-                
+
                 foreach (CampaignCheckBox chkBox in CheckBoxes)
                     chkBox.ApplyMapCode(mapIni, gameMode: null);
-                
+
                 foreach (CampaignDropDown dd in DropDowns)
                     dd.ApplyMapCode(mapIni, gameMode: null);
-                
+
                 mapIni.WriteIniFile(SafePath.CombineFilePath(ProgramConstants.GamePath, "spawnmap.ini"));
             }
 
@@ -496,7 +488,7 @@ namespace DTAClient.DXGUI.Campaign
                 if (string.IsNullOrEmpty(loadingScreenName))
                 {
                     string lsFilename = CustomMissionHelper.CustomMissionSupplementDefinition.FirstOrDefault(x => x.extension.Equals("shp", StringComparison.InvariantCultureIgnoreCase)).filename;
-                    
+
                     if (!string.IsNullOrEmpty(lsFilename))
                     {
                         spawnIniMissionIniSection.AddOrReplaceKey("LS640BkgdName", lsFilename);
@@ -506,7 +498,7 @@ namespace DTAClient.DXGUI.Campaign
                 if (string.IsNullOrEmpty(loadingScreenPalName))
                 {
                     string palFilename = CustomMissionHelper.CustomMissionSupplementDefinition.FirstOrDefault(x => x.extension.Equals("pal", StringComparison.InvariantCultureIgnoreCase)).filename;
-                    
+
                     if (!string.IsNullOrEmpty(palFilename))
                         spawnIniMissionIniSection.AddOrReplaceKey("LS800BkgdPal", palFilename);
                 }
@@ -566,8 +558,6 @@ namespace DTAClient.DXGUI.Campaign
                 }
 
                 // Reset user settings
-                bool userSettingsAltered = false;
-
                 foreach (IUserSetting setting in userSettings)
                 {
                     if (!setting.ResetToDefaultOnGameExit)
@@ -579,11 +569,9 @@ namespace DTAClient.DXGUI.Campaign
                         dd.SelectedIndex = dd.DefaultValue;
 
                     setting.Save();
-                    userSettingsAltered = true;
                 }
 
-                if (userSettingsAltered)
-                    UserINISettings.Instance.SaveSettings();
+                SaveSettings();
             }
 
         }
@@ -703,7 +691,7 @@ namespace DTAClient.DXGUI.Campaign
             else if (disableOfficialMissions)
             {
                 missions = missions.Where(mission => mission.IsCustomMission);
-            }                
+            }
             else
             {
                 // do nothing
@@ -749,6 +737,18 @@ namespace DTAClient.DXGUI.Campaign
         /// </summary>
         private void SaveSettings()
         {
+            SaveUserSettings();
+            SaveCampaignSettings();
+        }
+
+        private void SaveUserSettings()
+        {
+            userSettings.ForEach(c => c.Save());
+            UserINISettings.Instance.SaveSettings();
+        }
+
+        private void SaveCampaignSettings()
+        {
             if (!ClientConfiguration.Instance.SaveCampaignGameOptions)
                 return;
 
@@ -759,7 +759,7 @@ namespace DTAClient.DXGUI.Campaign
                 settingsFileInfo.Delete();
 
                 var settingsIni = new IniFile(settingsFileInfo.FullName);
-                
+
                 foreach (CampaignDropDown dd in DropDowns)
                     settingsIni.SetStringValue("GameOptions", dd.Name, dd.SelectedIndex.ToString());
 
@@ -773,17 +773,25 @@ namespace DTAClient.DXGUI.Campaign
                 Logger.Log($"Saving campaign settings failed! Reason: {ex}");
             }
         }
-        
+
         /// <summary>
         /// Loads settings from an INI file on the file system.
         /// </summary>
         private void LoadSettings()
         {
+            LoadUserSettings();
+            LoadCampaignSettings();
+        }
+
+        private void LoadUserSettings() => userSettings.ForEach(c => c.Load());
+
+        private void LoadCampaignSettings()
+        {
             if (!ClientConfiguration.Instance.SaveCampaignGameOptions)
                 return;
 
             var settingsIni = new IniFile(SafePath.CombineFilePath(ProgramConstants.GamePath, SETTINGS_PATH));
-                
+
             foreach (CampaignDropDown dd in DropDowns)
             {
                 dd.SelectedIndex = settingsIni.GetIntValue("GameOptions", dd.Name, dd.SelectedIndex);

--- a/DXMainClient/DXGUI/Campaign/CampaignSelector.cs
+++ b/DXMainClient/DXGUI/Campaign/CampaignSelector.cs
@@ -567,8 +567,6 @@ namespace DTAClient.DXGUI.Campaign
                         cb.Checked = cb.DefaultValue;
                     else if (setting is SettingDropDownBase dd)
                         dd.SelectedIndex = dd.DefaultValue;
-
-                    setting.Save();
                 }
 
                 SaveSettings();

--- a/DXMainClient/DXGUI/Generic/GameSessionCheckBox.cs
+++ b/DXMainClient/DXGUI/Generic/GameSessionCheckBox.cs
@@ -58,6 +58,8 @@ public class GameSessionCheckBox : XNAClientCheckBox, IGameSessionSetting
     private string enabledSpawnIniValue = "True";
     private string disabledSpawnIniValue = "False";
 
+    private bool DefaultChecked { get; set; }
+
     /// <summary>
     /// Whether this checkbox should be included in the GAME broadcast.
     /// </summary>
@@ -132,7 +134,7 @@ public class GameSessionCheckBox : XNAClientCheckBox, IGameSessionSetting
                 return;
             case "Checked":
                 bool checkedValue = Conversions.BooleanFromString(value, false);
-                Checked = checkedValue;
+                DefaultChecked = Checked = checkedValue;
                 return;
             case "MapScoringMode":
                 mapScoringMode = (CheckBoxMapScoringMode)Enum.Parse(typeof(CheckBoxMapScoringMode), value);
@@ -217,6 +219,6 @@ public class GameSessionCheckBox : XNAClientCheckBox, IGameSessionSetting
         if (!AllowChanges)
             throw new InvalidOperationException("Cannot reset to default when changes are not allowed.");
 
-        Checked = false;
+        Checked = DefaultChecked;
     }
 }

--- a/DXMainClient/DXGUI/Generic/GameSessionCheckBox.cs
+++ b/DXMainClient/DXGUI/Generic/GameSessionCheckBox.cs
@@ -211,4 +211,12 @@ public class GameSessionCheckBox : XNAClientCheckBox, IGameSessionSetting
 
         base.OnLeftClick(inputEventArgs);
     }
+
+    public void ResetToDefault()
+    {
+        if (!AllowChanges)
+            throw new InvalidOperationException("Cannot reset to default when changes are not allowed.");
+
+        Checked = false;
+    }
 }

--- a/Docs/INISystem.md
+++ b/Docs/INISystem.md
@@ -405,7 +405,7 @@ SortOrder=0                                ; integer, display order for icons in
 
 _(inherits [GameSessionCheckBox](#GameSessionCheckBox))_
 
-Use this control type for campaign dropdowns in `CampaignSelector.ini`. Inherits all properties from `GameSessionCheckBox`. Additional properties for this control type are shown below.
+Use this control type for campaign checkboxes in `CampaignSelector.ini`. Inherits all properties from `GameSessionCheckBox`. Additional properties for this control type are shown below.
 
 ```ini
 [SOMECAMPAIGNCHECKBOX]                  ; CampaignCheckBox

--- a/Docs/INISystem.md
+++ b/Docs/INISystem.md
@@ -401,6 +401,17 @@ SortOrder=0                                ; integer, display order for icons in
                                            ;          Lower values appear first.
 ```
 
+##### [CampaignCheckBox](https://github.com/CnCNet/xna-cncnet-client/blob/develop/DXMainClient/DXGUI/Campaign/CampaignCheckBox.cs)
+
+_(inherits [GameSessionCheckBox](#GameSessionCheckBox))_
+
+Use this control type for campaign dropdowns in `CampaignSelector.ini`. Inherits all properties from `GameSessionCheckBox`. Additional properties for this control type are shown below.
+
+```ini
+[SOMECAMPAIGNCHECKBOX]                  ; CampaignCheckBox
+ResetToDefaultOnGameExit=false          ; boolean, reset the checkbox to default value when the game exits.
+```
+
 ##### [GameLobbyCheckBox](https://github.com/CnCNet/xna-cncnet-client/blob/develop/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyCheckBox.cs)
 
 _(inherits [GameSessionCheckBox](#GameSessionCheckBox))_
@@ -439,6 +450,12 @@ Icons=                                     ; comma-separated strings,
 SortOrder=0                                ; integer, display order for icons in GameInformationPanel and GameListBox. 
                                            ;          Lower values appear first.
 ```
+
+##### [CampaignDropDown](https://github.com/CnCNet/xna-cncnet-client/blob/develop/DXMainClient/DXGUI/Campaign/CampaignDropDown.cs)
+
+_(inherits [GameSessionDropDown](#GameSessionDropDown))_
+
+Use this control type for campaign dropdowns in `CampaignSelector.ini`. Inherits all properties from `GameSessionDropDown`.
 
 ##### [GameLobbyDropDown](https://github.com/CnCNet/xna-cncnet-client/blob/develop/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyDropDown.cs)
 


### PR DESCRIPTION
This PR allows a CampaignCheckBox reset itself on game exits.

##### [CampaignCheckBox](https://github.com/CnCNet/xna-cncnet-client/blob/develop/DXMainClient/DXGUI/Campaign/CampaignCheckBox.cs)

_(inherits [GameSessionCheckBox](#GameSessionCheckBox))_

Use this control type for campaign dropdowns in `CampaignSelector.ini`. Inherits all properties from `GameSessionCheckBox`. Additional properties for this control type are shown below.

```ini
[SOMECAMPAIGNCHECKBOX]                  ; CampaignCheckBox
ResetToDefaultOnGameExit=false          ; boolean, reset the checkbox to default value when the game exits.
```