### PR TITLE
Fix "Unable to load library 'libHarfBuzzSharp'" on .NET Framework client

### DIFF
--- a/CommonAssembliesNetFx.txt
+++ b/CommonAssembliesNetFx.txt
@@ -1,5 +1,6 @@
 ClientUpdater.dll
 ClientUpdater.pdb
+arm64\libHarfBuzzSharp.dll
 Cyotek.Drawing.BitmapFont.dll
 DiscordRPC.dll
 Facepunch.Steamworks.Win64.dll
@@ -63,3 +64,5 @@ System.Text.Json.dll
 System.Threading.Tasks.Extensions.dll
 System.ValueTuple.dll
 TextCopy.dll
+x64\libHarfBuzzSharp.dll
+x86\libHarfBuzzSharp.dll

--- a/DXMainClient/Program.cs
+++ b/DXMainClient/Program.cs
@@ -56,7 +56,38 @@ namespace DTAClient
             AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
 #endif
 #endif
+
+#if NETFRAMEWORK
+            // Native libs (e.g. libHarfBuzzSharp.dll from HarfBuzzSharp.NativeAssets.Win32)
+            // ship under SPECIFIC_LIBRARY_PATH/{x64|x86|arm64}/. The .NET Framework runtime
+            // does not search those subfolders by default, and HarfBuzzSharp's resolver looks
+            // beside the EXE rather than beside its managed wrapper - so without help, P/Invoke
+            // calls fail with "Unable to load library 'libHarfBuzzSharp'".
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                string archSubfolder = RuntimeInformation.ProcessArchitecture switch
+                {
+                    Architecture.X64 => "x64",
+                    Architecture.X86 => "x86",
+                    Architecture.Arm64 => "arm64",
+                    _ => null
+                };
+
+                if (archSubfolder is not null)
+                {
+                    string nativeDir = Path.Combine(SPECIFIC_LIBRARY_PATH, archSubfolder);
+                    if (Directory.Exists(nativeDir))
+                        SetDllDirectory(nativeDir);
+                }
+            }
+#endif
         }
+
+#if NETFRAMEWORK
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        private static extern bool SetDllDirectory(string lpPathName);
+#endif
 
         private static string COMMON_LIBRARY_PATH;
         private static string SPECIFIC_LIBRARY_PATH;

--- a/DXMainClient/Program.cs
+++ b/DXMainClient/Program.cs
@@ -66,6 +66,25 @@ namespace DTAClient
             // calls fail with "Unable to load library 'libHarfBuzzSharp'".
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
+                static bool areSecureDllLoadingAPIsAvailable()
+                {
+                    var kernel32ModuleHandle = GetModuleHandle("kernel32");
+                    if (kernel32ModuleHandle == IntPtr.Zero)
+                        throw new Exception("Failed to get handle for kernel32.dll. Is your operating system broken?", new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error()));
+
+                    string[] requiredFunctions = ["SetDefaultDllDirectories", "AddDllDirectory", "RemoveDllDirectory"];
+                    foreach (string function in requiredFunctions)
+                    {
+                        if (GetProcAddress(kernel32ModuleHandle, function) == IntPtr.Zero)
+                            return false;
+                    }
+
+                    return true;
+                }
+
+                if (!areSecureDllLoadingAPIsAvailable())
+                    throw new PlatformNotSupportedException("This application requires at least Windows 7 SP1 with KB4457144 (alternatively, KB2533623 or KB3063858) installed.");
+
                 SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_APPLICATION_DIR | LOAD_LIBRARY_SEARCH_USER_DIRS | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
 
                 string archSubfolder = RuntimeInformation.ProcessArchitecture switch
