### PR TITLE
Fix OpenGL client stutter in windowed mode

### DIFF
--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -42,7 +42,16 @@ namespace DTAClient.DXGUI
         public GameClass()
         {
             graphics = new GraphicsDeviceManager(this);
+#if GL
+            // In windowed mode, VSync synchronises SwapBuffers with DWM's composite cycle,
+            // eliminating the micro-stutter caused by unsynchronised frame delivery.
+            // IsFixedTimeStep=false lets VSync be the sole frame timer so the client
+            // renders at the display's refresh rate with no sleep-based pacing.
+            graphics.SynchronizeWithVerticalRetrace = true;
+            IsFixedTimeStep = false;
+#else
             graphics.SynchronizeWithVerticalRetrace = false;
+#endif
 #if !XNA
             graphics.HardwareModeSwitch = false;
 

--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -43,10 +43,9 @@ namespace DTAClient.DXGUI
         {
             graphics = new GraphicsDeviceManager(this);
 #if GL
-            // In windowed mode, VSync synchronises SwapBuffers with DWM's composite cycle,
-            // eliminating the micro-stutter caused by unsynchronised frame delivery.
-            // IsFixedTimeStep=false lets VSync be the sole frame timer so the client
-            // renders at the display's refresh rate with no sleep-based pacing.
+            // VSync drives frame pacing via SwapBuffers, eliminating micro-stutter caused
+            // by unsynchronised frame delivery. IsFixedTimeStep=false lets VSync be the
+            // sole frame timer so the client renders at the display's refresh rate.
             graphics.SynchronizeWithVerticalRetrace = true;
             IsFixedTimeStep = false;
 #else

--- a/DXMainClient/DXGUI/Generic/GameInProgressWindow.cs
+++ b/DXMainClient/DXGUI/Generic/GameInProgressWindow.cs
@@ -31,6 +31,7 @@ namespace DTAClient.DXGUI
 
         private bool initialized = false;
         private bool nativeCursorUsed = false;
+        private bool savedIsFixedTimeStep = true;
 
         private List<string> debugSnapshotDirectories;
         private DateTime debugLogLastWriteTime;
@@ -70,7 +71,8 @@ namespace DTAClient.DXGUI
 
             window.CenterOnParent();
 
-            Game.TargetElapsedTime = TimeSpan.FromMilliseconds(1000.0 / UserINISettings.Instance.ClientFPS);
+            if (Game.IsFixedTimeStep)
+                Game.TargetElapsedTime = TimeSpan.FromMilliseconds(1000.0 / UserINISettings.Instance.ClientFPS);
 
             Visible = false;
             Enabled = false;
@@ -119,6 +121,8 @@ namespace DTAClient.DXGUI
             nativeCursorUsed = Game.IsMouseVisible;
             Game.IsMouseVisible = false;
             ProgramConstants.IsInGame = true;
+            savedIsFixedTimeStep = Game.IsFixedTimeStep;
+            Game.IsFixedTimeStep = true;
             Game.TargetElapsedTime = TimeSpan.FromMilliseconds(1000.0 / POWER_SAVING_FPS);
 #if WINFORMS
 
@@ -141,7 +145,9 @@ namespace DTAClient.DXGUI
             else
                 WindowManager.Cursor.Visible = true;
             ProgramConstants.IsInGame = false;
-            Game.TargetElapsedTime = TimeSpan.FromMilliseconds(1000.0 / UserINISettings.Instance.ClientFPS);
+            Game.IsFixedTimeStep = savedIsFixedTimeStep;
+            if (Game.IsFixedTimeStep)
+                Game.TargetElapsedTime = TimeSpan.FromMilliseconds(1000.0 / UserINISettings.Instance.ClientFPS);
 
 #if WINFORMS
             if (UserINISettings.Instance.MinimizeWindowsOnGameStart)

--- a/DXMainClient/DXGUI/Generic/GameInProgressWindow.cs
+++ b/DXMainClient/DXGUI/Generic/GameInProgressWindow.cs
@@ -31,7 +31,7 @@ namespace DTAClient.DXGUI
 
         private bool initialized = false;
         private bool nativeCursorUsed = false;
-        private bool savedIsFixedTimeStep = true;
+        private bool savedIsFixedTimeStep;
 
         private List<string> debugSnapshotDirectories;
         private DateTime debugLogLastWriteTime;
@@ -43,6 +43,7 @@ namespace DTAClient.DXGUI
                 throw new InvalidOperationException("GameInProgressWindow cannot be initialized twice!");
 
             initialized = true;
+            savedIsFixedTimeStep = Game.IsFixedTimeStep;
 
             BackgroundTexture = AssetLoader.CreateTexture(new Color(0, 0, 0, 128), 1, 1);
             PanelBackgroundDrawMode = PanelBackgroundImageDrawMode.STRETCHED;

--- a/DXMainClient/DXGUI/Generic/TopBar.cs
+++ b/DXMainClient/DXGUI/Generic/TopBar.cs
@@ -418,6 +418,8 @@ namespace DTAClient.DXGUI.Generic
                 if (locationY < 0)
                 {
                     locationY += DOWN_MOVEMENT_RATE * (gameTime.ElapsedGameTime.TotalMilliseconds / 10.0);
+                    if (locationY > 0)
+                        locationY = 0;
                     ClientRectangle = new Rectangle(X, (int)locationY,
                         Width, Height);
                 }
@@ -431,6 +433,8 @@ namespace DTAClient.DXGUI.Generic
                 if (locationY > -Height - 1)
                 {
                     locationY -= UP_MOVEMENT_RATE * (gameTime.ElapsedGameTime.TotalMilliseconds / 10.0);
+                    if (locationY < -Height - 1)
+                        locationY = -Height - 1;
                     ClientRectangle = new Rectangle(X, (int)locationY,
                         Width, Height);
                 }

--- a/DXMainClient/Startup.cs
+++ b/DXMainClient/Startup.cs
@@ -157,22 +157,8 @@ namespace DTAClient
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 Task.Run(InitSteamworks);
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                timeBeginPeriod(1);
-
             gameClass.Run();
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                timeEndPeriod(1);
         }
-
-        [DllImport("winmm.dll")]
-        [SupportedOSPlatform("windows")]
-        private static extern uint timeBeginPeriod(uint uPeriod);
-
-        [DllImport("winmm.dll")]
-        [SupportedOSPlatform("windows")]
-        private static extern uint timeEndPeriod(uint uPeriod);
 
         [SupportedOSPlatform("windows")]
         private void InitSteamworks()

--- a/DXMainClient/Startup.cs
+++ b/DXMainClient/Startup.cs
@@ -157,8 +157,22 @@ namespace DTAClient
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 Task.Run(InitSteamworks);
 
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                timeBeginPeriod(1);
+
             gameClass.Run();
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                timeEndPeriod(1);
         }
+
+        [DllImport("winmm.dll")]
+        [SupportedOSPlatform("windows")]
+        private static extern uint timeBeginPeriod(uint uPeriod);
+
+        [DllImport("winmm.dll")]
+        [SupportedOSPlatform("windows")]
+        private static extern uint timeEndPeriod(uint uPeriod);
 
         [SupportedOSPlatform("windows")]
         private void InitSteamworks()


### PR DESCRIPTION
Enables VSync and removes fixed timestep for GL builds so SwapBuffers synchronises with DWM's composite cycle. 

Fixes laggy cursor and choppy frames reported on AMD GPUs in windowed mode.