### PR TITLE
Add sync log uploading to mapdb

### DIFF
--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -488,6 +488,8 @@ namespace ClientCore
 
         public string CnCNetMapDBUploadURL => networkDefinitionsIni.GetStringValue(SETTINGS, "CnCNetMapDBUploadURL", "https://mapdb.cncnet.org/upload");
 
+        public string CnCNetSyncLogUploadURL => networkDefinitionsIni.GetStringValue(SETTINGS, "CnCNetSyncLogUploadURL", "https://mapdb.cncnet.org/sync-logs/");
+
         public bool DisableDiscordIntegration => networkDefinitionsIni.GetBooleanValue(SETTINGS, "DisableDiscordIntegration", false);
 
         public List<string> IRCServers => GetIRCServers();

--- a/ClientCore/Settings/UserINISettings.cs
+++ b/ClientCore/Settings/UserINISettings.cs
@@ -159,7 +159,7 @@ namespace ClientCore
             DisablePrivateMessagePopups = new BoolSetting(iniFile, MULTIPLAYER, "DisablePrivateMessagePopups", false);
             AllowPrivateMessagesFromState = new IntSetting(iniFile, MULTIPLAYER, "AllowPrivateMessagesFromState", (int)AllowPrivateMessagesFromEnum.All);
             EnableMapSharing = new BoolSetting(iniFile, MULTIPLAYER, "EnableMapSharing", true);
-            AutoUploadSyncLogs = new BoolSetting(iniFile, MULTIPLAYER, "AutoUploadSyncLogs", false);
+            AutoUploadSyncLogs = new BoolSetting(iniFile, MULTIPLAYER, "AutoUploadSyncLogs", true);
             AlwaysDisplayTunnelList = new BoolSetting(iniFile, MULTIPLAYER, "AlwaysDisplayTunnelList", false);
             MapSortState = new IntSetting(iniFile, MULTIPLAYER, "MapSortState", (int)SortDirection.None);
             SearchAllGameModes = new BoolSetting(iniFile, MULTIPLAYER, "SearchAllGameModes", false);

--- a/ClientCore/Settings/UserINISettings.cs
+++ b/ClientCore/Settings/UserINISettings.cs
@@ -159,6 +159,7 @@ namespace ClientCore
             DisablePrivateMessagePopups = new BoolSetting(iniFile, MULTIPLAYER, "DisablePrivateMessagePopups", false);
             AllowPrivateMessagesFromState = new IntSetting(iniFile, MULTIPLAYER, "AllowPrivateMessagesFromState", (int)AllowPrivateMessagesFromEnum.All);
             EnableMapSharing = new BoolSetting(iniFile, MULTIPLAYER, "EnableMapSharing", true);
+            AutoUploadSyncLogs = new BoolSetting(iniFile, MULTIPLAYER, "AutoUploadSyncLogs", false);
             AlwaysDisplayTunnelList = new BoolSetting(iniFile, MULTIPLAYER, "AlwaysDisplayTunnelList", false);
             MapSortState = new IntSetting(iniFile, MULTIPLAYER, "MapSortState", (int)SortDirection.None);
             SearchAllGameModes = new BoolSetting(iniFile, MULTIPLAYER, "SearchAllGameModes", false);
@@ -268,6 +269,8 @@ namespace ClientCore
         public IntSetting AllowPrivateMessagesFromState { get; private set; }
 
         public BoolSetting EnableMapSharing { get; private set; }
+
+        public BoolSetting AutoUploadSyncLogs { get; private set; }
 
         public BoolSetting AlwaysDisplayTunnelList { get; private set; }
 

--- a/DXMainClient/DXGUI/Generic/GameInProgressWindow.cs
+++ b/DXMainClient/DXGUI/Generic/GameInProgressWindow.cs
@@ -207,7 +207,8 @@ namespace DTAClient.DXGUI
                     debugLogLastWriteTime = lastWriteTime;
                 }
 
