### PR TITLE
Fix intermittent crash on exit

### DIFF
--- a/DXMainClient/DXGUI/Generic/MainMenu.cs
+++ b/DXMainClient/DXGUI/Generic/MainMenu.cs
@@ -1136,10 +1136,6 @@ namespace DTAClient.DXGUI.Generic
             Logger.Log("Exiting.");
             WindowManager.CloseGame();
             themeSong?.Dispose();
-#if !XNA
-            Thread.Sleep(1000);
-            Environment.Exit(0);
-#endif
         }
 
         public void SwitchOn()

--- a/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
+++ b/DXMainClient/Domain/DirectDrawCompatibilityChecker.cs
@@ -196,7 +196,7 @@ public static class DirectDrawCompatibilityChecker
                     Logger.Log("Administrator privileges required. Restart with elevated privileges.");
 
                     if (AdminRestarter.RestartAsAdmin())
-                        Environment.Exit(0);
+                        windowManager.CloseGame();
                 }
                 else
                 {

--- a/DXMainClient/Startup.cs
+++ b/DXMainClient/Startup.cs
@@ -128,9 +128,6 @@ namespace DTAClient
 
             ClientConfiguration.Instance.RefreshSettings();
 
-            // Start INI file preprocessor
-            PreprocessorBackgroundTask.Instance.Run();
-
             using GameClass gameClass = new GameClass();
 
             if (!UserINISettings.Instance.BorderlessWindowedClient)

--- a/DXMainClient/Startup.cs
+++ b/DXMainClient/Startup.cs
@@ -128,7 +128,7 @@ namespace DTAClient
             // Start INI file preprocessor
             PreprocessorBackgroundTask.Instance.Run();
 
-            GameClass gameClass = new GameClass();
+            using GameClass gameClass = new GameClass();
 
             if (!UserINISettings.Instance.BorderlessWindowedClient)
             {


### PR DESCRIPTION
Crash dump analysis showed the faulting thread was an XAUdio2 graph worker:
```
xaudio2_9!CGraphManager::GraphThreadProc
xaudio2_9!CX2Engine::OnProcessingPassStart
clr!UMThunkStub
clr!UMThunkStubRareDisableWorker      <-- raises 0xC0020001
```

XAudio2 could invoke managed callbacks after CLR teardown began, causing a native crash (0xC0020001) on a background thread (didn't appear in client log).


Goes with: https://github.com/CnCNet/Rampastring.XNAUI/pull/14