### PR TITLE
Add [RecommendedOptions] section for maps and game modes

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -2482,6 +2482,12 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             foreach (var dd in dropDownListClone)
                 dd.SelectedIndex = dd.HostSelectedIndex;
 
+            ApplyRecommendedCheckBoxOptions(GameMode.RecommendedCheckBoxValues);
+            ApplyRecommendedCheckBoxOptions(Map.RecommendedCheckBoxValues);
+
+            ApplyRecommendedDropDownOptions(GameMode.RecommendedDropDownValues);
+            ApplyRecommendedDropDownOptions(Map.RecommendedDropDownValues);
+
             // Enable all sides by default
             foreach (var ddSide in ddPlayerSides)
             {
@@ -2620,6 +2626,32 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                     dropDown.SelectedIndex = option.Value;
                     dropDown.AllowDropDown = false;
                     optionList.Remove(dropDown);
+                }
+            }
+        }
+
+        private void ApplyRecommendedCheckBoxOptions(List<KeyValuePair<string, bool>> recommendedOptions)
+        {
+            foreach (KeyValuePair<string, bool> option in recommendedOptions)
+            {
+                GameLobbyCheckBox checkBox = CheckBoxes.Find(chk => chk.Name == option.Key);
+                if (checkBox != null)
+                {
+                    checkBox.Checked = option.Value;
+                    checkBox.HostChecked = option.Value;
+                }
+            }
+        }
+
+        private void ApplyRecommendedDropDownOptions(List<KeyValuePair<string, int>> recommendedOptions)
+        {
+            foreach (KeyValuePair<string, int> option in recommendedOptions)
+            {
+                GameLobbyDropDown dropDown = DropDowns.Find(dd => dd.Name == option.Key);
+                if (dropDown != null)
+                {
+                    dropDown.SelectedIndex = option.Value;
+                    dropDown.HostSelectedIndex = option.Value;
                 }
             }
         }

--- a/DXMainClient/Domain/Multiplayer/GameMode.cs
+++ b/DXMainClient/Domain/Multiplayer/GameMode.cs
@@ -67,11 +67,15 @@ namespace DTAClient.Domain.Multiplayer
         private int randomizedMapCodesCount;
 
         private string forcedOptionsSection;
+        private string recommendedOptionsSection;
 
         public List<Map> Maps = new List<Map>();
 
         public List<KeyValuePair<string, bool>> ForcedCheckBoxValues = new List<KeyValuePair<string, bool>>();
         public List<KeyValuePair<string, int>> ForcedDropDownValues = new List<KeyValuePair<string, int>>();
+
+        public List<KeyValuePair<string, bool>> RecommendedCheckBoxValues = new List<KeyValuePair<string, bool>>();
+        public List<KeyValuePair<string, int>> RecommendedDropDownValues = new List<KeyValuePair<string, int>>();
 
         private List<KeyValuePair<string, string>> ForcedSpawnIniOptions = new List<KeyValuePair<string, string>>();
 
@@ -84,6 +88,8 @@ namespace DTAClient.Domain.Multiplayer
             clone.DisallowedComputerPlayerSides = [.. clone.DisallowedComputerPlayerSides];
             clone.ForcedCheckBoxValues = [.. clone.ForcedCheckBoxValues];
             clone.ForcedDropDownValues = [.. clone.ForcedDropDownValues];
+            clone.RecommendedCheckBoxValues = [.. clone.RecommendedCheckBoxValues];
+            clone.RecommendedDropDownValues = [.. clone.RecommendedDropDownValues];
             clone.ForcedSpawnIniOptions = [.. clone.ForcedSpawnIniOptions];
             clone.randomizedMapCodeININames = [.. clone.randomizedMapCodeININames];
 
@@ -106,6 +112,7 @@ namespace DTAClient.Domain.Multiplayer
             MaxPlayersOverride = section.GetIntValueOrNull("MaxPlayersOverride");
 
             forcedOptionsSection = section.GetStringValue("ForcedOptions", string.Empty);
+            recommendedOptionsSection = section.GetStringValue("RecommendedOptions", string.Empty);
             mapCodeININame = section.GetStringValue("MapCodeIniName", section.GetStringValue("MapCodeININame", Name + ".ini"));
             randomizedMapCodeININames = section.GetStringValue("RandomizedMapCodeIniNames", section.GetStringValue("RandomizedMapCodeININames", string.Empty)).Split(',', StringSplitOptions.RemoveEmptyEntries).ToList();
             randomizedMapCodesCount = section.GetIntValue("RandomizedMapCodesCount", 1);
@@ -115,6 +122,8 @@ namespace DTAClient.Domain.Multiplayer
             DisallowedComputerPlayerSides = section.GetListValue("DisallowedComputerPlayerSides", ',', int.Parse);
 
             ParseForcedOptions(forcedOptionsIni);
+
+            ParseRecommendedOptions(forcedOptionsIni);
 
             ParseSpawnIniOptions(forcedOptionsIni);
         }
