### PR TITLE
Fix race condition when reloading open maps in lobby

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -871,10 +871,14 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         {
             try
             {
+                // GameMode below is read from the pre-delete snapshot; resolve the surviving
+                // map count by name against the post-delete snapshot that DeleteCustomMap publishes.
+                string currentGameModeName = GameMode?.Name;
                 MapLoader.DeleteCustomMap(GameModeMap);
 
                 tbMapSearch.Text = string.Empty;
-                if (GameMode.Maps.Count == 0)
+                bool currentGameModeHasMaps = GameModeMaps.Any(gmm => gmm.GameMode.Name == currentGameModeName);
+                if (!currentGameModeHasMaps)
                 {
                     // this will trigger another GameMode to be selected
                     GameModeMap = GameModeMaps.FirstOrDefault(gm => gm.GameMode.Maps.Count > 0);

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -478,6 +478,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                     ChangeMap(updatedGameModeMap);
             }
 
+            RefreshGameModeFilter();
             ListMaps();
         }
 
@@ -486,7 +487,10 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             // If the currently selected map was removed, select a different one
             if (Map != null && Map.SHA1 == removedMap.SHA1)
             {
-                var availableMaps = GameModeMaps.Where(gmm => gmm.GameMode == GameMode).ToList();
+                var currentGameModeName = GameMode?.Name;
+                var availableMaps = GameModeMaps
+                    .Where(gmm => gmm.GameMode.Name == currentGameModeName)
+                    .ToList();
                 if (availableMaps.Any())
                 {
                     ChangeMap(availableMaps.First());
@@ -537,7 +541,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             GameModeMaps.Where(gmm => gmm.IsFavorite).ToList();
 
         private Func<List<GameModeMap>> GetGameModeMaps(GameMode gm) => () =>
-            GameModeMaps.Where(gmm => gmm.GameMode == gm).ToList();
+            GameModeMaps.Where(gmm => gmm.GameMode.Name == gm.Name).ToList();
 
         private void RefreshBtnPlayerExtraOptionsOpenTexture()
         {
@@ -936,7 +940,10 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             int randomValue = random.Next(0, maps.Count);
             bool isFavoriteMapsSelected = IsFavoriteMapsSelected();
-            GameModeMap = GameModeMaps.FirstOrDefault(gmm => (gmm.GameMode == GameMode || gmm.IsFavorite && isFavoriteMapsSelected) && gmm.Map == maps[randomValue]);
+            string currentGameModeName = GameMode?.Name;
+            GameModeMap = GameModeMaps.FirstOrDefault(gmm =>
+                ((gmm.GameMode.Name == currentGameModeName) || gmm.IsFavorite && isFavoriteMapsSelected) &&
+                gmm.Map == maps[randomValue]);
             Logger.Log("PickRandomMap: Rolled " + randomValue + " out of " + maps.Count + ". Picked map: " + Map.Name);
 
             ChangeMap(GameModeMap);

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -934,17 +934,13 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         {
             int totalPlayerCount = Players.Count(p => p.SideId < ddPlayerSides[0].Items.Count - 1)
                    + AIPlayers.Count;
-            List<Map> maps = GetMapList(totalPlayerCount);
-            if (maps.Count < 1)
+            List<GameModeMap> gameModeMaps = GetRandomGameModeMaps(totalPlayerCount);
+            if (gameModeMaps.Count < 1)
                 return;
 
-            int randomValue = random.Next(0, maps.Count);
-            bool isFavoriteMapsSelected = IsFavoriteMapsSelected();
-            string currentGameModeName = GameMode?.Name;
-            GameModeMap = GameModeMaps.FirstOrDefault(gmm =>
-                ((gmm.GameMode.Name == currentGameModeName) || gmm.IsFavorite && isFavoriteMapsSelected) &&
-                gmm.Map == maps[randomValue]);
-            Logger.Log("PickRandomMap: Rolled " + randomValue + " out of " + maps.Count + ". Picked map: " + Map.Name);
+            int randomValue = random.Next(0, gameModeMaps.Count);
+            GameModeMap = gameModeMaps[randomValue];
+            Logger.Log("PickRandomMap: Rolled " + randomValue + " out of " + gameModeMaps.Count + ". Picked map: " + GameModeMap.Map.Name);
 
             ChangeMap(GameModeMap);
             tbMapSearch.Text = string.Empty;
@@ -952,32 +948,21 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             ListMaps();
         }
 
-        private List<Map> GetMapList(int playerCount)
+        private List<GameModeMap> GetRandomGameModeMaps(int playerCount)
         {
-            List<Map> maps = IsFavoriteMapsSelected()
-                ? GetFavoriteGameModeMaps().Select(gameModeMap => gameModeMap.Map).ToList()
-                : GameMode?.Maps.ToList() ?? new List<Map>();
+            List<GameModeMap> gameModeMaps = IsFavoriteMapsSelected()
+                ? GetFavoriteGameModeMaps()
+                : GameModeMaps.Where(gmm => gmm.GameMode.Name == GameMode?.Name).ToList();
 
             if (playerCount != 1)
             {
+                gameModeMaps = gameModeMaps.Where(gmm => gmm.MaxPlayers == playerCount).ToList();
 
-                if (GameMode?.MaxPlayersOverride != null)
-                {
-                    // MaxPlayers have been overridden in GameMode. This means all maps in the game mode has the same MaxPlayers value
-                    if (playerCount != GameMode.MaxPlayersOverride)
-                        maps = [];
-                }
-                else
-                {
-                    // Maps could have different MaxPlayers values.
-                    maps = maps.Where(x => x.MaxPlayers == playerCount).ToList();
-                }
-
-                if (maps.Count < 1 && playerCount <= MAX_PLAYER_COUNT)
-                    return GetMapList(playerCount + 1);
+                if (gameModeMaps.Count < 1 && playerCount <= MAX_PLAYER_COUNT)
+                    return GetRandomGameModeMaps(playerCount + 1);
             }
 
-            return maps;
+            return gameModeMaps;
         }
 
         /// <summary>

--- a/DXMainClient/Domain/Multiplayer/GameMode.cs
+++ b/DXMainClient/Domain/Multiplayer/GameMode.cs
@@ -13,7 +13,7 @@ namespace DTAClient.Domain.Multiplayer
     /// <summary>
     /// A multiplayer game mode.
     /// </summary>
-    public class GameMode : GameModeMapBase
+    public class GameMode : GameModeMapBase, ICloneable
     {
         public GameMode(string name)
         {
@@ -89,6 +89,8 @@ namespace DTAClient.Domain.Multiplayer
 
             return clone;
         }
+
+        object ICloneable.Clone() => Clone();
 
         public void Initialize()
         {

--- a/DXMainClient/Domain/Multiplayer/GameMode.cs
+++ b/DXMainClient/Domain/Multiplayer/GameMode.cs
@@ -75,6 +75,21 @@ namespace DTAClient.Domain.Multiplayer
 
         private List<KeyValuePair<string, string>> ForcedSpawnIniOptions = new List<KeyValuePair<string, string>>();
 
+        public GameMode CloneForSnapshot()
+        {
+            GameMode clone = (GameMode)MemberwiseClone();
+            clone.Maps = new List<Map>(Maps);
+            clone.DisallowedPlayerSides = new List<int>(DisallowedPlayerSides);
+            clone.DisallowedHumanPlayerSides = new List<int>(DisallowedHumanPlayerSides);
+            clone.DisallowedComputerPlayerSides = new List<int>(DisallowedComputerPlayerSides);
+            clone.ForcedCheckBoxValues = new List<KeyValuePair<string, bool>>(ForcedCheckBoxValues);
+            clone.ForcedDropDownValues = new List<KeyValuePair<string, int>>(ForcedDropDownValues);
+            clone.ForcedSpawnIniOptions = new List<KeyValuePair<string, string>>(ForcedSpawnIniOptions);
+            clone.randomizedMapCodeININames = new List<string>(randomizedMapCodeININames);
+
+            return clone;
+        }
+
         public void Initialize()
         {
             IniFile forcedOptionsIni = new IniFile(SafePath.CombineFilePath(ProgramConstants.GamePath, ClientConfiguration.Instance.MPMapsIniPath));

--- a/DXMainClient/Domain/Multiplayer/GameMode.cs
+++ b/DXMainClient/Domain/Multiplayer/GameMode.cs
@@ -78,14 +78,14 @@ namespace DTAClient.Domain.Multiplayer
         public GameMode CloneForSnapshot()
         {
             GameMode clone = (GameMode)MemberwiseClone();
-            clone.Maps = new List<Map>(Maps);
-            clone.DisallowedPlayerSides = new List<int>(DisallowedPlayerSides);
-            clone.DisallowedHumanPlayerSides = new List<int>(DisallowedHumanPlayerSides);
-            clone.DisallowedComputerPlayerSides = new List<int>(DisallowedComputerPlayerSides);
-            clone.ForcedCheckBoxValues = new List<KeyValuePair<string, bool>>(ForcedCheckBoxValues);
-            clone.ForcedDropDownValues = new List<KeyValuePair<string, int>>(ForcedDropDownValues);
-            clone.ForcedSpawnIniOptions = new List<KeyValuePair<string, string>>(ForcedSpawnIniOptions);
-            clone.randomizedMapCodeININames = new List<string>(randomizedMapCodeININames);
+            clone.Maps = [.. clone.Maps];
+            clone.DisallowedPlayerSides = [.. clone.DisallowedPlayerSides];
+            clone.DisallowedHumanPlayerSides = [.. clone.DisallowedHumanPlayerSides];
+            clone.DisallowedComputerPlayerSides = [.. clone.DisallowedComputerPlayerSides];
+            clone.ForcedCheckBoxValues = [.. clone.ForcedCheckBoxValues];
+            clone.ForcedDropDownValues = [.. clone.ForcedDropDownValues];
+            clone.ForcedSpawnIniOptions = [.. clone.ForcedSpawnIniOptions];
+            clone.randomizedMapCodeININames = [.. clone.randomizedMapCodeININames];
 
             return clone;
         }

--- a/DXMainClient/Domain/Multiplayer/GameMode.cs
+++ b/DXMainClient/Domain/Multiplayer/GameMode.cs
@@ -75,7 +75,7 @@ namespace DTAClient.Domain.Multiplayer
 
         private List<KeyValuePair<string, string>> ForcedSpawnIniOptions = new List<KeyValuePair<string, string>>();
 
-        public GameMode CloneForSnapshot()
+        public GameMode Clone()
         {
             GameMode clone = (GameMode)MemberwiseClone();
             clone.Maps = [.. clone.Maps];

--- a/DXMainClient/Domain/Multiplayer/GameModeMap.cs
+++ b/DXMainClient/Domain/Multiplayer/GameModeMap.cs
@@ -74,8 +74,6 @@ namespace DTAClient.Domain.Multiplayer
             Map.IsCoop ?? GameMode.IsCoop ?? false;
 
         public int MaxPlayers =>
-            // Note: GameLobbyBase.GetMapList() assumes the priority.
-            // If you have modified the expression here, you should also update GameLobbyBase.GetMapList().
             GameMode.MaxPlayersOverride ?? Map.MaxPlayers ?? GameMode.MaxPlayers ?? 0;
 
         public int MinPlayers =>

--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -396,11 +396,6 @@ namespace DTAClient.Domain.Multiplayer
                 gameMode.Maps.RemoveAll(map => map.SHA1 == sha1);
         }
 
-        private void UpdateGameModeMaps()
-        {
-            ReplaceGameModeSnapshot(_gameModes);
-        }
-
         private void ReplaceGameModeSnapshot(List<GameMode> gameModes)
         {
             gameModes.RemoveAll(g => g.Maps.Count < 1);
@@ -408,17 +403,7 @@ namespace DTAClient.Domain.Multiplayer
             _gameModeMaps = new GameModeMapCollection(gameModes);
         }
 
-        private List<GameMode> CloneGameModeSnapshot() => GameModes.Select(CloneGameMode).ToList();
-
-        private static GameMode CloneGameMode(GameMode source)
-        {
-            GameMode clone = new GameMode(source.Name)
-            {
-                Maps = new List<Map>(source.Maps)
-            };
-
-            return clone;
-        }
+        private List<GameMode> CloneGameModeSnapshot() => GameModes.Select(gameMode => gameMode.CloneForSnapshot()).ToList();
 
         private async Task LoadMultiMapsAsync(IniFile mpMapsIni)
         {

--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -460,7 +460,7 @@ namespace DTAClient.Domain.Multiplayer
 
             foreach (Map map in tasks.Select(t => t.Result).Where(m => m != null))
             {
-                AddMapToGameModes(map, false);
+                AddMapToGameModes(map, _gameModes, false);
                 _translatedMapNames[map.UntranslatedName] = map.Name;
             }
         }
@@ -589,7 +589,7 @@ namespace DTAClient.Domain.Multiplayer
 
             foreach (Map map in customMapCache.Items.Values.Select(item => item.Map))
             {
-                AddMapToGameModes(map, false);
+                AddMapToGameModes(map, _gameModes, false);
             }
 
             Logger.Log("MapLoader: Custom maps loaded.");
@@ -738,10 +738,8 @@ namespace DTAClient.Domain.Multiplayer
         /// Adds map to all eligible game modes.
         /// </summary>
         /// <param name="map">Map to add.</param>
+        /// <param name="gameModes">Game modes collection.</param>
         /// <param name="enableLogging">If set to true, a message for each game mode the map is added to is output to the log file.</param>
-        private void AddMapToGameModes(Map map, bool enableLogging)
-            => AddMapToGameModes(map, _gameModes, enableLogging);
-
         private void AddMapToGameModes(Map map, List<GameMode> gameModes, bool enableLogging)
         {
             foreach (string gameMode in map.GameModes)

--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -151,7 +151,6 @@ namespace DTAClient.Domain.Multiplayer
             await LoadCustomMapsAsync();
 
             Logger.Log("MapLoader: Post-processing game mode map collections.");
-            _initialGameModes.RemoveAll(g => g.Maps.Count < 1);
             PublishSnapshot(_initialGameModes);
             _initialGameModes = null;
 
@@ -399,16 +398,16 @@ namespace DTAClient.Domain.Multiplayer
                 gameMode.Maps.RemoveAll(map => map.SHA1 == sha1);
         }
 
-        private void ReplaceGameModeSnapshot(List<GameMode> gameModes, bool removeEmptyGameModes = true)
+        private void ReplaceGameModeSnapshot(List<GameMode> gameModes, bool removeEmptyGameModes = true) =>
+            PublishSnapshot(gameModes, removeEmptyGameModes);
+
+        private void PublishSnapshot(List<GameMode> gameModes, bool removeEmptyGameModes = true)
         {
             if (removeEmptyGameModes)
                 gameModes.RemoveAll(g => g.Maps.Count < 1);
 
-            PublishSnapshot(gameModes);
+            _snapshot = new Snapshot(gameModes, new GameModeMapCollection(gameModes));
         }
-
-        private void PublishSnapshot(List<GameMode> gameModes)
-            => _snapshot = new Snapshot(gameModes, new GameModeMapCollection(gameModes));
 
         private List<GameMode> CloneGameModeSnapshot() => GameModes.Select(gameMode => gameMode.Clone()).ToList();
 

--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -410,7 +410,7 @@ namespace DTAClient.Domain.Multiplayer
         private void PublishSnapshot(List<GameMode> gameModes)
             => _snapshot = new Snapshot(gameModes, new GameModeMapCollection(gameModes));
 
-        private List<GameMode> CloneGameModeSnapshot() => GameModes.Select(gameMode => gameMode.CloneForSnapshot()).ToList();
+        private List<GameMode> CloneGameModeSnapshot() => GameModes.Select(gameMode => gameMode.Clone()).ToList();
 
         private async Task LoadMultiMapsAsync(IniFile mpMapsIni)
         {

--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -43,7 +43,7 @@ namespace DTAClient.Domain.Multiplayer
         private readonly object mapModificationLock = new object();
         private const int _mapChangeRetryCount = 3;
 
-        private readonly List<GameMode> _gameModes = [];
+        private List<GameMode> _gameModes = [];
 
         /// <summary>
         /// List of game modes.
@@ -201,11 +201,13 @@ namespace DTAClient.Domain.Multiplayer
                 {
                     lock (mapModificationLock)
                     {
-                        if (IsMapAlreadyLoaded(map.SHA1))
+                        List<GameMode> gameModeSnapshot = CloneGameModeSnapshot();
+
+                        if (IsMapAlreadyLoaded(map.SHA1, gameModeSnapshot))
                             return;
 
-                        AddMapToGameModes(map, true);
-                        UpdateGameModeMaps();
+                        AddMapToGameModes(map, gameModeSnapshot, true);
+                        ReplaceGameModeSnapshot(gameModeSnapshot);
 
                         Logger.Log($"MapLoader: Added new map {map.Name} from {filePath}");
                         MapChanged?.Invoke(this, new MapChangedEventArgs(map, MapChangeType.Added));
@@ -259,16 +261,17 @@ namespace DTAClient.Domain.Multiplayer
                 {
                     lock (mapModificationLock)
                     {
-                        string oldSHA1 = FindMapSHA1ByFilePath(baseFilePath);
+                        List<GameMode> gameModeSnapshot = CloneGameModeSnapshot();
+                        string oldSHA1 = FindMapSHA1ByFilePath(baseFilePath, gameModeSnapshot);
 
                         if (!string.IsNullOrEmpty(oldSHA1))
                         {
                             if (oldSHA1 != newMap.SHA1)
                             {
                                 // SHA1 changed, remove old and add new
-                                RemoveMapBySHA1(oldSHA1);
-                                AddMapToGameModes(newMap, true);
-                                UpdateGameModeMaps();
+                                RemoveMapBySHA1(oldSHA1, gameModeSnapshot);
+                                AddMapToGameModes(newMap, gameModeSnapshot, true);
+                                ReplaceGameModeSnapshot(gameModeSnapshot);
 
                                 Logger.Log($"MapLoader: Updated map {newMap.Name} from {filePath} (SHA1 changed: {oldSHA1} -> {newMap.SHA1})");
                                 MapChanged?.Invoke(this, new MapChangedEventArgs(newMap, MapChangeType.Updated, oldSHA1));
@@ -282,8 +285,8 @@ namespace DTAClient.Domain.Multiplayer
                         {
                             // Map not found, treat as new
                             Logger.Log($"MapLoader: Changed event for unknown map {filePath}, treating as new");
-                            AddMapToGameModes(newMap, true);
-                            UpdateGameModeMaps();
+                            AddMapToGameModes(newMap, gameModeSnapshot, true);
+                            ReplaceGameModeSnapshot(gameModeSnapshot);
                             MapChanged?.Invoke(this, new MapChangedEventArgs(newMap, MapChangeType.Added));
                         }
                     }
@@ -309,13 +312,14 @@ namespace DTAClient.Domain.Multiplayer
 
                 lock (mapModificationLock)
                 {
-                    string mapSHA1 = FindMapSHA1ByFilePath(baseFilePath);
+                    List<GameMode> gameModeSnapshot = CloneGameModeSnapshot();
+                    string mapSHA1 = FindMapSHA1ByFilePath(baseFilePath, gameModeSnapshot);
 
                     if (!string.IsNullOrEmpty(mapSHA1))
                     {
-                        var removedMap = FindMapBySHA1(mapSHA1);
-                        RemoveMapBySHA1(mapSHA1);
-                        UpdateGameModeMaps();
+                        var removedMap = FindMapBySHA1(mapSHA1, gameModeSnapshot);
+                        RemoveMapBySHA1(mapSHA1, gameModeSnapshot);
+                        ReplaceGameModeSnapshot(gameModeSnapshot);
 
                         Logger.Log($"MapLoader: Removed map from {filePath}");
                         if (removedMap != null)
@@ -362,26 +366,58 @@ namespace DTAClient.Domain.Multiplayer
         }
 
         private bool IsMapAlreadyLoaded(string sha1)
-            => GameModes.SelectMany(gm => gm.Maps).Any(map => map.SHA1 == sha1);
+            => IsMapAlreadyLoaded(sha1, GameModes);
+
+        private static bool IsMapAlreadyLoaded(string sha1, IEnumerable<GameMode> gameModes)
+            => gameModes.SelectMany(gm => gm.Maps).Any(map => map.SHA1 == sha1);
 
         private Map FindMapBySHA1(string sha1)
-            => GameModes.SelectMany(gm => gm.Maps).FirstOrDefault(map => map.SHA1 == sha1);
+            => FindMapBySHA1(sha1, GameModes);
+
+        private static Map FindMapBySHA1(string sha1, IEnumerable<GameMode> gameModes)
+            => gameModes.SelectMany(gm => gm.Maps).FirstOrDefault(map => map.SHA1 == sha1);
 
         private string FindMapSHA1ByFilePath(string baseFilePath)
-            => GameModes.SelectMany(gm => gm.Maps)
+            => FindMapSHA1ByFilePath(baseFilePath, GameModes);
+
+        private static string FindMapSHA1ByFilePath(string baseFilePath, IEnumerable<GameMode> gameModes)
+            => gameModes.SelectMany(gm => gm.Maps)
                 .Where(map => !map.Official && map.BaseFilePath.Equals(baseFilePath, StringComparison.OrdinalIgnoreCase))
                 .FirstOrDefault()?.SHA1;
 
         private void RemoveMapBySHA1(string sha1)
         {
-            foreach (var gameMode in GameModes)
+            RemoveMapBySHA1(sha1, GameModes);
+        }
+
+        private static void RemoveMapBySHA1(string sha1, IEnumerable<GameMode> gameModes)
+        {
+            foreach (var gameMode in gameModes)
                 gameMode.Maps.RemoveAll(map => map.SHA1 == sha1);
         }
 
         private void UpdateGameModeMaps()
         {
-            _gameModes.RemoveAll(g => g.Maps.Count < 1);
-            _gameModeMaps = new GameModeMapCollection(_gameModes);
+            ReplaceGameModeSnapshot(_gameModes);
+        }
+
+        private void ReplaceGameModeSnapshot(List<GameMode> gameModes)
+        {
+            gameModes.RemoveAll(g => g.Maps.Count < 1);
+            _gameModes = gameModes;
+            _gameModeMaps = new GameModeMapCollection(gameModes);
+        }
+
+        private List<GameMode> CloneGameModeSnapshot() => GameModes.Select(CloneGameMode).ToList();
+
+        private static GameMode CloneGameMode(GameMode source)
+        {
+            GameMode clone = new GameMode(source.Name)
+            {
+                Maps = new List<Map>(source.Maps)
+            };
+
+            return clone;
         }
 
         private async Task LoadMultiMapsAsync(IniFile mpMapsIni)
@@ -711,6 +747,9 @@ namespace DTAClient.Domain.Multiplayer
         /// <param name="map">Map to add.</param>
         /// <param name="enableLogging">If set to true, a message for each game mode the map is added to is output to the log file.</param>
         private void AddMapToGameModes(Map map, bool enableLogging)
+            => AddMapToGameModes(map, _gameModes, enableLogging);
+
+        private void AddMapToGameModes(Map map, List<GameMode> gameModes, bool enableLogging)
         {
             foreach (string gameMode in map.GameModes)
             {
@@ -722,11 +761,11 @@ namespace DTAClient.Domain.Multiplayer
                     if (!map.Official && !(AllowedGameModes.Contains(gameMode) || AllowedGameModes.Contains(gameModeAlias)))
                         continue;
 
-                    GameMode gm = GameModes.FirstOrDefault(g => g.Name == gameModeAlias);
+                    GameMode gm = gameModes.FirstOrDefault(g => g.Name == gameModeAlias);
                     if (gm == null)
                     {
                         gm = new GameMode(gameModeAlias);
-                        _gameModes.Add(gm);
+                        gameModes.Add(gm);
                     }
 
                     gm.Maps.Add(map);

--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -404,6 +404,7 @@ namespace DTAClient.Domain.Multiplayer
         {
             if (removeEmptyGameModes)
                 gameModes.RemoveAll(g => g.Maps.Count < 1);
+
             PublishSnapshot(gameModes);
         }
 

--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -61,7 +61,7 @@ namespace DTAClient.Domain.Multiplayer
             }
         }
 
-        private Snapshot _snapshot = new Snapshot(Array.Empty<GameMode>(), new GameModeMapCollection(Array.Empty<GameMode>()));
+        private volatile Snapshot _snapshot = new Snapshot(Array.Empty<GameMode>(), new GameModeMapCollection(Array.Empty<GameMode>()));
 
         /// <summary>
         /// List of game modes.

--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -47,7 +47,7 @@ namespace DTAClient.Domain.Multiplayer
         // LoadMapsInternalAsync publishes the first snapshot, it is set to null
         // and every subsequent update goes through ReplaceGameModeSnapshot under
         // mapModificationLock.
-        // TODO: Consider refactor this MapLoader class into two classes, one for initial loading and one for runtime updates, to avoid having this mutable state that is only used during initialization.
+        // TODO: Consider refactoring this MapLoader class into two classes, one for initial loading and one for runtime updates, to avoid having this mutable state that is only used during initialization.
         private List<GameMode> _initialGameModes = [];
 
         private sealed class Snapshot

--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -400,9 +400,10 @@ namespace DTAClient.Domain.Multiplayer
                 gameMode.Maps.RemoveAll(map => map.SHA1 == sha1);
         }
 
-        private void ReplaceGameModeSnapshot(List<GameMode> gameModes)
+        private void ReplaceGameModeSnapshot(List<GameMode> gameModes, bool removeEmptyGameModes = true)
         {
-            gameModes.RemoveAll(g => g.Maps.Count < 1);
+            if (removeEmptyGameModes)
+                gameModes.RemoveAll(g => g.Maps.Count < 1);
             PublishSnapshot(gameModes);
         }
 

--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -43,15 +43,32 @@ namespace DTAClient.Domain.Multiplayer
         private readonly object mapModificationLock = new object();
         private const int _mapChangeRetryCount = 3;
 
+        // Mutable buffer used only during the initial map-loading pass. After
+        // LoadMapsInternalAsync publishes the first snapshot, it is set to null
+        // and every subsequent update goes through ReplaceGameModeSnapshot under
+        // mapModificationLock.
         private List<GameMode> _gameModes = [];
+
+        private sealed class Snapshot
+        {
+            public IReadOnlyList<GameMode> GameModes { get; }
+            public IReadOnlyGameModeMapCollection GameModeMaps { get; }
+
+            public Snapshot(IReadOnlyList<GameMode> gameModes, IReadOnlyGameModeMapCollection gameModeMaps)
+            {
+                GameModes = gameModes;
+                GameModeMaps = gameModeMaps;
+            }
+        }
+
+        private Snapshot _snapshot = new Snapshot(Array.Empty<GameMode>(), new GameModeMapCollection(Array.Empty<GameMode>()));
 
         /// <summary>
         /// List of game modes.
         /// </summary>
-        public IReadOnlyList<GameMode> GameModes => _gameModes;
+        public IReadOnlyList<GameMode> GameModes => _snapshot.GameModes;
 
-        private GameModeMapCollection _gameModeMaps;
-        public IReadOnlyGameModeMapCollection GameModeMaps => _gameModeMaps;
+        public IReadOnlyGameModeMapCollection GameModeMaps => _snapshot.GameModeMaps;
 
         /// <summary>
         /// An event that is fired when the maps have been loaded.
@@ -134,7 +151,8 @@ namespace DTAClient.Domain.Multiplayer
 
             Logger.Log("MapLoader: Post-processing game mode map collections.");
             _gameModes.RemoveAll(g => g.Maps.Count < 1);
-            _gameModeMaps = new GameModeMapCollection(_gameModes);
+            PublishSnapshot(_gameModes);
+            _gameModes = null;
 
             // Clean up any name-based favorite entries after migration (legacy: changed from name to sha1)
             CleanupMigratedFavorites();
@@ -365,30 +383,16 @@ namespace DTAClient.Domain.Multiplayer
             }
         }
 
-        private bool IsMapAlreadyLoaded(string sha1)
-            => IsMapAlreadyLoaded(sha1, GameModes);
-
         private static bool IsMapAlreadyLoaded(string sha1, IEnumerable<GameMode> gameModes)
             => gameModes.SelectMany(gm => gm.Maps).Any(map => map.SHA1 == sha1);
 
-        private Map FindMapBySHA1(string sha1)
-            => FindMapBySHA1(sha1, GameModes);
-
         private static Map FindMapBySHA1(string sha1, IEnumerable<GameMode> gameModes)
             => gameModes.SelectMany(gm => gm.Maps).FirstOrDefault(map => map.SHA1 == sha1);
-
-        private string FindMapSHA1ByFilePath(string baseFilePath)
-            => FindMapSHA1ByFilePath(baseFilePath, GameModes);
 
         private static string FindMapSHA1ByFilePath(string baseFilePath, IEnumerable<GameMode> gameModes)
             => gameModes.SelectMany(gm => gm.Maps)
                 .Where(map => !map.Official && map.BaseFilePath.Equals(baseFilePath, StringComparison.OrdinalIgnoreCase))
                 .FirstOrDefault()?.SHA1;
-
-        private void RemoveMapBySHA1(string sha1)
-        {
-            RemoveMapBySHA1(sha1, GameModes);
-        }
 
         private static void RemoveMapBySHA1(string sha1, IEnumerable<GameMode> gameModes)
         {
@@ -399,9 +403,11 @@ namespace DTAClient.Domain.Multiplayer
         private void ReplaceGameModeSnapshot(List<GameMode> gameModes)
         {
             gameModes.RemoveAll(g => g.Maps.Count < 1);
-            _gameModes = gameModes;
-            _gameModeMaps = new GameModeMapCollection(gameModes);
+            PublishSnapshot(gameModes);
         }
+
+        private void PublishSnapshot(List<GameMode> gameModes)
+            => _snapshot = new Snapshot(gameModes, new GameModeMapCollection(gameModes));
 
         private List<GameMode> CloneGameModeSnapshot() => GameModes.Select(gameMode => gameMode.CloneForSnapshot()).ToList();
 
@@ -686,22 +692,23 @@ namespace DTAClient.Domain.Multiplayer
 
             if (map.InitializeFromCustomMap())
             {
-                foreach (GameMode gm in GameModes)
+                lock (mapModificationLock)
                 {
-                    if (gm.Maps.Find(m => m.SHA1 == map.SHA1) != null)
+                    List<GameMode> gameModeSnapshot = CloneGameModeSnapshot();
+
+                    if (IsMapAlreadyLoaded(map.SHA1, gameModeSnapshot))
                     {
                         Logger.Log("LoadCustomMap: Custom map " + customMapFile.FullName + " is already loaded!");
                         resultMessage = string.Format("Map {0} is already loaded.".L10N("Client:MapLoader:MapAlreadyLoaded"), map.Name);
 
                         return null;
                     }
+
+                    AddMapToGameModes(map, gameModeSnapshot, true);
+                    ReplaceGameModeSnapshot(gameModeSnapshot);
                 }
 
                 Logger.Log("LoadCustomMap: Map " + customMapFile.FullName + " added successfully.");
-
-                AddMapToGameModes(map, true);
-                var gameModes = GameModes.Where(gm => gm.Maps.Contains(map));
-                _gameModeMaps.AddRange(gameModes.Select(gm => new GameModeMap(gm, map, false)));
 
                 resultMessage = string.Format("Map {0} loaded successfully.".L10N("Client:MapLoader:MapLoadedSuccessfully"), map.Name);
 
@@ -718,12 +725,13 @@ namespace DTAClient.Domain.Multiplayer
         {
             Logger.Log("Deleting map " + gameModeMap.Map.UntranslatedName);
             File.Delete(gameModeMap.Map.CompleteFilePath);
-            foreach (GameMode gameMode in GameModeMaps.GameModes)
-            {
-                gameMode.Maps.Remove(gameModeMap.Map);
-            }
 
-            _gameModeMaps.Remove(gameModeMap);
+            lock (mapModificationLock)
+            {
+                List<GameMode> gameModeSnapshot = CloneGameModeSnapshot();
+                RemoveMapBySHA1(gameModeMap.Map.SHA1, gameModeSnapshot);
+                ReplaceGameModeSnapshot(gameModeSnapshot);
+            }
         }
 
         /// <summary>

--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -390,9 +390,7 @@ namespace DTAClient.Domain.Multiplayer
             => gameModes.SelectMany(gm => gm.Maps).FirstOrDefault(map => map.SHA1 == sha1);
 
         private static string FindMapSHA1ByFilePath(string baseFilePath, IEnumerable<GameMode> gameModes)
-            => gameModes.SelectMany(gm => gm.Maps)
-                .Where(map => !map.Official && map.BaseFilePath.Equals(baseFilePath, StringComparison.OrdinalIgnoreCase))
-                .FirstOrDefault()?.SHA1;
+            => gameModes.SelectMany(gm => gm.Maps).FirstOrDefault(map => !map.Official && map.BaseFilePath.Equals(baseFilePath, StringComparison.OrdinalIgnoreCase))?.SHA1;
 
         private static void RemoveMapBySHA1(string sha1, IEnumerable<GameMode> gameModes)
         {

--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -47,6 +47,7 @@ namespace DTAClient.Domain.Multiplayer
         // LoadMapsInternalAsync publishes the first snapshot, it is set to null
         // and every subsequent update goes through ReplaceGameModeSnapshot under
         // mapModificationLock.
+        // TODO: Consider refactor this MapLoader class into two classes, one for initial loading and one for runtime updates, to avoid having this mutable state that is only used during initialization.
         private List<GameMode> _initialGameModes = [];
 
         private sealed class Snapshot

--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -47,7 +47,7 @@ namespace DTAClient.Domain.Multiplayer
         // LoadMapsInternalAsync publishes the first snapshot, it is set to null
         // and every subsequent update goes through ReplaceGameModeSnapshot under
         // mapModificationLock.
-        private List<GameMode> _gameModes = [];
+        private List<GameMode> _initialGameModes = [];
 
         private sealed class Snapshot
         {
@@ -150,9 +150,9 @@ namespace DTAClient.Domain.Multiplayer
             await LoadCustomMapsAsync();
 
             Logger.Log("MapLoader: Post-processing game mode map collections.");
-            _gameModes.RemoveAll(g => g.Maps.Count < 1);
-            PublishSnapshot(_gameModes);
-            _gameModes = null;
+            _initialGameModes.RemoveAll(g => g.Maps.Count < 1);
+            PublishSnapshot(_initialGameModes);
+            _initialGameModes = null;
 
             // Clean up any name-based favorite entries after migration (legacy: changed from name to sha1)
             CleanupMigratedFavorites();
@@ -460,7 +460,7 @@ namespace DTAClient.Domain.Multiplayer
 
             foreach (Map map in tasks.Select(t => t.Result).Where(m => m != null))
             {
-                AddMapToGameModes(map, _gameModes, false);
+                AddMapToGameModes(map, _initialGameModes, false);
                 _translatedMapNames[map.UntranslatedName] = map.Name;
             }
         }
@@ -476,7 +476,7 @@ namespace DTAClient.Domain.Multiplayer
                     if (!string.IsNullOrEmpty(gameModeName))
                     {
                         GameMode gm = new GameMode(gameModeName);
-                        _gameModes.Add(gm);
+                        _initialGameModes.Add(gm);
                     }
                 }
             }
@@ -589,7 +589,7 @@ namespace DTAClient.Domain.Multiplayer
 
             foreach (Map map in customMapCache.Items.Values.Select(item => item.Map))
             {
-                AddMapToGameModes(map, _gameModes, false);
+                AddMapToGameModes(map, _initialGameModes, false);
             }
 
             Logger.Log("MapLoader: Custom maps loaded.");


### PR DESCRIPTION
Avoid in-place mutation of live map/game-mode collections when the custom map file watcher processes add/update/delete events. Build a new snapshot in MapLoader and update lobby consumers to avoid stale GameMode references after snapshot swaps.