### PR TITLE
Delay initializing map file watcher until custom map has been loaded

### DIFF
--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -90,10 +90,15 @@ namespace DTAClient.Domain.Multiplayer
 
         public MapLoader() { }
 
+        public void Initialize()
+        {
+            MapLoadingComplete += (sender, args) => StartMapFileWatcher();
+        }
+
         /// <summary>
         /// Sets up file watching for maps.
         /// </summary>
-        public void Initialize()
+        public void StartMapFileWatcher()
         {
             if (mapFileWatcher != null)
                 return;


### PR DESCRIPTION
I feel the current map file watcher initialization starts too early.

Client.log:

> 18.04. 05:14:11.690    Initializing loading screen.
> 18.04. 05:14:11.879    Updater: Updater initialization task started.
> **18.04. 05:14:11.879    MapFileWatcher: Started watching C:\temp\cncnet-yr\Maps\Custom\ for *.map files***
> 18.04. 05:14:11.880    Updater: Checking local file versions.
> 18.04. 05:14:11.881    MapLoader: Map loading task started.
> 18.04. 05:14:11.882    MapLoader: Loading maps from C:\temp\cncnet-yr\INI\MPMaps.ini.
> 18.04. 05:14:11.921    Game Client Version: YR 9.2.0
> 18.04. 05:14:11.921    Updater: Updater initialization task completed.
> 18.04. 05:14:12.116    MapLoader: Loading custom maps...
> 18.04. 05:14:12.118    MapLoader: Loaded custom map cache from file system in 1 ms
> 18.04. 05:14:12.124    MapLoader: Processed uncached custom maps in 6 ms
> 18.04. 05:14:12.125    MapLoader: Removed outdated maps from cache in 0 ms
> 18.04. 05:14:12.211    MapLoader: Saved custom map cache to disk in 84 ms
> 18.04. 05:14:12.212    MapLoader: Custom maps loaded.
> 18.04. 05:14:12.213    MapLoader: Post-processing game mode map collections.
> **18.04. 05:14:12.217    MapLoader: Map loading complete. Total time: 335 ms**

@11EJDE11