@@ -142,6 +151,27 @@ namespace DTAClient.Domain.Multiplayer
                 {
                     ForcedCheckBoxValues.Add(new KeyValuePair<string, bool>(key, Conversions.BooleanFromString(value, false)));
                 }
+            }
+        }
+
+        private void ParseRecommendedOptions(IniFile iniFile)
+        {
+            if (string.IsNullOrEmpty(recommendedOptionsSection))
+                return;
+
+            List<string> keys = iniFile.GetSectionKeys(recommendedOptionsSection);
+
+            if (keys == null)
+                return;
+
+            foreach (string key in keys)
+            {
+                string value = iniFile.GetStringValue(recommendedOptionsSection, key, string.Empty);
+
+                if (int.TryParse(value, out int intValue))
+                    RecommendedDropDownValues.Add(new KeyValuePair<string, int>(key, intValue));
+                else
+                    RecommendedCheckBoxValues.Add(new KeyValuePair<string, bool>(key, Conversions.BooleanFromString(value, false)));
             }
         }
 

--- a/DXMainClient/Domain/Multiplayer/Map.cs
+++ b/DXMainClient/Domain/Multiplayer/Map.cs
@@ -206,6 +206,12 @@ namespace DTAClient.Domain.Multiplayer
         [JsonInclude]
         public List<KeyValuePair<string, int>> ForcedDropDownValues = new List<KeyValuePair<string, int>>(0);
 
+        [JsonInclude]
+        public List<KeyValuePair<string, bool>> RecommendedCheckBoxValues = new List<KeyValuePair<string, bool>>(0);
+
+        [JsonInclude]
+        public List<KeyValuePair<string, int>> RecommendedDropDownValues = new List<KeyValuePair<string, int>>(0);
+
         [JsonIgnore]
         private List<ExtraMapPreviewTexture> extraTextures = new List<ExtraMapPreviewTexture>(0);
 
@@ -345,6 +351,15 @@ namespace DTAClient.Domain.Multiplayer
                         ParseForcedOptions(iniFile, foSection);
                 }
 
+                string recommendedOptionsSections = iniFile.GetStringValue(BaseFilePath, "RecommendedOptions", string.Empty);
+
+                if (!string.IsNullOrEmpty(recommendedOptionsSections))
+                {
+                    string[] sections = recommendedOptionsSections.Split(',');
+                    foreach (string roSection in sections)
+                        ParseRecommendedOptions(iniFile, roSection);
+                }
+
                 string forcedSpawnIniOptionsSections = iniFile.GetStringValue(BaseFilePath, "ForcedSpawnIniOptions", string.Empty);
 
                 if (!string.IsNullOrEmpty(forcedSpawnIniOptionsSections))
@@ -429,6 +444,7 @@ namespace DTAClient.Domain.Multiplayer
             customMapIni.AddSection("Map");
             customMapIni.AddSection("Waypoints");
             customMapIni.AddSection("ForcedOptions");
+            customMapIni.AddSection("RecommendedOptions");
             customMapIni.AddSection("ForcedSpawnIniOptions");
 
             // Optionally load preview sections, to accelerate building custom map caches without reading preview.
@@ -537,6 +553,7 @@ namespace DTAClient.Domain.Multiplayer
                 GetTeamStartMappingPresets(basicSection);
 
                 ParseForcedOptions(iniFile, "ForcedOptions");
+                ParseRecommendedOptions(iniFile, "RecommendedOptions");
                 ParseSpawnIniOptions(iniFile, "ForcedSpawnIniOptions");
 
                 ExtraININame = basicSection.GetStringValueOrNull("ExtraIniName") ?? basicSection.GetStringValueOrNull("ExtraININame");
@@ -584,6 +601,24 @@ namespace DTAClient.Domain.Multiplayer
                 {
                     ForcedCheckBoxValues.Add(new KeyValuePair<string, bool>(key, Conversions.BooleanFromString(value, false)));
                 }
+            }
+        }
+
+        private void ParseRecommendedOptions(IniFile iniFile, string recommendedOptionsSection)
+        {
+            List<string> keys = iniFile.GetSectionKeys(recommendedOptionsSection);
+
+            if (keys == null)
+                return;
+
+            foreach (string key in keys)
+            {
+                string value = iniFile.GetStringValue(recommendedOptionsSection, key, string.Empty);
+
+                if (int.TryParse(value, out int intValue))
+                    RecommendedDropDownValues.Add(new KeyValuePair<string, int>(key, intValue));
+                else
+                    RecommendedCheckBoxValues.Add(new KeyValuePair<string, bool>(key, Conversions.BooleanFromString(value, false)));
             }
         }
 


### PR DESCRIPTION
Maps and game modes can now suggest default option values that apply when the map is selected, without locking the controls.

[RecommendedOptions]
chkCrates=true
chkMultiEng=true

Works identically to [ForcedOptions] syntax but leaves checkboxes and dropdowns editable. Values persist when switching to a map that has no recommendation for that option - the last-set value is kept.

Supports both official maps (via MPMaps.ini) and custom maps.

(revival of #643 with the RecommendedOptions as suggested by kerbiter.)