### PR TITLE
Fix Auto Allying team mappings being ignored by non-hosts in LAN games

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
@@ -302,9 +302,9 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             AddNotice(string.Format("{0} connected from {1}".L10N("Client:Main:PlayerFromIP"), lpInfo.Name, lpInfo.IPAddress));
             lpInfo.StartReceiveLoop();
 
+            OnGameOptionChanged();
             CopyPlayerDataToUI();
             BroadcastPlayerOptions();
-            OnGameOptionChanged();
             BroadcastPlayerExtraOptions();
             UpdateDiscordPresence();
         }

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
@@ -304,8 +304,8 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             CopyPlayerDataToUI();
             BroadcastPlayerOptions();
-            BroadcastPlayerExtraOptions();
             OnGameOptionChanged();
+            BroadcastPlayerExtraOptions();
             UpdateDiscordPresence();
         }
 


### PR DESCRIPTION
When a player joined a LAN lobby, `BroadcastPlayerExtraOptions` was called before `OnGameOptionChanged`. The non-host would apply the host's team start mappings, then they'd get overwritten by the map's built-in preset when processing the game options message. This caused games to start with a different spawn.ini for each player and lead to desyncs in game.
Fixed by swapping the broadcast order so game options arrive before the extra options.