-                if (CopySyncErrorLogs(snapshotDirectory, null) || snapshotCreated)
+                bool hasSyncLogs = CopySyncErrorLogs(snapshotDirectory, null);
+                if (hasSyncLogs || snapshotCreated)
                 {
                     FileInfo snapShotDebugLogFileInfo = SafePath.GetFile(snapshotDirectory, "debug.log");
 
@@ -216,6 +217,9 @@ namespace DTAClient.DXGUI
 
                     CopyErrorLog(snapshotDirectory, "syringe.log", null);
                 }
+
+                if (hasSyncLogs && UserINISettings.Instance.AutoUploadSyncLogs.Value)
+                    SyncLogSharer.UploadSyncLogs(snapshotDirectory, gameStartTime);
             }
             else
             {

--- a/DXMainClient/DXGUI/Generic/GameInProgressWindow.cs
+++ b/DXMainClient/DXGUI/Generic/GameInProgressWindow.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using SixLabors.ImageSharp;
+using DTAClient.Domain.Multiplayer.CnCNet;
 
 namespace DTAClient.DXGUI
 {
@@ -31,6 +32,7 @@ namespace DTAClient.DXGUI
 
         private bool initialized = false;
         private bool nativeCursorUsed = false;
+        private DateTime gameStartTime;
 
         private List<string> debugSnapshotDirectories;
         private DateTime debugLogLastWriteTime;
@@ -102,7 +104,17 @@ namespace DTAClient.DXGUI
                     SafePath.DeleteFileIfExists(ProgramConstants.GamePath, "EXCEPT.TXT");
 
                     for (int i = 0; i < 8; i++)
+                    {
                         SafePath.DeleteFileIfExists(ProgramConstants.GamePath, "SYNC" + i + ".TXT");
+
+                        // Also delete multi-chunk variants like SYNC0_000.TXT, SYNC1_255.TXT, etc.
+                        foreach (FileInfo chunkFile in SafePath.GetDirectory(ProgramConstants.GamePath)
+                            .EnumerateFiles("SYNC" + i + "_*.TXT"))
+                        {
+                            try { chunkFile.Delete(); }
+                            catch { }
+                        }
+                    }
 
                     deletingLogFilesFailed = false;
                 }
@@ -119,6 +131,7 @@ namespace DTAClient.DXGUI
             nativeCursorUsed = Game.IsMouseVisible;
             Game.IsMouseVisible = false;
             ProgramConstants.IsInGame = true;
+            gameStartTime = DateTime.Now;
             Game.TargetElapsedTime = TimeSpan.FromMilliseconds(1000.0 / POWER_SAVING_FPS);
 #if WINFORMS
 
@@ -210,7 +223,11 @@ namespace DTAClient.DXGUI
                     return;
 
                 CopyErrorLog(SafePath.CombineDirectoryPath(ProgramConstants.ClientUserFilesPath, "GameCrashLogs"), "EXCEPT.TXT", dtn);
-                CopySyncErrorLogs(SafePath.CombineDirectoryPath(ProgramConstants.ClientUserFilesPath, "SyncErrorLogs"), dtn);
+                string syncErrorLogsDir = SafePath.CombineDirectoryPath(ProgramConstants.ClientUserFilesPath, "SyncErrorLogs");
+                bool hasSyncLogs = CopySyncErrorLogs(syncErrorLogsDir, dtn);
+
+                if (hasSyncLogs && UserINISettings.Instance.AutoUploadSyncLogs.Value)
+                    SyncLogSharer.UploadSyncLogs(syncErrorLogsDir, gameStartTime);
             }
         }
 

--- a/DXMainClient/DXGUI/Generic/OptionPanels/CnCNetOptionsPanel.cs
+++ b/DXMainClient/DXGUI/Generic/OptionPanels/CnCNetOptionsPanel.cs
@@ -34,6 +34,7 @@ namespace DTAClient.DXGUI.Generic.OptionPanels
         XNAClientCheckBox chkSteamIntegration;
         XNAClientCheckBox chkAllowGameInvitesFromFriendsOnly;
         XNAClientCheckBox chkDisablePrivateMessagePopup;
