### PR TITLE
Fix undefined hotkey configurations being lost on startup and save

### DIFF
--- a/ClientGUI/HotkeyConfigurationWindow.cs
+++ b/ClientGUI/HotkeyConfigurationWindow.cs
@@ -577,8 +577,10 @@ namespace ClientGUI
             Debug.Assert(!HasDuplicateHotkeys(), "There are duplicate hotkeys assigned. How could this happen?");
 
             IniFile keyboardIni = ClientConfiguration.Instance.SettingsIniAsKeyboardIni
-                    ? UserINISettings.Instance.SettingsIni
-                    : new IniFile() { FileName = SafePath.CombineFilePath(ProgramConstants.GamePath, ClientConfiguration.Instance.KeyboardINI) };
+                ? UserINISettings.Instance.SettingsIni
+                : new IniFile(SafePath.CombineFilePath(
+                    ProgramConstants.GamePath,
+                    ClientConfiguration.Instance.KeyboardINI));
 
             var hotkeySection = keyboardIni.GetOrAddSection(ClientConfiguration.Instance.KeyboardHotkeySection);
             foreach (var command in gameCommands)


### PR DESCRIPTION
This PR fixes a bug where hotkey configuration could be lost when the game starts.

In particular, custom hotkey entries added by other extension platforms, such as the hotkeys provided by [ObjectInfo.dll](https://github.com/handama/ObjectInfo), could disappear because KeyboardMD.ini was rewritten during startup with only the hotkeys known to the launcher.

This PR changes the save behavior so that existing hotkey entries are preserved instead of being unintentionally dropped.