### PR TITLE
Add "Use legacy fonts" option to allow users to revert to SpriteFonts

### DIFF
--- a/ClientCore/Settings/UserINISettings.cs
+++ b/ClientCore/Settings/UserINISettings.cs
@@ -115,6 +115,7 @@ namespace ClientCore
             BorderlessWindowedMode = new BoolSetting(iniFile, VIDEO, "NoWindowFrame", false);
             BorderlessWindowedClient = new BoolSetting(iniFile, VIDEO, "BorderlessWindowedClient", ClientConfiguration.Instance.UserDefault_BorderlessWindowedClient);
             IntegerScaledClient = new BoolSetting(iniFile, VIDEO, "IntegerScaledClient", ClientConfiguration.Instance.UserDefault_IntegerScaledClient);
+            UseLegacyFonts = new BoolSetting(iniFile, VIDEO, "UseLegacyFonts", false);
             ClientFPS = new IntSetting(iniFile, VIDEO, "ClientFPS", 60);
             DisplayToggleableExtraTextures = new BoolSetting(iniFile, VIDEO, "DisplayToggleableExtraTextures", true);
 
@@ -218,6 +219,7 @@ namespace ClientCore
         public IntSetting ClientResolutionY { get; set; }
         public BoolSetting BorderlessWindowedClient { get; private set; }
         public BoolSetting IntegerScaledClient { get; private set; }
+        public BoolSetting UseLegacyFonts { get; private set; }
         public IntSetting ClientFPS { get; private set; }
         public BoolSetting DisplayToggleableExtraTextures { get; private set; }
 

--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -143,6 +143,11 @@ namespace DTAClient.DXGUI
 #endif
             InitializeUISettings();
 
+            // Decide between TTF (Fonts.ini) and legacy SpriteFont assets before
+            // WindowManager.Initialize triggers FontManager.LoadFonts.
+            Rampastring.XNAUI.FontManagement.FontManager.UseLegacySpriteFonts =
+                UserINISettings.Instance.UseLegacyFonts;
+
             WindowManager wm = new(this, graphics);
             wm.Initialize(content, ProgramConstants.GetBaseResourcePath());
 

--- a/DXMainClient/DXGUI/Generic/OptionPanels/DisplayOptionsPanel.cs
+++ b/DXMainClient/DXGUI/Generic/OptionPanels/DisplayOptionsPanel.cs
@@ -48,6 +48,7 @@ namespace DTAClient.DXGUI.Generic.OptionPanels
         private XNAClientCheckBox chkIntegerScaledClient;
         private XNAClientDropDown ddClientTheme;
         private XNAClientDropDown ddTranslation;
+        private XNAClientCheckBox chkUseLegacyFonts;
 
         private XNALabel lblCompatibilityFixes;
         private XNALabel lblGameCompatibilityFix;
@@ -284,6 +285,20 @@ namespace DTAClient.DXGUI.Generic.OptionPanels
             foreach (var (translation, name) in Translation.GetTranslations())
                 ddTranslation.AddItem(new XNADropDownItem { Text = name, Tag = translation });
 
+            chkUseLegacyFonts = new XNAClientCheckBox(WindowManager);
+            chkUseLegacyFonts.Name = nameof(chkUseLegacyFonts);
+            chkUseLegacyFonts.ClientRectangle = new Rectangle(
+                lblClientResolution.X,
+                ddTranslation.Bottom + 16, 0, 0);
+            chkUseLegacyFonts.Text = "Use Legacy Fonts".L10N("Client:DTAConfig:UseLegacyFonts");
+            chkUseLegacyFonts.ToolTipText =
+                """
+                Use the original SpriteFont (bitmap) UI fonts instead of the
+                TrueType fonts. Some users prefer the crispness of the bitmap
+                fonts. Requires a client restart to apply.
+                """
+                .L10N("Client:DTAConfig:UseLegacyFontsToolTip");
+
             if (ClientConfiguration.Instance.ClientGameType == ClientType.TS && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 AddCompatibilityFixControls();
@@ -298,6 +313,7 @@ namespace DTAClient.DXGUI.Generic.OptionPanels
             AddChild(ddClientTheme);
             AddChild(lblTranslation);
             AddChild(ddTranslation);
+            AddChild(chkUseLegacyFonts);
             AddChild(lblClientResolution);
             AddChild(ddClientResolution);
             AddChild(lblRenderer);
@@ -626,6 +642,8 @@ namespace DTAClient.DXGUI.Generic.OptionPanels
             {
                 chkBackBufferInVRAM.Checked = UserINISettings.Instance.BackBufferInVRAM;
             }
+
+            chkUseLegacyFonts.Checked = UserINISettings.Instance.UseLegacyFonts;
         }
 
         public override bool Save()
@@ -673,6 +691,11 @@ namespace DTAClient.DXGUI.Generic.OptionPanels
                 restartRequired = true;
 
             IniSettings.IntegerScaledClient.Value = chkIntegerScaledClient.Checked;
+
+            if (IniSettings.UseLegacyFonts.Value != chkUseLegacyFonts.Checked)
+                restartRequired = true;
+
+            IniSettings.UseLegacyFonts.Value = chkUseLegacyFonts.Checked;
 
             restartRequired = restartRequired || IniSettings.ClientTheme != (string)ddClientTheme.SelectedItem.Tag;
 


### PR DESCRIPTION
Adds a checkbox to the DisplayOptionsPanel to enable legacy fonts.

Requires https://github.com/CnCNet/Rampastring.XNAUI/pull/21

I think we should offer this to users, at least initially. Currently the only way to go back to SpriteFonts would be to change your Fonts.ini which would get overwritten later with updates. This way, it is nice and easy for the user and will save a few headaches when we inevitably get some complaints.