### PR TITLE
Various fixups - Clamp skill level, thread-safe map updates, dispose map preview images

### DIFF
--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -394,6 +394,14 @@ namespace ClientCore
 
         public string SkillLevelOptions => clientDefinitionsIni.GetStringValue(SETTINGS, "SkillLevelOptions", "Any,Beginner,Intermediate,Pro");
 
+        public string[] GetSkillLevelOptions() => SkillLevelOptions.Split(',', StringSplitOptions.RemoveEmptyEntries);
+
+        public int NormalizeSkillLevel(int skillLevel)
+        {
+            int maxSkillLevelIndex = Math.Max(0, GetSkillLevelOptions().Length - 1);
+            return Math.Clamp(skillLevel, 0, maxSkillLevelIndex);
+        }
+
         public int DefaultSkillLevelIndex => clientDefinitionsIni.GetIntValue(SETTINGS, "DefaultSkillLevelIndex", 0);
 
         public bool CampaignTagSelectorEnabled => clientDefinitionsIni.GetBooleanValue(SETTINGS, "CampaignTagSelectorEnabled", false);

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetLobby.cs
@@ -1600,7 +1600,8 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 int tunnelPort = int.Parse(tunnelAddressAndPort[1]);
 
                 string loadedGameId = splitMessage[10];
-                int skillLevel = int.Parse(splitMessage[11]);
+                int skillLevel = ClientConfiguration.Instance.NormalizeSkillLevel(
+                    Conversions.IntFromString(splitMessage[11], ClientConfiguration.Instance.DefaultSkillLevelIndex));
                 string mapHash = splitMessage[12];
 
                 int[] gameOptionValues = null;

--- a/DXMainClient/DXGUI/Multiplayer/GameInformationPanel.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameInformationPanel.cs
@@ -15,7 +15,6 @@ using Microsoft.Xna.Framework.Graphics;
 
 using Rampastring.XNAUI;
 using Rampastring.XNAUI.XNAControls;
-using Image = SixLabors.ImageSharp.Image;
 
 namespace DTAClient.DXGUI.Multiplayer
 {
@@ -256,30 +255,33 @@ namespace DTAClient.DXGUI.Multiplayer
 
                 Map map = mapLoader.FindMapByHash(game.MapHash);
 
-                Image mapPreviewImage = map != null && !map.IsImmediatePreviewImageAvailable()
-                    ? mapLoader.GetCachedPreviewImageFromMap(map, syncLoadOnCacheMiss: false)
-                    : null;
-
                 if (map?.IsImmediatePreviewImageAvailable() ?? false)
                 {
                     mapPreviewTexture = AssetLoader.LoadTextureUncached(map.PreviewPath);
                     mapPreviewTextureNeedsDispose = true;
                 }
-                else if (mapPreviewImage != null)
-                {
-                    mapPreviewTexture = AssetLoader.TextureFromImage(mapPreviewImage);
-                    mapPreviewTextureNeedsDispose = true;
-                }
-                else if (noMapPreviewTexture != null)
-                {
-                    Debug.Assert(!noMapPreviewTexture.IsDisposed, "noMapPreviewTexture should never be disposed.");
-                    mapPreviewTexture = noMapPreviewTexture;
-                    mapPreviewTextureNeedsDispose = false;
-                }
                 else
                 {
-                    mapPreviewTexture = null;
-                    mapPreviewTextureNeedsDispose = false;
+                    Texture2D cachedTexture = map != null
+                        ? mapLoader.GetCachedPreviewTextureFromMap(map, syncLoadOnCacheMiss: false)
+                        : null;
+
+                    if (cachedTexture != null)
+                    {
+                        mapPreviewTexture = cachedTexture;
+                        mapPreviewTextureNeedsDispose = true;
+                    }
+                    else if (noMapPreviewTexture != null)
+                    {
+                        Debug.Assert(!noMapPreviewTexture.IsDisposed, "noMapPreviewTexture should never be disposed.");
+                        mapPreviewTexture = noMapPreviewTexture;
+                        mapPreviewTextureNeedsDispose = false;
+                    }
+                    else
+                    {
+                        mapPreviewTexture = null;
+                        mapPreviewTextureNeedsDispose = false;
+                    }
                 }
             }
             else

--- a/DXMainClient/DXGUI/Multiplayer/GameInformationPanel.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameInformationPanel.cs
@@ -256,9 +256,16 @@ namespace DTAClient.DXGUI.Multiplayer
 
                 Map map = mapLoader.FindMapByHash(game.MapHash);
 
-                Image mapPreviewImage = map != null ? mapLoader.GetCachedPreviewImageFromMap(map, syncLoadOnCacheMiss: false) : null;
+                Image mapPreviewImage = map != null && !map.IsImmediatePreviewImageAvailable()
+                    ? mapLoader.GetCachedPreviewImageFromMap(map, syncLoadOnCacheMiss: false)
+                    : null;
 
-                if (mapPreviewImage != null)
+                if (map?.IsImmediatePreviewImageAvailable() ?? false)
+                {
+                    mapPreviewTexture = AssetLoader.LoadTextureUncached(map.PreviewPath);
+                    mapPreviewTextureNeedsDispose = true;
+                }
+                else if (mapPreviewImage != null)
                 {
                     mapPreviewTexture = AssetLoader.TextureFromImage(mapPreviewImage);
                     mapPreviewTextureNeedsDispose = true;

--- a/DXMainClient/DXGUI/Multiplayer/GameInformationPanel.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameInformationPanel.cs
@@ -242,8 +242,9 @@ namespace DTAClient.DXGUI.Multiplayer
                 lblPlayerNames[i].Visible = false;
             }
 