@@ -78,7 +97,7 @@ namespace DTAClient
 
                 if (archSubfolder is not null)
                 {
-                    void addDllDirectoryIfExists(string path)
+                    static void addDllDirectoryIfExists(string path)
                     {
                         if (Directory.Exists(path))
                             AddDllDirectory(path);
@@ -108,6 +127,14 @@ namespace DTAClient
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         private static extern IntPtr AddDllDirectory(string lpPathName);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, EntryPoint = "GetModuleHandleW", ExactSpelling = true, SetLastError = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        private static extern IntPtr GetModuleHandle([In][MarshalAs(UnmanagedType.LPWStr)] string lpModuleName);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Ansi, ExactSpelling = true, SetLastError = true, ThrowOnUnmappableChar = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        private static extern IntPtr GetProcAddress([In] IntPtr hModule, [In][MarshalAs(UnmanagedType.LPStr)] string lpProcName);
 #endif
 
         private static string COMMON_LIBRARY_PATH;

--- a/DXMainClient/Program.cs
+++ b/DXMainClient/Program.cs
@@ -59,7 +59,8 @@ namespace DTAClient
 
 #if NETFRAMEWORK
             // Native libs (e.g. libHarfBuzzSharp.dll from HarfBuzzSharp.NativeAssets.Win32)
-            // ship under SPECIFIC_LIBRARY_PATH/{x64|x86|arm64}/. The .NET Framework runtime
+            // ship under either SPECIFIC_LIBRARY_PATH/{x64|x86|arm64}/
+            // or COMMON_LIBRARY_PATH/{x64|x86|arm64}/. The .NET Framework runtime
             // does not search those subfolders by default, and HarfBuzzSharp's resolver looks
             // beside the EXE rather than beside its managed wrapper - so without help, P/Invoke
             // calls fail with "Unable to load library 'libHarfBuzzSharp'".

--- a/DXMainClient/Program.cs
+++ b/DXMainClient/Program.cs
@@ -65,6 +65,8 @@ namespace DTAClient
             // calls fail with "Unable to load library 'libHarfBuzzSharp'".
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
+                SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_APPLICATION_DIR | LOAD_LIBRARY_SEARCH_USER_DIRS | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+
                 string archSubfolder = RuntimeInformation.ProcessArchitecture switch
                 {
                     Architecture.X64 => "x64",
@@ -75,9 +77,14 @@ namespace DTAClient
 
                 if (archSubfolder is not null)
                 {
-                    string nativeDir = Path.Combine(SPECIFIC_LIBRARY_PATH, archSubfolder);
-                    if (Directory.Exists(nativeDir))
-                        SetDllDirectory(nativeDir);
+                    void addDllDirectoryIfExists(string path)
+                    {
+                        if (Directory.Exists(path))
+                            AddDllDirectory(path);
+                    }
+
+                    addDllDirectoryIfExists(Path.Combine(SPECIFIC_LIBRARY_PATH, archSubfolder));
+                    addDllDirectoryIfExists(Path.Combine(COMMON_LIBRARY_PATH, archSubfolder));
                 }
             }
 #endif
@@ -87,6 +94,19 @@ namespace DTAClient
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         private static extern bool SetDllDirectory(string lpPathName);
+
+        private const int LOAD_LIBRARY_SEARCH_APPLICATION_DIR = 0x00000200;
+        private const int LOAD_LIBRARY_SEARCH_USER_DIRS = 0x00000400;
+        private const int LOAD_LIBRARY_SEARCH_SYSTEM32 = 0x00000800;
+        private const int LOAD_LIBRARY_SEARCH_DEFAULT_DIRS = 0x00001000;
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        private static extern bool SetDefaultDllDirectories(int directoryFlags);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        private static extern IntPtr AddDllDirectory(string lpPathName);
 #endif
 
         private static string COMMON_LIBRARY_PATH;

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -86,8 +86,17 @@
     <ReadLinesFromFile File="$(_CommonAssembliesFilePath)">
       <Output TaskParameter="Lines" ItemName="_CommonFiles" />
     </ReadLinesFromFile>
-    <Move SourceFiles="$(PublishDir)%(_CommonFiles.Identity)" DestinationFolder="$(PublishDir)..\" Condition="!Exists('$(PublishDir)..\%(_CommonFiles.Identity)')" />
-    <Delete Files="$(PublishDir)%(_CommonFiles.Identity)" Condition="Exists('$(PublishDir)..\%(_CommonFiles.Identity)')" />
+
+    <ItemGroup>
+      <_CommonFilesToMove Include="@(_CommonFiles)" Condition="!Exists('$(PublishDir)..\%(Identity)')" />
+      <_CommonFilesToDelete Include="@(_CommonFiles)" Condition="Exists('$(PublishDir)..\%(Identity)')" />
+    </ItemGroup>
+
+    <Move
+      SourceFiles="@(_CommonFilesToMove -> '$(PublishDir)%(Identity)')"
+      DestinationFiles="@(_CommonFilesToMove -> '$(PublishDir)..\%(Identity)')"
+      Condition="'@(_CommonFilesToMove)' != ''" />
+    <Delete Files="@(_CommonFilesToDelete -> '$(PublishDir)%(Identity)')" Condition="'@(_CommonFilesToDelete)' != ''" />
   </Target>
 
   <!-- Note: the folder structure should be consistent with scripts\build.ps1 file -->

--- a/Scripts/Get-CommonAssemblyList.ps1
+++ b/Scripts/Get-CommonAssemblyList.ps1
@@ -35,14 +35,16 @@ $Script:Engines | ForEach-Object {
   [string]$Private:Engine = $PSItem
   [string]$Private:PlatformFolder = Join-Path $Binaries $Private:Engine
 
-  Get-ChildItem $Private:PlatformFolder | Where-Object {
+  Get-ChildItem $Private:PlatformFolder -Recurse | Where-Object {
     $PSItem -is [System.IO.FileInfo]
   } | ForEach-Object {
-    if (!$Script:FileHashTable.ContainsKey($PSItem.Name)) {
-      $Script:FileHashTable[$PSItem.Name] = [hashtable]@{}
+    [string]$Private:RelativePath = [System.IO.Path]::GetRelativePath($Private:PlatformFolder, $PSItem.FullName)
+
+    if (!$Script:FileHashTable.ContainsKey($Private:RelativePath)) {
+      $Script:FileHashTable[$Private:RelativePath] = [hashtable]@{}
     }
 
-    $Script:FileHashTable[$PSItem.Name][$Engine] = Get-FileHash $PSItem
+    $Script:FileHashTable[$Private:RelativePath][$Engine] = Get-FileHash $PSItem
   }
 }
 


### PR DESCRIPTION
on .NET Framework builds, TTF font loading fails with "Unable to load library 'libHarfBuzzSharp'" because the native lib ships under Resources/Binaries/[engine]/[x64,x86] - a path Windows' LoadLibrary doesn't search by default, and which doesn't match where HarfBuzzSharp's own resolver looks (next to the EXE).

This adds a SetDLLDirectory call in Program.cs static ctor to add the correct arch folder to the DLL search path. .NET 8 is unaffected (it loads natives via deps.json + runtimes/<rid>/native/).