### PR TITLE
Apply keyboard INI changes on startup

### DIFF
--- a/ClientGUI/HotkeyConfigurationWindow.cs
+++ b/ClientGUI/HotkeyConfigurationWindow.cs
@@ -302,40 +302,28 @@ namespace ClientGUI
         private void LoadKeyboardINI()
         {
             keyboardINI = new IniFile(SafePath.CombineFilePath(ProgramConstants.GamePath, ClientConfiguration.Instance.KeyboardINI));
+            var hotkeySection = keyboardINI.GetOrAddSection("Hotkey");
 
-            if (SafePath.GetFile(ProgramConstants.GamePath, ClientConfiguration.Instance.KeyboardINI).Exists)
+            // Load the hotkeys from the INI file
+            foreach (var command in gameCommands)
             {
-                foreach (var command in gameCommands)
-                {
-                    int hotkey = keyboardINI.GetIntValue("Hotkey", command.ININame, 0);
+                int? hotkey = hotkeySection.GetIntValueOrNull(command.ININame);
 
-                    Hotkey hotkeyStruct = new Hotkey(hotkey);
+                if (hotkey.HasValue)
+                {
+                    Hotkey hotkeyStruct = new Hotkey(hotkey.Value);
                     command.Hotkey = new Hotkey(GetKeyOverride(hotkeyStruct.Key), hotkeyStruct.Modifier);
                 }
             }
-            else
-            {
-                foreach (var command in gameCommands)
-                {
-                    command.Hotkey = command.DefaultHotkey;
-                }
-            }
 
-            var hotkeySection = keyboardINI.GetSection("Hotkey");
-
+            // Assign default hotkeys
             foreach (var command in gameCommands)
             {
-                // Now, let's handle the hotkey "0". It means either one of the following two things:
-                // 1. This hotkey is missing from the keyboard INI file, and the default hot key file does not have a default hot key specified.
-                // 2. The player intended to set the hotkey to "None".
-                // We can distinguish these cases by checking if the key exists in the [Hotkey] section.
-                // If we treat a missing hotkey value as "None", then the players won't be able to get the new default hot key
-                // without manually editing their keyboard INI file, which is not good.
-                // Therefore, we'll prefer the default key over "None" only when the hotkey entry is missing.
-                bool hasExplicitHotkey = hotkeySection?.KeyExists(command.ININame) == true;
+                bool hotkeyAssigned = hotkeySection.KeyExists(command.ININame);
 
-                if (!hasExplicitHotkey && command.Hotkey.Equals(Hotkey.None) && !command.DefaultHotkey.Equals(Hotkey.None))
+                if (!hotkeyAssigned && !command.DefaultHotkey.Equals(Hotkey.None))
                 {
+                    // Try assigning the default hotkey if it exists and is not occupied by other commands
                     bool occupied = false;
                     foreach (var otherCommand in gameCommands)
                     {

--- a/ClientGUI/HotkeyConfigurationWindow.cs
+++ b/ClientGUI/HotkeyConfigurationWindow.cs
@@ -221,6 +221,11 @@ namespace ClientGUI
 
             Keyboard.OnKeyPressed += Keyboard_OnKeyPressed;
             EnabledChanged += HotkeyConfigurationWindow_EnabledChanged;
+
+            // Apply the hotkeys, so if the default keyboard ini file is updated during the client update, the changes will be reflected immediately
+            LoadKeyboardINI();
+            RefreshHotkeyList();
+            WriteKeyboardINI();
         }
 
         /// <summary>

--- a/ClientGUI/HotkeyConfigurationWindow.cs
+++ b/ClientGUI/HotkeyConfigurationWindow.cs
@@ -321,16 +321,20 @@ namespace ClientGUI
                 }
             }
 
+            var hotkeySection = keyboardINI.GetSection("Hotkey");
+
             foreach (var command in gameCommands)
             {
                 // Now, let's handle the hotkey "0". It means either one of the following two things:
                 // 1. This hotkey is missing from the keyboard INI file, and the default hot key file does not have a default hot key specified.
                 // 2. The player intended to set the hotkey to "None".
-                // Currently, there's no way to distinguish these two cases.
-                // However, consider a command, that does not have a default hot key at first, and later, the modder adds a default hot key for it in the default keyboard INI file.
-                // If we treat the "0" hotkey value as "None", then the players won't be able to get the new default hot key without manually editing their keyboard INI file, which is not good.
-                // Therefore, for now, we'll prefer the default key over "None".
-                if (command.Hotkey.Equals(Hotkey.None) && !command.DefaultHotkey.Equals(Hotkey.None))
+                // We can distinguish these cases by checking if the key exists in the [Hotkey] section.
+                // If we treat a missing hotkey value as "None", then the players won't be able to get the new default hot key
+                // without manually editing their keyboard INI file, which is not good.
+                // Therefore, we'll prefer the default key over "None" only when the hotkey entry is missing.
+                bool hasExplicitHotkey = hotkeySection?.KeyExists(command.ININame) == true;
+
+                if (!hasExplicitHotkey && command.Hotkey.Equals(Hotkey.None) && !command.DefaultHotkey.Equals(Hotkey.None))
                 {
                     bool occupied = false;
                     foreach (var otherCommand in gameCommands)

--- a/ClientGUI/HotkeyConfigurationWindow.cs
+++ b/ClientGUI/HotkeyConfigurationWindow.cs
@@ -222,7 +222,7 @@ namespace ClientGUI
             Keyboard.OnKeyPressed += Keyboard_OnKeyPressed;
             EnabledChanged += HotkeyConfigurationWindow_EnabledChanged;
 
-            // Apply the hotkeys, so if the default keyboard ini file is updated during the client update, the changes will be reflected immediately
+            // Apply the hotkeys, so if the default keyboard ini file is updated during a client update, the changes will be reflected immediately
             LoadKeyboardINI();
             RefreshHotkeyList();
             WriteKeyboardINI();

--- a/ClientGUI/HotkeyConfigurationWindow.cs
+++ b/ClientGUI/HotkeyConfigurationWindow.cs
@@ -1,12 +1,16 @@
-﻿using ClientCore.Extensions;
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+
 using ClientCore;
+using ClientCore.Extensions;
+
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
+
 using Rampastring.Tools;
 using Rampastring.XNAUI;
 using Rampastring.XNAUI.XNAControls;
-using System;
-using System.Collections.Generic;
 
 namespace ClientGUI
 {
@@ -316,6 +320,34 @@ namespace ClientGUI
                     command.Hotkey = command.DefaultHotkey;
                 }
             }
+
+            foreach (var command in gameCommands)
+            {
+                // Now, let's handle the hotkey "0". It means either one of the following two things:
+                // 1. This hotkey is missing from the keyboard INI file, and the default hot key file does not have a default hot key specified.
+                // 2. The player intended to set the hotkey to "None".
+                // Currently, there's no way to distinguish these two cases.
+                // However, consider a command, that does not have a default hot key at first, and later, the modder adds a default hot key for it in the default keyboard INI file.
+                // If we treat the "0" hotkey value as "None", then the players won't be able to get the new default hot key without manually editing their keyboard INI file, which is not good.
+                // Therefore, for now, we'll prefer the default key over "None".
+                if (command.Hotkey.Equals(Hotkey.None) && !command.DefaultHotkey.Equals(Hotkey.None))
+                {
+                    bool occupied = false;
+                    foreach (var otherCommand in gameCommands)
+                    {
+                        if (otherCommand != command && otherCommand.Hotkey.Equals(command.DefaultHotkey))
+                        {
+                            occupied = true;
+                            break;
+                        }
+                    }
+
+                    if (!occupied)
+                    {
+                        command.Hotkey = command.DefaultHotkey;
+                    }
+                }
+            }
         }
 
         private void LbHotkeys_SelectedIndexChanged(object sender, EventArgs e)
@@ -580,6 +612,8 @@ namespace ClientGUI
 
             public Keys Key { get; private set; }
             public KeyModifiers Modifier { get; private set; }
+
+            public static readonly Hotkey None = new(0);
 
             public override string ToString()
             {


### PR DESCRIPTION
The client will now call LoadKeyboardINI(), RefreshHotkeyList(), and WriteKeyboardINI() on startup so any updates to the default keyboard INI (for example, add new default keyboard keys for Phobos commands during a client update) are applied immediately.