-            string skillLevel = skillLevelOptions[game.SkillLevel];
-            string localizedSkillLevel = skillLevel.L10N($"INI:ClientDefinitions:SkillLevel:{game.SkillLevel}");
+            int skillLevelIndex = ClientConfiguration.Instance.NormalizeSkillLevel(game.SkillLevel);
+            string skillLevel = skillLevelOptions[skillLevelIndex];
+            string localizedSkillLevel = skillLevel.L10N($"INI:ClientDefinitions:SkillLevel:{skillLevelIndex}");
             lblSkillLevel.Text = "Preferred Skill Level:".L10N("Client:Main:GameInfoSkillLevel") + " " + localizedSkillLevel;
             lblSkillLevel.Visible = true;
 

--- a/DXMainClient/DXGUI/Multiplayer/GameListBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameListBox.cs
@@ -319,9 +319,10 @@ namespace DTAClient.DXGUI.Multiplayer
                 || hg.Game.InternalName != localGameIdentifier.ToLower();
             int gameTextureWidth = showGameIcon ? hg.Game.Texture.Width : 0;
 
+            int skillLevelIndex = ClientConfiguration.Instance.NormalizeSkillLevel(hg.SkillLevel);
             int skillLevelIconWidth = 0;
-            if (txSkillLevelIcons[hg.SkillLevel] != null)
-                skillLevelIconWidth = txSkillLevelIcons[hg.SkillLevel].Width;
+            if (txSkillLevelIcons[skillLevelIndex] != null)
+                skillLevelIconWidth = txSkillLevelIcons[skillLevelIndex].Width;
 
             int maxTextWidth = Width - gameTextureWidth -
                 (hg.Incompatible ? txIncompatibleGame.Width : 0) -
@@ -467,7 +468,8 @@ namespace DTAClient.DXGUI.Multiplayer
                 }
 
                 // skill level icon (shown even if passworded)
