### PR TITLE
Fix dropdown border not expanding for preferred item label text

### DIFF
--- a/ClientGUI/XNAClientPreferredItemDropDown.cs
+++ b/ClientGUI/XNAClientPreferredItemDropDown.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework;
 using Rampastring.Tools;
 using Rampastring.XNAUI;
 using Rampastring.XNAUI.XNAControls;
@@ -41,6 +41,20 @@ namespace ClientGUI
             base.ParseControlINIAttribute(iniFile, key, value);
         }
 
+        public override void OpenDropDown()
+        {
+            if (PreferredItemIndexes.Count > 0)
+            {
+                PreferredItemIndexes.ForEach(i => Items[i].Text += " " + PreferredItemLabel);
+                base.OpenDropDown();
+                PreferredItemIndexes.ForEach(i => Items[i].Text = Items[i].Text.Substring(0, Items[i].Text.Length - PreferredItemLabel.Length - 1));
+            }
+            else
+            {
+                base.OpenDropDown();
+            }
+        }
+
         /// <summary>
         /// Draws the drop-down.
         /// </summary>
@@ -51,7 +65,6 @@ namespace ClientGUI
                 PreferredItemIndexes.ForEach(i =>
                 {
                     XNADropDownItem preferredItem = Items[i];
-                    string preferredItemOriginalText = preferredItem.Text;
                     preferredItem.Text += " " + PreferredItemLabel;
                 });
 
@@ -67,7 +80,6 @@ namespace ClientGUI
             {
                 base.Draw(gameTime);
             }
-
         }
     }
 }


### PR DESCRIPTION
- Fixes the "Client Resolution" dropdown border not expanding to fit items like "1920x1080 (recommended)" when opened
- `openWidth` is calculated in `OpenDropDown()`, but `XNAClientPreferredItemDropDown` only appended the preferred label during `Draw()`, so the border never accounted for the extra text
- Goes with https://github.com/CnCNet/Rampastring.XNAUI/pull/9