+        XNAClientCheckBox chkAutoUploadSyncLogs;
 
         XNAClientDropDown ddAllowPrivateMessagesFrom;
 
@@ -171,6 +172,15 @@ namespace DTAClient.DXGUI.Generic.OptionPanels
             chkSteamIntegration.Text = "Show the game being played in Steam".L10N("Client:DTAConfig:SteamStatus");
 
             AddChild(chkSteamIntegration);
+
+            chkAutoUploadSyncLogs = new XNAClientCheckBox(WindowManager);
+            chkAutoUploadSyncLogs.Name = nameof(chkAutoUploadSyncLogs);
+            chkAutoUploadSyncLogs.ClientRectangle = new Rectangle(
+                chkSteamIntegration.X,
+                chkSteamIntegration.Bottom + 12, 0, 0);
+            chkAutoUploadSyncLogs.Text = "Automatically upload desync logs".L10N("Client:DTAConfig:AutoUploadSyncLogs");
+
+            AddChild(chkAutoUploadSyncLogs);
         }
 
         private void InitAllowPrivateMessagesFromDropdown()
@@ -339,6 +349,7 @@ namespace DTAClient.DXGUI.Generic.OptionPanels
                 && IniSettings.DiscordIntegration;
 
             chkAllowGameInvitesFromFriendsOnly.Checked = IniSettings.AllowGameInvitesFromFriendsOnly;
+            chkAutoUploadSyncLogs.Checked = IniSettings.AutoUploadSyncLogs;
 
             string localGame = ClientConfiguration.Instance.LocalGame.ToUpperInvariant();
 
@@ -377,6 +388,7 @@ namespace DTAClient.DXGUI.Generic.OptionPanels
             }
 
             IniSettings.AllowGameInvitesFromFriendsOnly.Value = chkAllowGameInvitesFromFriendsOnly.Checked;
+            IniSettings.AutoUploadSyncLogs.Value = chkAutoUploadSyncLogs.Checked;
 
             foreach (var chkBox in followedGameChks)
             {

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -1588,6 +1588,14 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             StopInactiveCheck();
             channel.SendCTCPMessage("STRTD", QueuedMessageType.SYSTEM_MESSAGE, 20);
 
+            SyncLogSharer.SetGameInfo(
+                mapSha1: Map?.SHA1 ?? lastMapSHA1,
+                mapName: Map?.Name ?? lastMapName,
+                gameMode: GameMode?.UntranslatedUIName ?? lastGameMode,
+                gameSlug: localGame,
+                playerName: ProgramConstants.PLAYERNAME,
+                randomSeed: RandomSeed);
+
             base.StartGame();
         }
 

--- a/DXMainClient/Domain/Multiplayer/CnCNet/SyncLogSharer.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/SyncLogSharer.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -8,6 +9,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using ClientCore;
+using ClientCore.PlatformShim;
 using Rampastring.Tools;
 
 namespace DTAClient.Domain.Multiplayer.CnCNet