-                Texture2D txSkillLevelIcon = txSkillLevelIcons[hostedGame.SkillLevel];
+                int skillLevelIndex = ClientConfiguration.Instance.NormalizeSkillLevel(hostedGame.SkillLevel);
+                Texture2D txSkillLevelIcon = txSkillLevelIcons[skillLevelIndex];
                 if (txSkillLevelIcon != null)
                 {
                     rightX -= txSkillLevelIcon.Width;

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -449,7 +449,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             gameRoomName = newGameRoomName;
             channel.UIName = newGameRoomName;
             playerLimit = newMaxPlayers;
-            skillLevel = newSkillLevel;
+            skillLevel = ClientConfiguration.Instance.NormalizeSkillLevel(newSkillLevel);
 
             if (passwordChanged)
             {
@@ -486,8 +486,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             if (skillLevelChanged)
             {
                 string[] skillLevelOptions = ClientConfiguration.Instance.SkillLevelOptions.Split(',');
-                string skillLevelName = skillLevelOptions[newSkillLevel];
-                string localizedSkillLevel = skillLevelName.L10N($"INI:ClientDefinitions:SkillLevel:{newSkillLevel}");
+                string skillLevelName = skillLevelOptions[skillLevel];
+                string localizedSkillLevel = skillLevelName.L10N($"INI:ClientDefinitions:SkillLevel:{skillLevel}");
                 AddNotice(string.Format("Skill level changed to {0}."
                     .L10N("Client:Main:SkillLevelChanged"), localizedSkillLevel));
             }
@@ -534,7 +534,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             string newGameRoomName = parts[0];
             int newMaxPlayers = Conversions.IntFromString(parts[1], playerLimit);
-            int newSkillLevel = Conversions.IntFromString(parts[2], skillLevel);
+            int newSkillLevel = ClientConfiguration.Instance.NormalizeSkillLevel(
+                Conversions.IntFromString(parts[2], skillLevel));
             bool newIsCustomPassword = Convert.ToBoolean(Conversions.IntFromString(parts[3], 0));
 
             bool gameNameChanged = gameRoomName != newGameRoomName;
@@ -563,8 +564,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             if (skillLevelChanged)
             {
                 string[] skillLevelOptions = ClientConfiguration.Instance.SkillLevelOptions.Split(',');
-                string skillLevelName = skillLevelOptions[newSkillLevel];
-                string localizedSkillLevel = skillLevelName.L10N($"INI:ClientDefinitions:SkillLevel:{newSkillLevel}");
+                string skillLevelName = skillLevelOptions[skillLevel];
+                string localizedSkillLevel = skillLevelName.L10N($"INI:ClientDefinitions:SkillLevel:{skillLevel}");
                 AddNotice(string.Format("{0} changed skill level to {1}."
                     .L10N("Client:Main:HostChangedSkillLevel"), sender, localizedSkillLevel));
             }

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -429,6 +429,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             if (!IsHost)
                 return;
 
+            newSkillLevel = ClientConfiguration.Instance.NormalizeSkillLevel(newSkillLevel);
+
             bool gameNameChanged = gameRoomName != newGameRoomName;
             bool maxPlayersChanged = playerLimit != newMaxPlayers;
             bool skillLevelChanged = skillLevel != newSkillLevel;
@@ -449,7 +451,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             gameRoomName = newGameRoomName;
             channel.UIName = newGameRoomName;
             playerLimit = newMaxPlayers;
-            skillLevel = ClientConfiguration.Instance.NormalizeSkillLevel(newSkillLevel);
+            skillLevel = newSkillLevel;
 
             if (passwordChanged)
             {

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
@@ -435,13 +435,20 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             Debug.Assert(!mapPreviewTextureNeedsDispose, "previous texture must be disposed before loading a new texture");
 
-            Image previewTextureImage = mapLoader.GetCachedPreviewImageFromMap(GameModeMap.Map, syncLoadOnCacheMiss: true);
-
-            mapPreviewTexture = previewTextureImage != null
-                ? AssetLoader.TextureFromImage(previewTextureImage)
-                // This null case indicates a "hidden preview", where the map itself intends not to show a preview, so we just show a black box instead of no texture at all.
-                // Use the same `- 2` to let xRatio and yRatio get calculated as 1.
-                : AssetLoader.CreateTexture(Color.Black, Width - 2, Height - 2);
+            Image previewTextureImage = null;
+            if (GameModeMap.Map.IsImmediatePreviewImageAvailable())
+            {
+                mapPreviewTexture = AssetLoader.LoadTextureUncached(GameModeMap.Map.PreviewPath);
+            }
+            else
+            {
+                previewTextureImage = mapLoader.GetCachedPreviewImageFromMap(GameModeMap.Map, syncLoadOnCacheMiss: true);
+                mapPreviewTexture = previewTextureImage != null
+                    ? AssetLoader.TextureFromImage(previewTextureImage)
+                    // This null case indicates a "hidden preview", where the map itself intends not to show a preview, so we just show a black box instead of no texture at all.
+                    // Use the same `- 2` to let xRatio and yRatio get calculated as 1.
+                    : AssetLoader.CreateTexture(Color.Black, Width - 2, Height - 2);
+            }
 
             if (mapPreviewTexture == null)
             {

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
@@ -14,7 +14,6 @@ using ClientGUI;
 using ClientCore.Extensions;
 using System.Diagnostics;
 using Color = Microsoft.Xna.Framework.Color;
-using Image = SixLabors.ImageSharp.Image;
 
 namespace DTAClient.DXGUI.Multiplayer.GameLobby
 {
@@ -435,29 +434,20 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             Debug.Assert(!mapPreviewTextureNeedsDispose, "previous texture must be disposed before loading a new texture");
 
-            Image previewTextureImage = null;
             if (GameModeMap.Map.IsImmediatePreviewImageAvailable())
             {
                 mapPreviewTexture = AssetLoader.LoadTextureUncached(GameModeMap.Map.PreviewPath);
             }
             else
             {
-                previewTextureImage = mapLoader.GetCachedPreviewImageFromMap(GameModeMap.Map, syncLoadOnCacheMiss: true);
-                mapPreviewTexture = previewTextureImage != null
-                    ? AssetLoader.TextureFromImage(previewTextureImage)
-                    // This null case indicates a "hidden preview", where the map itself intends not to show a preview, so we just show a black box instead of no texture at all.
-                    // Use the same `- 2` to let xRatio and yRatio get calculated as 1.
-                    : AssetLoader.CreateTexture(Color.Black, Width - 2, Height - 2);
+                // null return indicates a "hidden preview" — the map intentionally has no preview, so show a black box.
+                // Use the same `- 2` to let xRatio and yRatio get calculated as 1.
+                mapPreviewTexture = mapLoader.GetCachedPreviewTextureFromMap(GameModeMap.Map, syncLoadOnCacheMiss: true)
+                    ?? AssetLoader.CreateTexture(Color.Black, Width - 2, Height - 2);
             }
 
             if (mapPreviewTexture == null)
-            {
-                string errorMessage = "Failed to load map preview texture.";
-                if (previewTextureImage != null)
-                    errorMessage += " " + $"Map preview image: {GameModeMap.Map.PreviewPath}.";
-
-                throw new Exception(errorMessage);
-            }
+                throw new Exception($"Failed to load map preview texture. Map: {GameModeMap.Map.PreviewPath}.");
 
             mapPreviewTextureNeedsDispose = true;
 

--- a/DXMainClient/Domain/Multiplayer/CacheManagerBase.cs
+++ b/DXMainClient/Domain/Multiplayer/CacheManagerBase.cs
@@ -174,6 +174,9 @@ public abstract class CacheManagerBase<TInput, TOutput> : ICacheManager<TInput, 
     {
         lock (cacheLock)
         {
+            foreach (CacheEntry cacheEntry in cache.Values)
+                OnOutputRemoved(cacheEntry.Output);
+
             cache.Clear();
             lruList.Clear();
         }
@@ -185,6 +188,10 @@ public abstract class CacheManagerBase<TInput, TOutput> : ICacheManager<TInput, 
     /// <param name="input">The input.</param>
     /// <returns>The output.</returns>
     protected abstract TOutput? ComputeOutputForInput(TInput input);
+
+    protected virtual void OnOutputRemoved(TOutput? output)
+    {
+    }
 
     /// <summary>
     /// Worker thread that processes computation requests sequentially.
@@ -254,7 +261,10 @@ public abstract class CacheManagerBase<TInput, TOutput> : ICacheManager<TInput, 
         lruList.RemoveLast();
 
         if (cache.TryGetValue(lruInput, out CacheEntry? entry))
+        {
+            OnOutputRemoved(entry.Output);
             cache.Remove(lruInput);
+        }
     }
 
     /// <summary>

--- a/DXMainClient/Domain/Multiplayer/CacheManagerBase.cs
+++ b/DXMainClient/Domain/Multiplayer/CacheManagerBase.cs
@@ -10,7 +10,8 @@ namespace DTAClient.Domain.Multiplayer;
 /// <summary>
 /// Thread-safe manager for caching outputs with LRU eviction policy.
 /// Processes computation requests sequentially to limit CPU usage to a single thread.
-/// Note: this manager assumes the `TOutput` objects are managed, so it never disposes them directly.
+/// Subclasses can override <see cref="OnOutputRemoved"/> to release resources held by an
+/// output when it is evicted, replaced, or cleared.
 /// </summary>
 public abstract class CacheManagerBase<TInput, TOutput> : ICacheManager<TInput, TOutput> where TInput : notnull
 {
@@ -268,7 +269,7 @@ public abstract class CacheManagerBase<TInput, TOutput> : ICacheManager<TInput, 
     }
 
     /// <summary>
-    /// Disposes the cache manager. Does not dispose cached outputs directly; left to garbage collector.
+    /// Disposes the cache manager. Cached outputs are released via <see cref="OnOutputRemoved"/>.
     /// </summary>
     public void Dispose()
     {

--- a/DXMainClient/Domain/Multiplayer/GameMode.cs
+++ b/DXMainClient/Domain/Multiplayer/GameMode.cs
@@ -21,6 +21,33 @@ namespace DTAClient.Domain.Multiplayer
             Initialize();
         }
 
+        private GameMode(GameMode source)
+        {
+            Name = source.Name;
+            UIName = source.UIName;
+            UntranslatedUIName = source.UntranslatedUIName;
+            DisallowedPlayerSides = source.DisallowedPlayerSides;
+            DisallowedHumanPlayerSides = source.DisallowedHumanPlayerSides;
+            DisallowedComputerPlayerSides = source.DisallowedComputerPlayerSides;
+            MinPlayersOverride = source.MinPlayersOverride;
+            MaxPlayersOverride = source.MaxPlayersOverride;
+            mapCodeIniPath = source.mapCodeIniPath;
+            randomizedMapCodeININames = source.randomizedMapCodeININames;
+            randomizedMapCodesCount = source.randomizedMapCodesCount;
+            forcedOptionsSection = source.forcedOptionsSection;
+            Maps = new List<Map>(source.Maps);
+            ForcedCheckBoxValues = source.ForcedCheckBoxValues;
+            ForcedDropDownValues = source.ForcedDropDownValues;
+            ForcedSpawnIniOptions = source.ForcedSpawnIniOptions;
+            CopyBaseSettingsFrom(source);
+        }
+
+        /// <summary>
+        /// Returns a copy with a private Maps list, suitable for the map loader's
+        /// copy-on-write snapshot. Does not re-read MPMaps.ini.
+        /// </summary>
+        internal GameMode CloneForSnapshot() => new GameMode(this);
+
         private const string BASE_INI_PATH = "INI/Map Code/";
         private const string SPAWN_INI_OPTIONS_SECTION = "ForcedSpawnIniOptions";
 

--- a/DXMainClient/Domain/Multiplayer/GameModeMapBase.cs
+++ b/DXMainClient/Domain/Multiplayer/GameModeMapBase.cs
@@ -134,5 +134,22 @@ namespace DTAClient.Domain.Multiplayer
             CoopDifficultyLevel = section.GetIntValueOrNull("CoopDifficultyLevel");
         }
 
+        /// <summary>
+        /// Copies parsed base settings from another instance without re-reading the source INI.
+        /// </summary>
+        protected void CopyBaseSettingsFrom(GameModeMapBase source)
+        {
+            MaxPlayers = source.MaxPlayers;
+            MinPlayers = source.MinPlayers;
+            EnforceMaxPlayers = source.EnforceMaxPlayers;
+            AllowedStartingLocations = source.AllowedStartingLocations;
+            IsCoop = source.IsCoop;
+            CoopInfo = source.CoopInfo;
+            CoopDifficultyLevel = source.CoopDifficultyLevel;
+            MultiplayerOnly = source.MultiplayerOnly;
+            HumanPlayersOnly = source.HumanPlayersOnly;
+            ForceRandomStartLocations = source.ForceRandomStartLocations;
+            ForceNoTeams = source.ForceNoTeams;
+        }
     }
 }

--- a/DXMainClient/Domain/Multiplayer/GenericHostedGame.cs
+++ b/DXMainClient/Domain/Multiplayer/GenericHostedGame.cs
@@ -1,5 +1,8 @@
-﻿using DTAClient.Domain.Multiplayer.CnCNet;
 using System;
+
+using ClientCore;
+
+using DTAClient.Domain.Multiplayer.CnCNet;
 
 namespace DTAClient.Domain.Multiplayer
 {
@@ -7,7 +10,7 @@ namespace DTAClient.Domain.Multiplayer
     /// A base class for hosted games.
     /// CnCNet and LAN games derive from this.
     /// </summary>
-    public abstract class GenericHostedGame: IEquatable<GenericHostedGame>
+    public abstract class GenericHostedGame : IEquatable<GenericHostedGame>
     {
         public virtual string RoomName { get; set; }
         public bool Incompatible { get; set; }
@@ -28,7 +31,11 @@ namespace DTAClient.Domain.Multiplayer
 
         public DateTime LastRefreshTime { get; set; }
 
-        public int SkillLevel { get; set; }
+        public int SkillLevel
+        {
+            get => field;
+            set => field = ClientConfiguration.Instance.NormalizeSkillLevel(value);
+        }
 
         public virtual bool Equals(GenericHostedGame other)
             => string.Equals(RoomName, other?.RoomName, StringComparison.InvariantCultureIgnoreCase);

--- a/DXMainClient/Domain/Multiplayer/ICacheManager.cs
+++ b/DXMainClient/Domain/Multiplayer/ICacheManager.cs
@@ -12,12 +12,14 @@ public interface ICacheManager<TInput, TOutput> : IDisposable
     public int Count { get; }
 
     /// <summary>
-    /// Clears all cached items. The manager does not call Dispose() on the items; it assumes they are managed and will be collected by the garbage collector.
+    /// Clears all cached items. Subclasses may override <see cref="CacheManagerBase{TInput,TOutput}.OnOutputRemoved"/> to release resources on eviction.
     /// </summary>
     public void Clear();
 
     /// <summary>
     /// Requests an output to be computed for the specified input.
+    /// The returned output is owned by the cache and may be evicted and disposed at any time.
+    /// Callers must use the output immediately and must not retain a reference to it.
     /// </summary>
     /// <param name="input">The input to get the output.</param>
     /// <param name="output">The cached output if found or computed.</param>

--- a/DXMainClient/Domain/Multiplayer/ICacheManager.cs
+++ b/DXMainClient/Domain/Multiplayer/ICacheManager.cs
@@ -18,8 +18,6 @@ public interface ICacheManager<TInput, TOutput> : IDisposable
 
     /// <summary>
     /// Requests an output to be computed for the specified input.
-    /// The returned output is owned by the cache and may be evicted and disposed at any time.
-    /// Callers must use the output immediately and must not retain a reference to it.
     /// </summary>
     /// <param name="input">The input to get the output.</param>
     /// <param name="output">The cached output if found or computed.</param>

--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -9,7 +9,10 @@ using System.Threading.Tasks;
 using ClientCore;
 using ClientCore.Extensions;
 
+using Microsoft.Xna.Framework.Graphics;
+
 using Rampastring.Tools;
+using Rampastring.XNAUI;
 
 using SixLabors.ImageSharp;
 
@@ -799,21 +802,20 @@ namespace DTAClient.Domain.Multiplayer
         }
 
         /// <summary>
-        /// Returns a cached preview image for non-immediate previews (extracted from a custom map).
+        /// Returns a cached preview texture for non-immediate previews (extracted from a custom map),
+        /// or null if the preview is not yet cached or the map has an intentionally hidden preview.
         /// Maps with an immediate (on-disk) preview must load it directly via
-        /// <see cref="Map.PreviewPath"/> with AssetLoader.LoadTextureUncached so the intermediate
-        /// Image does not need to be tracked for disposal.
-        /// The returned image is owned by the cache — use it immediately and do not retain the reference.
+        /// <see cref="Map.PreviewPath"/> with <see cref="AssetLoader.LoadTextureUncached"/>.
         /// </summary>
-        public Image GetCachedPreviewImageFromMap(Map map, bool syncLoadOnCacheMiss = false)
+        public Texture2D GetCachedPreviewTextureFromMap(Map map, bool syncLoadOnCacheMiss = false)
         {
             if (!(map?.IsNonImmediatePreviewImageAvailable() ?? false))
                 return null;
 
-            if (mapPreviewCacheManager.Request(map, out Image image, syncComputeOnCacheMiss: syncLoadOnCacheMiss, addToQueue: true))
-                return image;
+            if (!mapPreviewCacheManager.Request(map, out Image image, syncComputeOnCacheMiss: syncLoadOnCacheMiss, addToQueue: true))
+                return null;
 
-            return null;
+            return image != null ? AssetLoader.TextureFromImage(image) : null;
         }
 
         public Map FindMapByHash(string mapHash) => GameModeMaps?.FindMapByHash(mapHash);

--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -43,7 +43,7 @@ namespace DTAClient.Domain.Multiplayer
         private readonly object mapModificationLock = new object();
         private const int _mapChangeRetryCount = 3;
 
-        private readonly List<GameMode> _gameModes = [];
+        private List<GameMode> _gameModes = [];
 
         /// <summary>
         /// List of game modes.
@@ -201,11 +201,13 @@ namespace DTAClient.Domain.Multiplayer
                 {
                     lock (mapModificationLock)
                     {
-                        if (IsMapAlreadyLoaded(map.SHA1))
+                        List<GameMode> gameModeSnapshot = CloneGameModeSnapshot();
+
+                        if (IsMapAlreadyLoaded(map.SHA1, gameModeSnapshot))
                             return;
 
-                        AddMapToGameModes(map, true);
-                        UpdateGameModeMaps();
+                        AddMapToGameModes(map, gameModeSnapshot, true);
+                        ReplaceGameModeSnapshot(gameModeSnapshot);
 
                         Logger.Log($"MapLoader: Added new map {map.Name} from {filePath}");
                         MapChanged?.Invoke(this, new MapChangedEventArgs(map, MapChangeType.Added));
@@ -259,16 +261,17 @@ namespace DTAClient.Domain.Multiplayer
                 {
                     lock (mapModificationLock)
                     {
-                        string oldSHA1 = FindMapSHA1ByFilePath(baseFilePath);
+                        List<GameMode> gameModeSnapshot = CloneGameModeSnapshot();
+                        string oldSHA1 = FindMapSHA1ByFilePath(baseFilePath, gameModeSnapshot);
 
                         if (!string.IsNullOrEmpty(oldSHA1))
                         {
                             if (oldSHA1 != newMap.SHA1)
                             {
                                 // SHA1 changed, remove old and add new
-                                RemoveMapBySHA1(oldSHA1);
-                                AddMapToGameModes(newMap, true);
-                                UpdateGameModeMaps();
+                                RemoveMapBySHA1(oldSHA1, gameModeSnapshot);
+                                AddMapToGameModes(newMap, gameModeSnapshot, true);
+                                ReplaceGameModeSnapshot(gameModeSnapshot);
 
                                 Logger.Log($"MapLoader: Updated map {newMap.Name} from {filePath} (SHA1 changed: {oldSHA1} -> {newMap.SHA1})");
                                 MapChanged?.Invoke(this, new MapChangedEventArgs(newMap, MapChangeType.Updated, oldSHA1));
@@ -282,8 +285,8 @@ namespace DTAClient.Domain.Multiplayer
                         {
                             // Map not found, treat as new
                             Logger.Log($"MapLoader: Changed event for unknown map {filePath}, treating as new");
-                            AddMapToGameModes(newMap, true);
-                            UpdateGameModeMaps();
+                            AddMapToGameModes(newMap, gameModeSnapshot, true);
+                            ReplaceGameModeSnapshot(gameModeSnapshot);
                             MapChanged?.Invoke(this, new MapChangedEventArgs(newMap, MapChangeType.Added));
                         }
                     }
@@ -309,13 +312,14 @@ namespace DTAClient.Domain.Multiplayer
 
                 lock (mapModificationLock)
                 {
-                    string mapSHA1 = FindMapSHA1ByFilePath(baseFilePath);
+                    List<GameMode> gameModeSnapshot = CloneGameModeSnapshot();
+                    string mapSHA1 = FindMapSHA1ByFilePath(baseFilePath, gameModeSnapshot);
 
                     if (!string.IsNullOrEmpty(mapSHA1))
                     {
-                        var removedMap = FindMapBySHA1(mapSHA1);
-                        RemoveMapBySHA1(mapSHA1);
-                        UpdateGameModeMaps();
+                        var removedMap = FindMapBySHA1(mapSHA1, gameModeSnapshot);
+                        RemoveMapBySHA1(mapSHA1, gameModeSnapshot);
+                        ReplaceGameModeSnapshot(gameModeSnapshot);
 
                         Logger.Log($"MapLoader: Removed map from {filePath}");
                         if (removedMap != null)
@@ -362,26 +366,58 @@ namespace DTAClient.Domain.Multiplayer
         }
 
         private bool IsMapAlreadyLoaded(string sha1)
-            => GameModes.SelectMany(gm => gm.Maps).Any(map => map.SHA1 == sha1);
+            => IsMapAlreadyLoaded(sha1, GameModes);
+
+        private static bool IsMapAlreadyLoaded(string sha1, IEnumerable<GameMode> gameModes)
+            => gameModes.SelectMany(gm => gm.Maps).Any(map => map.SHA1 == sha1);
 
         private Map FindMapBySHA1(string sha1)
-            => GameModes.SelectMany(gm => gm.Maps).FirstOrDefault(map => map.SHA1 == sha1);
+            => FindMapBySHA1(sha1, GameModes);
+
+        private static Map FindMapBySHA1(string sha1, IEnumerable<GameMode> gameModes)
+            => gameModes.SelectMany(gm => gm.Maps).FirstOrDefault(map => map.SHA1 == sha1);
 
         private string FindMapSHA1ByFilePath(string baseFilePath)
-            => GameModes.SelectMany(gm => gm.Maps)
+            => FindMapSHA1ByFilePath(baseFilePath, GameModes);
+
+        private static string FindMapSHA1ByFilePath(string baseFilePath, IEnumerable<GameMode> gameModes)
+            => gameModes.SelectMany(gm => gm.Maps)
                 .Where(map => !map.Official && map.BaseFilePath.Equals(baseFilePath, StringComparison.OrdinalIgnoreCase))
                 .FirstOrDefault()?.SHA1;
 
         private void RemoveMapBySHA1(string sha1)
         {
-            foreach (var gameMode in GameModes)
+            RemoveMapBySHA1(sha1, GameModes);
+        }
+
+        private static void RemoveMapBySHA1(string sha1, IEnumerable<GameMode> gameModes)
+        {
+            foreach (var gameMode in gameModes)
                 gameMode.Maps.RemoveAll(map => map.SHA1 == sha1);
         }
 
         private void UpdateGameModeMaps()
         {
-            _gameModes.RemoveAll(g => g.Maps.Count < 1);
-            _gameModeMaps = new GameModeMapCollection(_gameModes);
+            ReplaceGameModeSnapshot(_gameModes);
+        }
+
+        private void ReplaceGameModeSnapshot(List<GameMode> gameModes)
+        {
+            gameModes.RemoveAll(g => g.Maps.Count < 1);
+            _gameModes = gameModes;
+            _gameModeMaps = new GameModeMapCollection(gameModes);
+        }
+
+        private List<GameMode> CloneGameModeSnapshot() => GameModes.Select(CloneGameMode).ToList();
+
+        private static GameMode CloneGameMode(GameMode source)
+        {
+            GameMode clone = new GameMode(source.Name)
+            {
+                Maps = new List<Map>(source.Maps)
+            };
+
+            return clone;
         }
 
         private async Task LoadMultiMapsAsync(IniFile mpMapsIni)
@@ -711,6 +747,9 @@ namespace DTAClient.Domain.Multiplayer
         /// <param name="map">Map to add.</param>
         /// <param name="enableLogging">If set to true, a message for each game mode the map is added to is output to the log file.</param>
         private void AddMapToGameModes(Map map, bool enableLogging)
+            => AddMapToGameModes(map, _gameModes, enableLogging);
+
+        private void AddMapToGameModes(Map map, List<GameMode> gameModes, bool enableLogging)
         {
             foreach (string gameMode in map.GameModes)
             {
@@ -722,11 +761,11 @@ namespace DTAClient.Domain.Multiplayer
                     if (!map.Official && !(AllowedGameModes.Contains(gameMode) || AllowedGameModes.Contains(gameModeAlias)))
                         continue;
 
-                    GameMode gm = GameModes.FirstOrDefault(g => g.Name == gameModeAlias);
+                    GameMode gm = gameModes.FirstOrDefault(g => g.Name == gameModeAlias);
                     if (gm == null)
                     {
                         gm = new GameMode(gameModeAlias);
-                        _gameModes.Add(gm);
+                        gameModes.Add(gm);
                     }
 
                     gm.Maps.Add(map);

--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -803,6 +803,7 @@ namespace DTAClient.Domain.Multiplayer
         /// Maps with an immediate (on-disk) preview must load it directly via
         /// <see cref="Map.PreviewPath"/> with AssetLoader.LoadTextureUncached so the intermediate
         /// Image does not need to be tracked for disposal.
+        /// The returned image is owned by the cache — use it immediately and do not retain the reference.
         /// </summary>
         public Image GetCachedPreviewImageFromMap(Map map, bool syncLoadOnCacheMiss = false)
         {

--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -128,7 +128,8 @@ namespace DTAClient.Domain.Multiplayer
 
             LoadGameModes(mpMapsIni);
             LoadGameModeAliases(mpMapsIni);
-            // LoadMultiMapsAsync and LoadCustomMapsAsync both modify the game mode map collection. We intend to keep the collection non-thread-safe for performance, so the two methods must not be called simultaneously.
+            // Initial load runs before the file watcher is started (see Initialize), so it modifies
+            // _gameModes directly without going through the copy-on-write snapshot path used at runtime.
             await LoadMultiMapsAsync(mpMapsIni);
             await LoadCustomMapsAsync();
 
@@ -365,40 +366,21 @@ namespace DTAClient.Domain.Multiplayer
             }
         }
 
-        private bool IsMapAlreadyLoaded(string sha1)
-            => IsMapAlreadyLoaded(sha1, GameModes);
-
         private static bool IsMapAlreadyLoaded(string sha1, IEnumerable<GameMode> gameModes)
             => gameModes.SelectMany(gm => gm.Maps).Any(map => map.SHA1 == sha1);
 
-        private Map FindMapBySHA1(string sha1)
-            => FindMapBySHA1(sha1, GameModes);
-
         private static Map FindMapBySHA1(string sha1, IEnumerable<GameMode> gameModes)
             => gameModes.SelectMany(gm => gm.Maps).FirstOrDefault(map => map.SHA1 == sha1);
-
-        private string FindMapSHA1ByFilePath(string baseFilePath)
-            => FindMapSHA1ByFilePath(baseFilePath, GameModes);
 
         private static string FindMapSHA1ByFilePath(string baseFilePath, IEnumerable<GameMode> gameModes)
             => gameModes.SelectMany(gm => gm.Maps)
                 .Where(map => !map.Official && map.BaseFilePath.Equals(baseFilePath, StringComparison.OrdinalIgnoreCase))
                 .FirstOrDefault()?.SHA1;
 
-        private void RemoveMapBySHA1(string sha1)
-        {
-            RemoveMapBySHA1(sha1, GameModes);
-        }
-
         private static void RemoveMapBySHA1(string sha1, IEnumerable<GameMode> gameModes)
         {
             foreach (var gameMode in gameModes)
                 gameMode.Maps.RemoveAll(map => map.SHA1 == sha1);
-        }
-
-        private void UpdateGameModeMaps()
-        {
-            ReplaceGameModeSnapshot(_gameModes);
         }
 
         private void ReplaceGameModeSnapshot(List<GameMode> gameModes)
@@ -408,17 +390,7 @@ namespace DTAClient.Domain.Multiplayer
             _gameModeMaps = new GameModeMapCollection(gameModes);
         }
 
-        private List<GameMode> CloneGameModeSnapshot() => GameModes.Select(CloneGameMode).ToList();
-
-        private static GameMode CloneGameMode(GameMode source)
-        {
-            GameMode clone = new GameMode(source.Name)
-            {
-                Maps = new List<Map>(source.Maps)
-            };
-
-            return clone;
-        }
+        private List<GameMode> CloneGameModeSnapshot() => GameModes.Select(gm => gm.CloneForSnapshot()).ToList();
 
         private async Task LoadMultiMapsAsync(IniFile mpMapsIni)
         {
@@ -701,26 +673,26 @@ namespace DTAClient.Domain.Multiplayer
 
             if (map.InitializeFromCustomMap())
             {
-                foreach (GameMode gm in GameModes)
+                lock (mapModificationLock)
                 {
-                    if (gm.Maps.Find(m => m.SHA1 == map.SHA1) != null)
+                    if (IsMapAlreadyLoaded(map.SHA1, GameModes))
                     {
                         Logger.Log("LoadCustomMap: Custom map " + customMapFile.FullName + " is already loaded!");
                         resultMessage = string.Format("Map {0} is already loaded.".L10N("Client:MapLoader:MapAlreadyLoaded"), map.Name);
 
                         return null;
                     }
+
+                    List<GameMode> gameModeSnapshot = CloneGameModeSnapshot();
+                    AddMapToGameModes(map, gameModeSnapshot, true);
+                    ReplaceGameModeSnapshot(gameModeSnapshot);
+
+                    Logger.Log("LoadCustomMap: Map " + customMapFile.FullName + " added successfully.");
+
+                    resultMessage = string.Format("Map {0} loaded successfully.".L10N("Client:MapLoader:MapLoadedSuccessfully"), map.Name);
+
+                    return map;
                 }
-
-                Logger.Log("LoadCustomMap: Map " + customMapFile.FullName + " added successfully.");
-
-                AddMapToGameModes(map, true);
-                var gameModes = GameModes.Where(gm => gm.Maps.Contains(map));
-                _gameModeMaps.AddRange(gameModes.Select(gm => new GameModeMap(gm, map, false)));
-
-                resultMessage = string.Format("Map {0} loaded successfully.".L10N("Client:MapLoader:MapLoadedSuccessfully"), map.Name);
-
-                return map;
             }
 
             Logger.Log("LoadCustomMap: Loading map " + customMapFile.FullName + " failed!");
@@ -733,12 +705,13 @@ namespace DTAClient.Domain.Multiplayer
         {
             Logger.Log("Deleting map " + gameModeMap.Map.UntranslatedName);
             File.Delete(gameModeMap.Map.CompleteFilePath);
-            foreach (GameMode gameMode in GameModeMaps.GameModes)
-            {
-                gameMode.Maps.Remove(gameModeMap.Map);
-            }
 
-            _gameModeMaps.Remove(gameModeMap);
+            lock (mapModificationLock)
+            {
+                List<GameMode> gameModeSnapshot = CloneGameModeSnapshot();
+                RemoveMapBySHA1(gameModeMap.Map.SHA1, gameModeSnapshot);
+                ReplaceGameModeSnapshot(gameModeSnapshot);
+            }
         }
 
         /// <summary>
@@ -825,23 +798,21 @@ namespace DTAClient.Domain.Multiplayer
                 _ = mapPreviewCacheManager.Request(map, out Image _, addToQueue: true);
         }
 
+        /// <summary>
+        /// Returns a cached preview image for non-immediate previews (extracted from a custom map).
+        /// Maps with an immediate (on-disk) preview must load it directly via
+        /// <see cref="Map.PreviewPath"/> with AssetLoader.LoadTextureUncached so the intermediate
+        /// Image does not need to be tracked for disposal.
+        /// </summary>
         public Image GetCachedPreviewImageFromMap(Map map, bool syncLoadOnCacheMiss = false)
         {
-            if (map?.IsImmediatePreviewImageAvailable() ?? false)
-            {
-                return map.GetImmediatePreviewImage();
-            }
-            else if (map?.IsNonImmediatePreviewImageAvailable() ?? false)
-            {
-                if (mapPreviewCacheManager.Request(map, out Image image, syncComputeOnCacheMiss: syncLoadOnCacheMiss, addToQueue: true))
-                    return image;
-                else
-                    return null;
-            }
-            else
-            {
+            if (!(map?.IsNonImmediatePreviewImageAvailable() ?? false))
                 return null;
-            }
+
+            if (mapPreviewCacheManager.Request(map, out Image image, syncComputeOnCacheMiss: syncLoadOnCacheMiss, addToQueue: true))
+                return image;
+
+            return null;
         }
 
         public Map FindMapByHash(string mapHash) => GameModeMaps?.FindMapByHash(mapHash);

--- a/DXMainClient/Domain/Multiplayer/MapPreviewCacheManager.cs
+++ b/DXMainClient/Domain/Multiplayer/MapPreviewCacheManager.cs
@@ -22,4 +22,9 @@ public class MapPreviewCacheManager : CacheManagerBase<Map, Image>, IMapPreviewC
         Image? image = map.GetNonImmediatePreviewImage();
         return image;
     }
+
+    protected override void OnOutputRemoved(Image? output)
+    {
+        output?.Dispose();
+    }
 }

--- a/DXMainClient/Domain/Multiplayer/MapPreviewCacheManager.cs
+++ b/DXMainClient/Domain/Multiplayer/MapPreviewCacheManager.cs
@@ -6,7 +6,8 @@ namespace DTAClient.Domain.Multiplayer;
 /// <summary>
 /// Thread-safe manager for caching map preview images with LRU eviction policy.
 /// Processes image extraction requests sequentially to limit CPU usage to a single thread.
-/// Note: this manager assumes the `Image` objects are managed, so it never disposes them directly.
+/// Disposes evicted <see cref="Image"/> objects via <see cref="OnOutputRemoved"/>;
+/// callers must not retain references to images returned by <see cref="ICacheManager{TInput,TOutput}.Request"/>.
 /// </summary>
 public class MapPreviewCacheManager : CacheManagerBase<Map, Image>, IMapPreviewCacheManager
 {

--- a/DXMainClient/Domain/Multiplayer/MapPreviewCacheManager.cs
+++ b/DXMainClient/Domain/Multiplayer/MapPreviewCacheManager.cs
@@ -6,8 +6,7 @@ namespace DTAClient.Domain.Multiplayer;
 /// <summary>
 /// Thread-safe manager for caching map preview images with LRU eviction policy.
 /// Processes image extraction requests sequentially to limit CPU usage to a single thread.
-/// Disposes evicted <see cref="Image"/> objects via <see cref="OnOutputRemoved"/>;
-/// callers must not retain references to images returned by <see cref="ICacheManager{TInput,TOutput}.Request"/>.
+/// Disposes evicted <see cref="Image"/> objects via <see cref="OnOutputRemoved"/>.
 /// </summary>
 public class MapPreviewCacheManager : CacheManagerBase<Map, Image>, IMapPreviewCacheManager
 {


### PR DESCRIPTION
Couple of fixups that are needed before our next release.

-Fixes an issue where a lobby's skill level being out of bounds could crash the client
-Fixes a race condition when reloading maps while they are open in lobby
-Fix a memory leak with preview images

Don't merge just yet, need to do some more checking on the map stuff tomorrow.