### PR TITLE
Tolerate invalid path characters in mission scenario field

### DIFF
--- a/DXMainClient/DXGUI/Campaign/CampaignSelector.cs
+++ b/DXMainClient/DXGUI/Campaign/CampaignSelector.cs
@@ -442,6 +442,12 @@ namespace DTAClient.DXGUI.Campaign
 
             bool copyMapsToSpawnmapINI = ClientConfiguration.Instance.CopyMissionsToSpawnmapINI;
 
+            if (mission.Scenario.IndexOfAny(Path.GetInvalidPathChars()) != -1)
+            {
+                Logger.Log($"CampaignSelector: mission scenario contains invalid path characters. Mission code name: {mission.CodeName}. Scenario: {mission.Scenario}. This mission will be launched without applying {nameof(ClientConfiguration.Instance.CopyMissionsToSpawnmapINI)}.");
+                copyMapsToSpawnmapINI = false;
+            }
+
             Logger.Log("About to write spawn.ini.");
             IniFile spawnIni = new(spawnerSettingsFile.FullName)
             {
@@ -518,25 +524,18 @@ namespace DTAClient.DXGUI.Campaign
 
             if (copyMapsToSpawnmapINI)
             {
+                var mapIni = new IniFile(SafePath.CombineFilePath(ProgramConstants.GamePath, mission.Scenario));
 
-                if (mission.Scenario.IndexOfAny(Path.GetInvalidPathChars()) != -1)
-                {
-                    Logger.Log($"CampaignSelector: mission scenario contains invalid path characters. Mission code name: {mission.CodeName}. Scenario: {mission.Scenario}. This mission will be launched without applying {nameof(ClientConfiguration.Instance.CopyMissionsToSpawnmapINI)}.");
-                }
-                else
-                {
-                    var mapIni = new IniFile(SafePath.CombineFilePath(ProgramConstants.GamePath, mission.Scenario));
+                IniFile.ConsolidateIniFiles(mapIni, difficultyIni);
 
-                    IniFile.ConsolidateIniFiles(mapIni, difficultyIni);
+                foreach (CampaignCheckBox chkBox in CheckBoxes)
+                    chkBox.ApplyMapCode(mapIni, gameMode: null);
 
-                    foreach (CampaignCheckBox chkBox in CheckBoxes)
-                        chkBox.ApplyMapCode(mapIni, gameMode: null);
+                foreach (CampaignDropDown dd in DropDowns)
+                    dd.ApplyMapCode(mapIni, gameMode: null);
 
-                    foreach (CampaignDropDown dd in DropDowns)
-                        dd.ApplyMapCode(mapIni, gameMode: null);
+                mapIni.WriteIniFile(SafePath.CombineFilePath(ProgramConstants.GamePath, "spawnmap.ini"));
 
-                    mapIni.WriteIniFile(SafePath.CombineFilePath(ProgramConstants.GamePath, "spawnmap.ini"));
-                }
             }
 
             UserINISettings.Instance.Difficulty.Value = trbDifficultySelector.Value;

--- a/DXMainClient/DXGUI/Campaign/CampaignSelector.cs
+++ b/DXMainClient/DXGUI/Campaign/CampaignSelector.cs
@@ -434,17 +434,21 @@ namespace DTAClient.DXGUI.Campaign
         {
             CustomMissionHelper.CopySupplementalMissionFiles(mission);
 
-            string scenario = mission.Scenario;
-
             FileInfo spawnerSettingsFile = SafePath.GetFile(ProgramConstants.GamePath, ProgramConstants.SPAWNER_SETTINGS);
 
             spawnerSettingsFile.Delete();
 
             bool copyMapsToSpawnmapINI = ClientConfiguration.Instance.CopyMissionsToSpawnmapINI;
 
-            if (mission.Scenario.ToWin32FileName() != mission.Scenario)
+            string scenario = mission.Scenario;
+            string scenarioPath = null;
+            try
             {
-                Logger.Log($"CampaignSelector: mission scenario contains invalid path characters. Mission code name: {mission.CodeName}. Scenario: {mission.Scenario}. This mission will be launched without applying {nameof(ClientConfiguration.Instance.CopyMissionsToSpawnmapINI)}.");
+                scenarioPath = SafePath.CombineFilePath(ProgramConstants.GamePath, mission.Scenario);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"CampaignSelector: mission scenario contains invalid path characters. Mission code name: {mission.CodeName}. Scenario: {mission.Scenario}. This mission will be launched without applying {nameof(ClientConfiguration.Instance.CopyMissionsToSpawnmapINI)}. Error: {ex.Message}");
                 copyMapsToSpawnmapINI = false;
             }
 
@@ -524,7 +528,7 @@ namespace DTAClient.DXGUI.Campaign
 
             if (copyMapsToSpawnmapINI)
             {
-                var mapIni = new IniFile(SafePath.CombineFilePath(ProgramConstants.GamePath, mission.Scenario));
+                var mapIni = new IniFile(scenarioPath);
 
                 IniFile.ConsolidateIniFiles(mapIni, difficultyIni);
 
@@ -555,13 +559,16 @@ namespace DTAClient.DXGUI.Campaign
         {
             bool hasGameMissionData = false;
 
-            if (mission.Scenario.ToWin32FileName() != mission.Scenario)
+            string scenarioPath;
+            try
             {
-                Logger.Log($"CampaignSelector: mission scenario contains invalid path characters. Mission code name: {mission.CodeName}. Scenario: {mission.Scenario}. This mission will be launched without mission section data.");
+                scenarioPath = SafePath.CombineFilePath(ProgramConstants.GamePath, mission.Scenario);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"CampaignSelector: mission scenario contains invalid path characters. Mission code name: {mission.CodeName}. Scenario: {mission.Scenario}. This mission will be launched without mission section data. Error: {ex.Message}");
                 return;
             }
-
-            string scenarioPath = SafePath.CombineFilePath(ProgramConstants.GamePath, mission.Scenario);
 
             if (!mission.IsCustomMission && File.Exists(scenarioPath))
             {

--- a/DXMainClient/DXGUI/Campaign/CampaignSelector.cs
+++ b/DXMainClient/DXGUI/Campaign/CampaignSelector.cs
@@ -518,17 +518,25 @@ namespace DTAClient.DXGUI.Campaign
 
             if (copyMapsToSpawnmapINI)
             {
-                var mapIni = new IniFile(SafePath.CombineFilePath(ProgramConstants.GamePath, mission.Scenario));
 
-                IniFile.ConsolidateIniFiles(mapIni, difficultyIni);
+                if (mission.Scenario.IndexOfAny(Path.GetInvalidPathChars()) != -1)
+                {
+                    Logger.Log($"CampaignSelector: mission scenario contains invalid path characters. Mission code name: {mission.CodeName}. Scenario: {mission.Scenario}. This mission will be launched without applying {nameof(ClientConfiguration.Instance.CopyMissionsToSpawnmapINI)}.");
+                }
+                else
+                {
+                    var mapIni = new IniFile(SafePath.CombineFilePath(ProgramConstants.GamePath, mission.Scenario));
 
-                foreach (CampaignCheckBox chkBox in CheckBoxes)
-                    chkBox.ApplyMapCode(mapIni, gameMode: null);
+                    IniFile.ConsolidateIniFiles(mapIni, difficultyIni);
 
-                foreach (CampaignDropDown dd in DropDowns)
-                    dd.ApplyMapCode(mapIni, gameMode: null);
+                    foreach (CampaignCheckBox chkBox in CheckBoxes)
+                        chkBox.ApplyMapCode(mapIni, gameMode: null);
 
-                mapIni.WriteIniFile(SafePath.CombineFilePath(ProgramConstants.GamePath, "spawnmap.ini"));
+                    foreach (CampaignDropDown dd in DropDowns)
+                        dd.ApplyMapCode(mapIni, gameMode: null);
+
+                    mapIni.WriteIniFile(SafePath.CombineFilePath(ProgramConstants.GamePath, "spawnmap.ini"));
+                }
             }
 
             UserINISettings.Instance.Difficulty.Value = trbDifficultySelector.Value;
@@ -548,6 +556,13 @@ namespace DTAClient.DXGUI.Campaign
         public static void WriteMissionSectionToSpawnIni(IniFile spawnIni, Mission mission)
         {
             bool hasGameMissionData = false;
+
+            if (mission.Scenario.IndexOfAny(Path.GetInvalidPathChars()) != -1)
+            {
+                Logger.Log($"CampaignSelector: mission scenario contains invalid path characters. Mission code name: {mission.CodeName}. Scenario: {mission.Scenario}. This mission will be launched without mission section data.");
+                return;
+            }
+
             string scenarioPath = SafePath.CombineFilePath(ProgramConstants.GamePath, mission.Scenario);
 
             if (!mission.IsCustomMission && File.Exists(scenarioPath))

--- a/DXMainClient/DXGUI/Campaign/CampaignSelector.cs
+++ b/DXMainClient/DXGUI/Campaign/CampaignSelector.cs
@@ -442,7 +442,7 @@ namespace DTAClient.DXGUI.Campaign
 
             bool copyMapsToSpawnmapINI = ClientConfiguration.Instance.CopyMissionsToSpawnmapINI;
 
-            if (mission.Scenario.IndexOfAny(Path.GetInvalidPathChars()) != -1)
+            if (mission.Scenario.ToWin32FileName() != mission.Scenario)
             {
                 Logger.Log($"CampaignSelector: mission scenario contains invalid path characters. Mission code name: {mission.CodeName}. Scenario: {mission.Scenario}. This mission will be launched without applying {nameof(ClientConfiguration.Instance.CopyMissionsToSpawnmapINI)}.");
                 copyMapsToSpawnmapINI = false;
@@ -555,7 +555,7 @@ namespace DTAClient.DXGUI.Campaign
         {
             bool hasGameMissionData = false;
 
-            if (mission.Scenario.IndexOfAny(Path.GetInvalidPathChars()) != -1)
+            if (mission.Scenario.ToWin32FileName() != mission.Scenario)
             {
                 Logger.Log($"CampaignSelector: mission scenario contains invalid path characters. Mission code name: {mission.CodeName}. Scenario: {mission.Scenario}. This mission will be launched without mission section data.");
                 return;

--- a/DXMainClient/DXGUI/Campaign/CampaignSelector.cs
+++ b/DXMainClient/DXGUI/Campaign/CampaignSelector.cs
@@ -445,7 +445,7 @@ namespace DTAClient.DXGUI.Campaign
 
             if (!scenarioPathFound)
             {
-                Logger.Log($"CampaignSelector: mission scenario contains invalid path characters. Mission code name: {mission.CodeName}. Scenario: {mission.Scenario}. This mission will be launched without applying {nameof(ClientConfiguration.Instance.CopyMissionsToSpawnmapINI)}. Error: {ex.Message}");
+                Logger.Log($"CampaignSelector: mission scenario contains invalid path characters. Mission code name: {mission.CodeName}. Scenario: {mission.Scenario}. This mission will be launched without applying {nameof(ClientConfiguration.Instance.CopyMissionsToSpawnmapINI)}.");
                 copyMapsToSpawnmapINI = false;
             }
 
@@ -559,7 +559,7 @@ namespace DTAClient.DXGUI.Campaign
             bool scenarioPathFound = mission.TryGetScenarioFilePath(out string scenarioPath);
             if (!scenarioPathFound)
             {
-                Logger.Log($"CampaignSelector: mission scenario contains invalid path characters. Mission code name: {mission.CodeName}. Scenario: {mission.Scenario}. This mission will be launched without mission section data. Error: {ex.Message}");
+                Logger.Log($"CampaignSelector: mission scenario contains invalid path characters. Mission code name: {mission.CodeName}. Scenario: {mission.Scenario}. This mission will be launched without mission section data.");
                 return;
             }
 

--- a/DXMainClient/DXGUI/Campaign/CampaignSelector.cs
+++ b/DXMainClient/DXGUI/Campaign/CampaignSelector.cs
@@ -535,7 +535,6 @@ namespace DTAClient.DXGUI.Campaign
                     dd.ApplyMapCode(mapIni, gameMode: null);
 
                 mapIni.WriteIniFile(SafePath.CombineFilePath(ProgramConstants.GamePath, "spawnmap.ini"));
-
             }
 
             UserINISettings.Instance.Difficulty.Value = trbDifficultySelector.Value;

--- a/DXMainClient/DXGUI/Campaign/CampaignSelector.cs
+++ b/DXMainClient/DXGUI/Campaign/CampaignSelector.cs
@@ -441,12 +441,9 @@ namespace DTAClient.DXGUI.Campaign
             bool copyMapsToSpawnmapINI = ClientConfiguration.Instance.CopyMissionsToSpawnmapINI;
 
             string scenario = mission.Scenario;
-            string scenarioPath = null;
-            try
-            {
-                scenarioPath = SafePath.CombineFilePath(ProgramConstants.GamePath, mission.Scenario);
-            }
-            catch (Exception ex)
+            bool scenarioPathFound = mission.TryGetScenarioFilePath(out string scenarioPath);
+
+            if (!scenarioPathFound)
             {
                 Logger.Log($"CampaignSelector: mission scenario contains invalid path characters. Mission code name: {mission.CodeName}. Scenario: {mission.Scenario}. This mission will be launched without applying {nameof(ClientConfiguration.Instance.CopyMissionsToSpawnmapINI)}. Error: {ex.Message}");
                 copyMapsToSpawnmapINI = false;
@@ -559,12 +556,8 @@ namespace DTAClient.DXGUI.Campaign
         {
             bool hasGameMissionData = false;
 
-            string scenarioPath;
-            try
-            {
-                scenarioPath = SafePath.CombineFilePath(ProgramConstants.GamePath, mission.Scenario);
-            }
-            catch (Exception ex)
+            bool scenarioPathFound = mission.TryGetScenarioFilePath(out string scenarioPath);
+            if (!scenarioPathFound)
             {
                 Logger.Log($"CampaignSelector: mission scenario contains invalid path characters. Mission code name: {mission.CodeName}. Scenario: {mission.Scenario}. This mission will be launched without mission section data. Error: {ex.Message}");
                 return;

--- a/DXMainClient/Domain/Mission.cs
+++ b/DXMainClient/Domain/Mission.cs
@@ -85,7 +85,7 @@ namespace DTAClient.Domain
         public int Side { get; private set; }
 
         /// <summary>
-        /// Refers to the map file. Must be a relative path to the game folder. If it contains invalid path characters like '>', the client will treat it as a special scenario that does not have a map file, passing the string directly to the spawner.
+        /// Refers to the map file. Must be a relative path to the game folder. If it contains invalid path characters like '>', the client treats it as a special scenario that does not have a map file, passing the string directly to the spawner.
         /// </summary>
         public string Scenario { get; private set; }
         public string GUIName { get; private set; }

--- a/DXMainClient/Domain/Mission.cs
+++ b/DXMainClient/Domain/Mission.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
+using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -84,7 +85,7 @@ namespace DTAClient.Domain
         public int Side { get; private set; }
 
         /// <summary>
-        /// Refers to the map file. Must be a relative path to the game folder.
+        /// Refers to the map file. Must be a relative path to the game folder. If it contains invalid path characters like ">", the client will treat it as a special scenario that does not have a map file, passing the string directly to the spawner.
         /// </summary>
         public string Scenario { get; private set; }
         public string GUIName { get; private set; }
@@ -109,5 +110,21 @@ namespace DTAClient.Domain
         public IniSection? GameMissionConfigSection { get; set; }
 
         public string PreviewImage { get; private set; }
+
+        public bool TryGetScenarioFilePath(out string scenarioFilePath)
+        {
+            scenarioFilePath = null;
+            if (string.IsNullOrEmpty(Scenario))
+                return false;
+
+            foreach (string segment in Scenario.Split('/', '\\'))
+            {
+                if (string.IsNullOrEmpty(segment) || segment != segment.ToWin32FileName())
+                    return false;
+            }
+
+            scenarioFilePath = SafePath.CombineFilePath(ProgramConstants.GamePath, Scenario);
+            return true;
+        }
     }
 }

--- a/DXMainClient/Domain/Mission.cs
+++ b/DXMainClient/Domain/Mission.cs
@@ -85,7 +85,7 @@ namespace DTAClient.Domain
         public int Side { get; private set; }
 
         /// <summary>
-        /// Refers to the map file. Must be a relative path to the game folder. If it contains invalid path characters like ">", the client will treat it as a special scenario that does not have a map file, passing the string directly to the spawner.
+        /// Refers to the map file. Must be a relative path to the game folder. If it contains invalid path characters like '>', the client will treat it as a special scenario that does not have a map file, passing the string directly to the spawner.
         /// </summary>
         public string Scenario { get; private set; }
         public string GUIName { get; private set; }

--- a/DXMainClient/Domain/Mission.cs
+++ b/DXMainClient/Domain/Mission.cs
@@ -1,10 +1,6 @@
 ﻿using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Diagnostics;
-using System.IO;
-using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 


### PR DESCRIPTION
Currently the client in develop branch crashes in CnCNet YR after integrating custom mission support

This PR skips these features if `scenario` field contains invalid path characters, e.g., '>', which is used for another propose

CnCNet YR:

https://github.com/CnCNet/cncnet-yr-client-package/blob/9c98bed32a12864466870a1c6ccf72addd4913d0/package/INI/Battle.ini

(Also, I intend to leave *this* PR as a draft. Please let *me* merge it in the end no matter what the PR status is)