@@ -19,11 +21,8 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
     /// </summary>
     public static class SyncLogSharer
     {
-        public static event EventHandler SyncLogUploadStarted;
-        public static event EventHandler SyncLogUploadComplete;
-        public static event EventHandler SyncLogUploadFailed;
-
         private const int UPLOAD_TIMEOUT = 30000; // ms
+        private const int FILE_BUFFER_SIZE = 65536;
 
         // Set by CnCNetGameLobby before game start. All values are shared across every
         // client in the same game session, so they can be used to derive the game_hash.
@@ -76,17 +75,17 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
             string gameHash = ComputeGameHash(_lastMapSha1, _lastRandomSeed, _lastGameSlug);
 
             // Collect the SYNC files that were just copied (one per player slot, index 0–7).
-            // CopySyncErrorLogs renames them to SYNC{n}_yyyy_MM_dd_HH_mm.TXT, so we match
-            // by prefix and pick only files created after gameStarted.
+            // Non-Ares: CopySyncErrorLogs names them SYNC{n}_yyyy_MM_dd_HH_mm.TXT.
+            // Ares: files are copied as SYNC{n}.TXT into the snapshot directory.
+            // SYNC{i}*.TXT matches both; the CreationTime filter isolates this session.
             var filesToUpload = new List<(int index, string path)>();
             for (int i = 0; i < 8; i++)
             {
-                string prefix = $"SYNC{i}_";
                 DirectoryInfo dir = new DirectoryInfo(syncErrorLogsDirectory);
                 if (!dir.Exists) break;
 
                 FileInfo found = dir
-                    .EnumerateFiles($"{prefix}*.TXT")
+                    .EnumerateFiles($"SYNC{i}*.TXT")
                     .Where(f => f.CreationTime >= gameStarted.AddSeconds(-5))
                     .OrderByDescending(f => f.CreationTime)
                     .FirstOrDefault();
@@ -105,9 +104,6 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
 
             ThreadPool.QueueUserWorkItem(_ =>
             {
-                SyncLogUploadStarted?.Invoke(null, EventArgs.Empty);
-                bool anyFailed = false;
-
                 foreach ((int index, string path) in filesToUpload)
                 {
                     try
@@ -118,14 +114,8 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
                     catch (Exception ex)
                     {
                         Logger.Log($"SyncLogSharer: Failed to upload SYNC{index}: {ex.Message}");
-                        anyFailed = true;
                     }
                 }
-
-                if (anyFailed)
-                    SyncLogUploadFailed?.Invoke(null, EventArgs.Empty);
-                else
-                    SyncLogUploadComplete?.Invoke(null, EventArgs.Empty);
             });
         }
 
@@ -168,7 +158,7 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
                 $"Content-Type: text/plain\r\n\r\n");
             requestStream.Write(header, 0, header.Length);
 
-            byte[] buffer = new byte[65536];
+            byte[] buffer = new byte[FILE_BUFFER_SIZE];
             int read;
             while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
                 requestStream.Write(buffer, 0, read);
@@ -183,7 +173,7 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
 
         private static void WriteFormField(Stream stream, string boundary, string name, string value)
         {
-            byte[] bytes = Encoding.UTF8.GetBytes(
+            byte[] bytes = EncodingExt.UTF8NoBOM.GetBytes(
                 $"{boundary}\r\nContent-Disposition: form-data; name=\"{name}\"\r\n\r\n{value}\r\n");
             stream.Write(bytes, 0, bytes.Length);
         }
@@ -191,12 +181,13 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
         /// <summary>
         /// Derives a stable, session-unique identifier from values shared by all game clients.
         /// The random seed is set once per game and is identical on every machine.
+        /// Format: <c>SHA1("{mapSha1}|{randomSeed}|{gameSlug}")</c> as a lowercase hex string.
         /// </summary>
         private static string ComputeGameHash(string mapSha1, int randomSeed, string gameSlug)
         {
             string input = $"{mapSha1}|{randomSeed}|{gameSlug}";
             using SHA1 sha1 = SHA1.Create();
-            byte[] hash = sha1.ComputeHash(Encoding.UTF8.GetBytes(input));
+            byte[] hash = sha1.ComputeHash(EncodingExt.UTF8NoBOM.GetBytes(input));
             return Convert.ToHexString(hash).ToLowerInvariant();
         }
     }

--- a/DXMainClient/Domain/Multiplayer/CnCNet/SyncLogSharer.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/SyncLogSharer.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using ClientCore;
+using Rampastring.Tools;
+
+namespace DTAClient.Domain.Multiplayer.CnCNet
+{
+    /// <summary>
+    /// Uploads SYNC*.TXT desync logs to the CnCNet map API after a multiplayer game desyncs.
+    /// Call <see cref="SetGameInfo"/> before the game launches, then <see cref="UploadSyncLogs"/>
+    /// after the game exits and sync files have been found.
+    /// </summary>
+    public static class SyncLogSharer
+    {
+        public static event EventHandler SyncLogUploadStarted;
+        public static event EventHandler SyncLogUploadComplete;
+        public static event EventHandler SyncLogUploadFailed;
+
+        private const int UPLOAD_TIMEOUT = 30000; // ms
+
+        // Set by CnCNetGameLobby before game start. All values are shared across every
+        // client in the same game session, so they can be used to derive the game_hash.
+        private static string _lastMapSha1 = string.Empty;
+        private static string _lastMapName = string.Empty;
+        private static string _lastGameMode = string.Empty;
+        private static string _lastGameSlug = string.Empty;
+        private static string _lastPlayerName = string.Empty;
+        private static int _lastRandomSeed;
+
+        /// <summary>
+        /// Store the game metadata before launching. Must be called on the game-launch path.
+        /// </summary>
+        public static void SetGameInfo(
+            string mapSha1,
+            string mapName,
+            string gameMode,
+            string gameSlug,
+            string playerName,
+            int randomSeed)
+        {
+            _lastMapSha1 = mapSha1 ?? string.Empty;
+            _lastMapName = mapName ?? string.Empty;
+            _lastGameMode = gameMode ?? string.Empty;
+            _lastGameSlug = gameSlug ?? string.Empty;
+            _lastPlayerName = playerName ?? string.Empty;
+            _lastRandomSeed = randomSeed;
+        }
+
+        /// <summary>
+        /// Finds SYNC*.TXT files written after <paramref name="gameStarted"/> in
+        /// <paramref name="syncErrorLogsDirectory"/> and uploads the first chunk of each (index 0–7).
+        /// Runs in a background thread; fire and forget.
+        /// </summary>
+        /// <param name="syncErrorLogsDirectory">
+        ///     The directory where <c>CopySyncErrorLogs</c> deposited the renamed files.
+        /// </param>
+        /// <param name="gameStarted">
+        ///     The approximate time the game started, used to identify files from this session.
+        /// </param>
+        public static void UploadSyncLogs(string syncErrorLogsDirectory, DateTime gameStarted)
+        {
+            string uploadUrl = ClientConfiguration.Instance.CnCNetSyncLogUploadURL;
+            if (string.IsNullOrWhiteSpace(uploadUrl))
+            {
+                Logger.Log("SyncLogSharer: Upload URL not configured, skipping.");
+                return;
+            }
+
+            string gameHash = ComputeGameHash(_lastMapSha1, _lastRandomSeed, _lastGameSlug);
+
+            // Collect the SYNC files that were just copied (one per player slot, index 0–7).
+            // CopySyncErrorLogs renames them to SYNC{n}_yyyy_MM_dd_HH_mm.TXT, so we match
+            // by prefix and pick only files created after gameStarted.
+            var filesToUpload = new List<(int index, string path)>();
+            for (int i = 0; i < 8; i++)
+            {
+                string prefix = $"SYNC{i}_";
+                DirectoryInfo dir = new DirectoryInfo(syncErrorLogsDirectory);
+                if (!dir.Exists) break;
+
+                FileInfo found = dir
+                    .EnumerateFiles($"{prefix}*.TXT")
+                    .Where(f => f.CreationTime >= gameStarted.AddSeconds(-5))
+                    .OrderByDescending(f => f.CreationTime)
+                    .FirstOrDefault();
+
+                if (found != null)
+                    filesToUpload.Add((i, found.FullName));
+            }
+
+            if (filesToUpload.Count == 0)
+            {
+                Logger.Log("SyncLogSharer: No recent SYNC files found to upload.");
+                return;
+            }
+
+            Logger.Log($"SyncLogSharer: Uploading {filesToUpload.Count} sync log(s) for game hash {gameHash[..8]}…");
+
+            ThreadPool.QueueUserWorkItem(_ =>
+            {
+                SyncLogUploadStarted?.Invoke(null, EventArgs.Empty);
+                bool anyFailed = false;
+
+                foreach ((int index, string path) in filesToUpload)
+                {
+                    try
+                    {
+                        UploadFile(uploadUrl, path, index, gameHash);
+                        Logger.Log($"SyncLogSharer: Uploaded SYNC{index} successfully.");
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Log($"SyncLogSharer: Failed to upload SYNC{index}: {ex.Message}");
+                        anyFailed = true;
+                    }
+                }
+
+                if (anyFailed)
+                    SyncLogUploadFailed?.Invoke(null, EventArgs.Empty);
+                else
+                    SyncLogUploadComplete?.Invoke(null, EventArgs.Empty);
+            });
+        }
+
+        private static void UploadFile(string uploadUrl, string filePath, int syncIndex, string gameHash)
+        {
+            ServicePointManager.Expect100Continue = false;
+
+            using FileStream stream = File.OpenRead(filePath);
+
+            string boundary = "---------------------------" + DateTime.Now.Ticks.ToString("x", NumberFormatInfo.InvariantInfo);
+            WebRequest request = WebRequest.Create(uploadUrl);
+            request.Timeout = UPLOAD_TIMEOUT;
+            request.Method = "POST";
+            request.ContentType = $"multipart/form-data; boundary={boundary}";
+            boundary = "--" + boundary;
+
+            var fields = new Dictionary<string, string>
+            {
+                { "game_hash",        gameHash },
+                { "player_name",      _lastPlayerName },
+                { "sync_file_index",  syncIndex.ToString() },
+                { "map_sha1",         _lastMapSha1 },
+                { "map_name",         _lastMapName },
+                { "game_mode",        _lastGameMode },
+                { "game_slug",        _lastGameSlug },
+            };
+
+            using Stream requestStream = request.GetRequestStream();
+
+            // Write form text fields.
+            foreach (KeyValuePair<string, string> kvp in fields)
+            {
+                WriteFormField(requestStream, boundary, kvp.Key, kvp.Value);
+            }
+
+            // Write the file.
+            string fileName = Path.GetFileName(filePath);
+            byte[] header = Encoding.ASCII.GetBytes(
+                $"{boundary}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"{fileName}\"\r\n" +
+                $"Content-Type: text/plain\r\n\r\n");
+            requestStream.Write(header, 0, header.Length);
+
+            byte[] buffer = new byte[65536];
+            int read;
+            while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
+                requestStream.Write(buffer, 0, read);
+
+            byte[] footer = Encoding.ASCII.GetBytes($"\r\n{boundary}--\r\n");
+            requestStream.Write(footer, 0, footer.Length);
+
+            using WebResponse response = request.GetResponse();
+            using StreamReader reader = new StreamReader(response.GetResponseStream()!);
+            Logger.Log($"SyncLogSharer: Server response for SYNC{syncIndex}: " + reader.ReadToEnd());
+        }
+
+        private static void WriteFormField(Stream stream, string boundary, string name, string value)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(
+                $"{boundary}\r\nContent-Disposition: form-data; name=\"{name}\"\r\n\r\n{value}\r\n");
+            stream.Write(bytes, 0, bytes.Length);
+        }
+
+        /// <summary>
+        /// Derives a stable, session-unique identifier from values shared by all game clients.
+        /// The random seed is set once per game and is identical on every machine.
+        /// </summary>
+        private static string ComputeGameHash(string mapSha1, int randomSeed, string gameSlug)
+        {
+            string input = $"{mapSha1}|{randomSeed}|{gameSlug}";
+            using SHA1 sha1 = SHA1.Create();
+            byte[] hash = sha1.ComputeHash(Encoding.UTF8.GetBytes(input));
+            return Convert.ToHexString(hash).ToLowerInvariant();
+        }
+    }
+}


### PR DESCRIPTION
- Adds sync log uploading to mapdb.
- Fixes an issue with sync logs not deleting when mpdebug is enabled (slightly different filename).
- On by default. Can be turned off in settings.

Info that gets sent:
"game_hash",      
"player_name",    
"sync_file_index",
"map_sha1",       
"map_name",       
"game_mode",      
"game_slug",      


_Currently a draft as I need to add an endpoint to the mapdb (have this mostly working locally, just need to give it more testing and review with YD)._