### PR TITLE
Add building auto-detection for map preview overlays and fix incorrect starting locations

### DIFF
--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -95,6 +95,11 @@ namespace ClientCore
             DTACnCNetClient_ini = new IniFile(SafePath.CombineFilePath(ProgramConstants.GetResourcePath(), CLIENT_SETTINGS));
         }
 
+        /// <summary>
+        /// Returns the [AutoMapOverlays] section from ClientDefinitions.ini, or null if absent.
+        /// </summary>
+        public IniSection GetAutoMapOverlaysSection() => clientDefinitionsIni.GetSection("AutoMapOverlays");
+
         #region Client settings
 
         private string _mainMenuMusicName = null;

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MapPreviewBox.cs
@@ -278,6 +278,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         {
             UserINISettings.Instance.DisplayToggleableExtraTextures.Value =
                 !UserINISettings.Instance.DisplayToggleableExtraTextures;
+            UserINISettings.Instance.SaveSettings();
 
             RefreshExtraTexturesBtn();
         }

--- a/DXMainClient/Domain/Multiplayer/AutoMapOverlayDefinition.cs
+++ b/DXMainClient/Domain/Multiplayer/AutoMapOverlayDefinition.cs
@@ -1,0 +1,43 @@
+namespace DTAClient.Domain.Multiplayer
+{
+    /// <summary>
+    /// Defines a building type that is automatically detected in map files
+    /// and rendered as an overlay icon on the map preview.
+    /// Loaded from the [AutoMapOverlays] section of ClientDefinitions.ini.
+    /// Format: BuildingID,ImageFile,OwnerFilter,CellOffsetX,CellOffsetY[,Toggleable]
+    /// </summary>
+    public sealed class AutoMapOverlayDefinition
+    {
+        /// <summary>Building type ID as it appears in [Structures], e.g. "CAOILD".</summary>
+        public string BuildingId { get; }
+
+        /// <summary>Texture file name to render on the preview, e.g. "oilderrick.png".</summary>
+        public string TextureName { get; }
+
+        /// <summary>
+        /// If non-empty, only buildings whose owner matches this string (case-insensitive) are detected.
+        /// Leave empty to detect regardless of owner.
+        /// </summary>
+        public string OwnerFilter { get; }
+
+        /// <summary>Offset added to the building's cell X coordinate when placing the overlay icon.</summary>
+        public int CellOffsetX { get; }
+
+        /// <summary>Offset added to the building's cell Y coordinate when placing the overlay icon.</summary>
+        public int CellOffsetY { get; }
+
+        /// <summary>Whether the overlay icon can be toggled on/off by the user.</summary>
+        public bool Toggleable { get; }
+
+        public AutoMapOverlayDefinition(string buildingId, string textureName, string ownerFilter,
+            int cellOffsetX, int cellOffsetY, bool toggleable)
+        {
+            BuildingId = buildingId;
+            TextureName = textureName;
+            OwnerFilter = ownerFilter;
+            CellOffsetX = cellOffsetX;
+            CellOffsetY = cellOffsetY;
+            Toggleable = toggleable;
+        }
+    }
+}

--- a/DXMainClient/Domain/Multiplayer/IsoMapPackDecoder.cs
+++ b/DXMainClient/Domain/Multiplayer/IsoMapPackDecoder.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+
+using lzo.net;
+
+namespace DTAClient.Domain.Multiplayer
+{
+    /// <summary>
+    /// Decodes IsoMapPack5 tile data from a TS/RA2 map file.
+    /// Extracts the per-cell height (level) values needed for accurate map preview overlay placement.
+    /// </summary>
+    internal static class IsoMapPackDecoder
+    {
+        // 11 bytes per tile: x(int16) y(int16) tileIndex(int32) subTile(byte) level(byte) iceGrowth(byte)
+        private const int TileRecordSize = 11;
+
+        /// <summary>
+        /// Packs isometric tile (x, y) coordinates into a single long key for fast dictionary lookup.
+        /// Both values must fit in a ushort (0–65535), which holds for all practical TS/RA2 map sizes.
+        /// </summary>
+        public static long TileKey(int x, int y) => ((long)(ushort)x << 16) | (ushort)y;
+
+        /// <summary>
+        /// Decodes the concatenated base64 IsoMapPack5 string and returns a dictionary
+        /// from packed tile key (see <see cref="TileKey"/>) to height level.
+        /// Returns an empty dictionary if the input is empty or malformed.
+        /// </summary>
+        public static Dictionary<long, byte> Decode(string base64)
+        {
+            var empty = new Dictionary<long, byte>(0);
+            if (string.IsNullOrEmpty(base64))
+                return empty;
+
+            byte[] compressed;
+            try { compressed = Convert.FromBase64String(base64); }
+            catch { return empty; }
+
+            // First pass: sum all decompressed block sizes so we can allocate one output buffer.
+            // Block header: [inputSize:uint16][outputSize:uint16] — same format as PreviewPack.
+            int totalOutputSize = 0;
+            for (int p = 0; p + 4 <= compressed.Length;)
+            {
+                int inSz  = BitConverter.ToUInt16(compressed, p);
+                int outSz = BitConverter.ToUInt16(compressed, p + 2);
+                if (inSz == 0 || outSz == 0) break;
+                totalOutputSize += outSz;
+                p += 4 + inSz;
+            }
+
+            if (totalOutputSize == 0)
+                return empty;
+
+            // Single allocation for all decompressed data.
+            byte[] data = new byte[totalOutputSize];
+            int writePos = 0;
+
+            // Second pass: decompress each LZO1X block directly into the output buffer.
+            for (int p = 0; p + 4 <= compressed.Length;)
+            {
+                int inSz  = BitConverter.ToUInt16(compressed, p);
+                int outSz = BitConverter.ToUInt16(compressed, p + 2);
+                if (inSz == 0 || outSz == 0) break;
+
+                using var lzoStream = new LzoStream(
+                    new MemoryStream(compressed, p + 4, inSz),
+                    CompressionMode.Decompress);
+
+                int read = 0;
+                while (read < outSz)
+                {
+                    int n = lzoStream.Read(data, writePos + read, outSz - read);
+                    if (n == 0) break;
+                    read += n;
+                }
+                writePos += outSz;
+                p += 4 + inSz;
+            }
+
+            // Parse 11-byte tile records. Level byte is at offset 9 within each record.
+            int tileCount = totalOutputSize / TileRecordSize;
+            var tileLevels = new Dictionary<long, byte>(tileCount);
+            for (int p = 0; p + TileRecordSize <= writePos; p += TileRecordSize)
+            {
+                short x = BitConverter.ToInt16(data, p);
+                short y = BitConverter.ToInt16(data, p + 2);
+                if (x > 0 && y > 0)
+                    tileLevels[TileKey(x, y)] = data[p + 9];
+            }
+
+            return tileLevels;
+        }
+    }
+}

--- a/DXMainClient/Domain/Multiplayer/Map.cs
+++ b/DXMainClient/Domain/Multiplayer/Map.cs
@@ -13,11 +13,11 @@ using ClientCore.Extensions;
 
 using DTAClient.DXGUI.Multiplayer.GameLobby;
 
+using Microsoft.Xna.Framework;
+
 using Rampastring.Tools;
 
-using SixLabors.ImageSharp;
-
-using Point = Microsoft.Xna.Framework.Point;
+using Image = SixLabors.ImageSharp.Image;
 
 namespace DTAClient.Domain.Multiplayer
 {
@@ -185,9 +185,17 @@ namespace DTAClient.Domain.Multiplayer
 
         /// <summary>
         /// The pixel coordinates of the map's player starting locations.
+        /// Always recomputed from waypoints so that WaypointLevels are applied correctly.
         /// </summary>
-        [JsonInclude]
+        [JsonIgnore]
         public List<Point> startingLocations;
+
+        /// <summary>
+        /// Per-waypoint tile height levels decoded from IsoMapPack5.
+        /// Index matches the waypoints list. Null until tile level data has been applied.
+        /// </summary>
+        [JsonIgnore]
+        public int[] WaypointLevels;
 
         [JsonInclude]
         public List<TeamStartMappingPreset> TeamStartMappingPresets = new List<TeamStartMappingPreset>();
@@ -401,16 +409,36 @@ namespace DTAClient.Domain.Multiplayer
             {
                 startingLocations = new List<Point>();
 
-                foreach (string waypoint in waypoints)
+                for (int i = 0; i < waypoints.Count; i++)
                 {
                     if (MainClientConstants.USE_ISOMETRIC_CELLS)
-                        startingLocations.Add(GetIsometricWaypointCoords(waypoint, actualSize, localSize, previewSize));
+                    {
+                        int levelOverride = WaypointLevels != null && i < WaypointLevels.Length
+                            ? WaypointLevels[i]
+                            : -1;
+                        startingLocations.Add(GetIsometricWaypointCoords(waypoints[i], actualSize, localSize, previewSize, levelOverride));
+                    }
                     else
-                        startingLocations.Add(GetTDRAWaypointCoords(waypoint, x, y, width, height, previewSize));
+                    {
+                        startingLocations.Add(GetTDRAWaypointCoords(waypoints[i], x, y, width, height, previewSize));
+                    }
                 }
             }
 
             return startingLocations;
+        }
+
+        /// <summary>
+        /// Applies decoded tile level data to this map.
+        /// Corrects waypoint positions for cliff height and populates auto-detected building overlays.
+        /// </summary>
+        public void ApplyTileLevelData(int[] wpLevels, IReadOnlyList<ExtraMapPreviewTexture> detectedOverlays)
+        {
+            WaypointLevels = wpLevels;
+            startingLocations = null; // force recompute with correct levels
+
+            if (detectedOverlays != null && detectedOverlays.Count > 0)
+                extraTextures.AddRange(detectedOverlays);
         }
 
         public Point MapPointToMapPreviewPoint(Point mapPoint, Point previewSize, int level)
@@ -507,9 +535,6 @@ namespace DTAClient.Domain.Multiplayer
                 {
                     Bases = Convert.ToInt32(Conversions.BooleanFromString(bases, false));
                 }
-
-                localSize = iniFile.GetStringValue("Map", "LocalSize", "0,0,0,0").Split(',');
-                actualSize = iniFile.GetStringValue("Map", "Size", "0,0,0,0").Split(',');
 
                 if (MainClientConstants.USE_ISOMETRIC_CELLS)
                 {
@@ -785,23 +810,38 @@ namespace DTAClient.Domain.Multiplayer
         }
 
         /// <summary>
+        /// Extracts isometric cell (x, y) from the numeric part of a waypoint string (e.g. "102063").
+        /// Last 3 digits are X, the remainder is Y.
+        /// Returns (0, 0) if the string is too short or cannot be parsed.
+        /// </summary>
+        internal static (int x, int y) ParseWaypointCellCoords(string waypointNumStr)
+        {
+            if (waypointNumStr.Length < 4)
+                return (0, 0);
+            int xIdx = waypointNumStr.Length - 3;
+            int y = 0;
+            bool ok = int.TryParse(waypointNumStr.Substring(xIdx), NumberStyles.Integer, CultureInfo.InvariantCulture, out int x) &&
+                      int.TryParse(waypointNumStr.Substring(0, xIdx), NumberStyles.Integer, CultureInfo.InvariantCulture, out y);
+            return ok ? (x, y) : (0, 0);
+        }
+
+        /// <summary>
         /// Converts a waypoint's coordinate string into pixel coordinates on the preview image.
         /// </summary>
+        /// <param name="levelOverride">
+        /// When >= 0, overrides the level from the waypoint string (used when tile level data
+        /// has been decoded from IsoMapPack5). Pass -1 to use the level embedded in the waypoint string.
+        /// </param>
         /// <returns>The waypoint's location on the map preview as a point.</returns>
         private static Point GetIsometricWaypointCoords(string waypoint, string[] actualSizeValues, string[] localSizeValues,
-            Point previewSizePoint)
+            Point previewSizePoint, int levelOverride = -1)
         {
             string[] parts = waypoint.Split(',');
+            var (isoTileX, isoTileY) = ParseWaypointCellCoords(parts[0]);
 
-            int xCoordIndex = parts[0].Length - 3;
-
-            int isoTileY = Convert.ToInt32(parts[0].Substring(0, xCoordIndex), CultureInfo.InvariantCulture);
-            int isoTileX = Convert.ToInt32(parts[0].Substring(xCoordIndex), CultureInfo.InvariantCulture);
-
-            int level = 0;
-
-            if (parts.Length > 1)
-                level = Conversions.IntFromString(parts[1], 0);
+            int level = levelOverride >= 0
+                ? levelOverride
+                : (parts.Length > 1 ? Conversions.IntFromString(parts[1], 0) : 0);
 
             return GetIsoTilePixelCoord(isoTileX, isoTileY, actualSizeValues, localSizeValues, previewSizePoint, level);
         }

--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -10,12 +13,13 @@ using ClientCore;
 using ClientCore.Caching;
 using ClientCore.Extensions;
 
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
 using Rampastring.Tools;
 using Rampastring.XNAUI;
 
-using SixLabors.ImageSharp;
+using Image = SixLabors.ImageSharp.Image;
 
 namespace DTAClient.Domain.Multiplayer
 {
@@ -39,13 +43,22 @@ namespace DTAClient.Domain.Multiplayer
             .Select(version => SafePath.CombineFilePath(ProgramConstants.ClientUserFilesPath, GetCustomMapCacheFileName(version)))
             .ToList();
 
+        private const int CurrentMapTileLevelCacheVersion = 1;
+        private static readonly string MAP_TILE_LEVEL_CACHE = SafePath.CombineFilePath(
+            ProgramConstants.ClientUserFilesPath, $"map_tile_levels_v{CurrentMapTileLevelCacheVersion}");
+
         private const string MultiMapsSection = "MultiMaps";
         private const string GameModesSection = "GameModes";
         private const string GameModeAliasesSection = "GameModeAliases";
         private readonly JsonSerializerOptions jsonSerializerOptions = new JsonSerializerOptions { IncludeFields = true };
         private MapFileWatcher mapFileWatcher;
         private readonly object mapModificationLock = new object();
+        private readonly object tileLevelCacheLock = new object();
         private const int _mapChangeRetryCount = 3;
+
+        private bool _tileLevelSupportLoaded;
+        private IReadOnlyList<AutoMapOverlayDefinition> _autoMapOverlayDefs = Array.Empty<AutoMapOverlayDefinition>();
+        private MapTileLevelCache _mapTileLevelCache;
 
         // Mutable buffer used only during the initial map-loading pass. After
         // LoadMapsInternalAsync publishes the first snapshot, it is set to null
@@ -148,11 +161,15 @@ namespace DTAClient.Domain.Multiplayer
 
             IniFile mpMapsIni = new IniFile(mpMapsPath);
 
+            EnsureTileLevelSupportLoaded();
+
             LoadGameModes(mpMapsIni);
             LoadGameModeAliases(mpMapsIni);
             // LoadMultiMapsAsync and LoadCustomMapsAsync both modify the game mode map collection. We intend to keep the collection non-thread-safe for performance, so the two methods must not be called simultaneously.
-            await LoadMultiMapsAsync(mpMapsIni);
-            await LoadCustomMapsAsync();
+            await LoadMultiMapsAsync(mpMapsIni, _mapTileLevelCache, _autoMapOverlayDefs);
+            await LoadCustomMapsAsync(_mapTileLevelCache, _autoMapOverlayDefs);
+
+            SaveTileLevelCache();
 
             Logger.Log("MapLoader: Post-processing game mode map collections.");
             PublishSnapshot(_initialGameModes);
@@ -221,6 +238,9 @@ namespace DTAClient.Domain.Multiplayer
 
                 if (success && map != null)
                 {
+                    ApplyTileLevelDataToMap(map, _mapTileLevelCache, _autoMapOverlayDefs);
+                    SaveTileLevelCache();
+
                     lock (mapModificationLock)
                     {
                         List<GameMode> gameModeSnapshot = CloneGameModeSnapshot();
@@ -281,6 +301,9 @@ namespace DTAClient.Domain.Multiplayer
 
                 if (success && newMap != null)
                 {
+                    ApplyTileLevelDataToMap(newMap, _mapTileLevelCache, _autoMapOverlayDefs);
+                    SaveTileLevelCache();
+
                     lock (mapModificationLock)
                     {
                         List<GameMode> gameModeSnapshot = CloneGameModeSnapshot();
@@ -331,6 +354,8 @@ namespace DTAClient.Domain.Multiplayer
                 string baseFilePath = GetBaseFilePathFromFullPath(filePath);
                 if (string.IsNullOrEmpty(baseFilePath))
                     return;
+
+                RemoveTileLevelCacheEntry(baseFilePath);
 
                 lock (mapModificationLock)
                 {
@@ -415,7 +440,8 @@ namespace DTAClient.Domain.Multiplayer
 
         private List<GameMode> CloneGameModeSnapshot() => GameModes.Select(gameMode => gameMode.Clone()).ToList();
 
-        private async Task LoadMultiMapsAsync(IniFile mpMapsIni)
+        private async Task LoadMultiMapsAsync(IniFile mpMapsIni, MapTileLevelCache tileLevelCache,
+            IReadOnlyList<AutoMapOverlayDefinition> autoOverlayDefs)
         {
             List<string> keys = mpMapsIni.GetSectionKeys(MultiMapsSection);
 
@@ -442,6 +468,8 @@ namespace DTAClient.Domain.Multiplayer
                     var map = new Map(mapFilePathValue, false);
                     if (!map.InitializeFromMpMapsINI(mpMapsIni))
                         return null;
+
+                    ApplyTileLevelDataToMap(map, tileLevelCache, autoOverlayDefs);
 
                     return map;
                 }
@@ -500,7 +528,8 @@ namespace DTAClient.Domain.Multiplayer
             }
         }
 
-        private async Task LoadCustomMapsAsync()
+        private async Task LoadCustomMapsAsync(MapTileLevelCache tileLevelCache,
+            IReadOnlyList<AutoMapOverlayDefinition> autoOverlayDefs)
         {
             DirectoryInfo customMapsDirectory = SafePath.GetDirectory(ProgramConstants.GamePath, CUSTOM_MAPS_DIRECTORY);
 
@@ -539,16 +568,21 @@ namespace DTAClient.Domain.Multiplayer
                         .Replace(Path.DirectorySeparatorChar, '/')
                         .Replace(Path.AltDirectorySeparatorChar, '/');
 
+                    Map map;
                     if (customMapCache.Items.TryGetValue(normalizedPath, out var cachedItem) && !cachedItem.IsOutdated())
                     {
-                        // Use cached map
-                        return normalizedPath;
+                        map = cachedItem.Map;
+                    }
+                    else
+                    {
+                        // Not in cache or outdated
+                        map = new Map(normalizedPath, true);
+                        if (!map.InitializeFromCustomMap())
+                            return normalizedPath;
+                        customMapCache.Items[normalizedPath] = new CustomMapCache.Item(map);
                     }
 
-                    // Not in cache or outdated
-                    var map = new Map(normalizedPath, true);
-                    if (map.InitializeFromCustomMap())
-                        customMapCache.Items[normalizedPath] = new CustomMapCache.Item(map);
+                    ApplyTileLevelDataToMap(map, tileLevelCache, autoOverlayDefs);
 
                     return normalizedPath;
                 })).ToArray();
@@ -696,6 +730,10 @@ namespace DTAClient.Domain.Multiplayer
 
             if (map.InitializeFromCustomMap())
             {
+                EnsureTileLevelSupportLoaded();
+                ApplyTileLevelDataToMap(map, _mapTileLevelCache, _autoMapOverlayDefs);
+                SaveTileLevelCache();
+
                 lock (mapModificationLock)
                 {
                     List<GameMode> gameModeSnapshot = CloneGameModeSnapshot();
@@ -859,5 +897,329 @@ namespace DTAClient.Domain.Multiplayer
         public Map FindMapByHash(string mapHash) => GameModeMaps?.FindMapByHash(mapHash);
 
         public void Dispose() => mapPreviewCacheManager?.Dispose();
+
+        private void EnsureTileLevelSupportLoaded()
+        {
+            if (_tileLevelSupportLoaded)
+                return;
+
+            lock (tileLevelCacheLock)
+            {
+                if (_tileLevelSupportLoaded)
+                    return;
+
+                _autoMapOverlayDefs = LoadAutoMapOverlayDefinitions();
+
+                _mapTileLevelCache = LoadMapTileLevelCache(_autoMapOverlayDefs);
+                _tileLevelSupportLoaded = true;
+            }
+        }
+
+        private void SaveTileLevelCache()
+        {
+            if (!_tileLevelSupportLoaded || _mapTileLevelCache == null)
+                return;
+
+            lock (tileLevelCacheLock)
+            {
+                SaveMapTileLevelCache(_mapTileLevelCache, _autoMapOverlayDefs);
+            }
+        }
+
+        private void RemoveTileLevelCacheEntry(string baseFilePath)
+        {
+            if (!_tileLevelSupportLoaded || _mapTileLevelCache == null)
+                return;
+
+            string key = NormalizeMapBaseFilePath(baseFilePath);
+            if (_mapTileLevelCache.Items.TryRemove(key, out _))
+                SaveTileLevelCache();
+        }
+
+        /// <summary>
+        /// Loads auto map overlay definitions from the [AutoMapOverlays] section
+        /// of ClientDefinitions.ini.
+        /// Format per entry: BuildingID,ImageFile,OwnerFilter,CellOffsetX,CellOffsetY[,Toggleable]
+        /// </summary>
+        private static IReadOnlyList<AutoMapOverlayDefinition> LoadAutoMapOverlayDefinitions()
+        {
+            IniSection section = ClientConfiguration.Instance.GetAutoMapOverlaysSection();
+            if (section == null)
+                return Array.Empty<AutoMapOverlayDefinition>();
+
+            var defs = new List<AutoMapOverlayDefinition>();
+            foreach (var kvp in section.Keys)
+            {
+                string[] parts = kvp.Value.Split(',');
+                if (parts.Length < 5)
+                {
+                    Logger.Log($"MapLoader: Invalid AutoMapOverlay entry '{kvp.Value}' — expected at least 5 comma-separated fields.");
+                    continue;
+                }
+
+                string buildingId = parts[0].Trim();
+                string textureName = parts[1].Trim();
+                string ownerFilter = parts[2].Trim();
+
+                if (!int.TryParse(parts[3].Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out int offsetX) ||
+                    !int.TryParse(parts[4].Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out int offsetY))
+                {
+                    Logger.Log($"MapLoader: Invalid cell offsets in AutoMapOverlay entry '{kvp.Value}'.");
+                    continue;
+                }
+
+                bool toggleable = parts.Length > 5 && Conversions.BooleanFromString(parts[5].Trim(), false);
+                defs.Add(new AutoMapOverlayDefinition(buildingId, textureName, ownerFilter, offsetX, offsetY, toggleable));
+            }
+            return defs;
+        }
+
+        /// <summary>
+        /// Computes a short hash of the auto overlay config so the tile level cache can be
+        /// invalidated when the building detection configuration changes.
+        /// </summary>
+        private static string ComputeAutoOverlayConfigHash(IReadOnlyList<AutoMapOverlayDefinition> defs)
+        {
+            if (defs.Count == 0)
+                return "empty";
+
+            string repr = string.Join("|", defs.Select(d =>
+                $"{d.BuildingId},{d.TextureName},{d.OwnerFilter},{d.CellOffsetX},{d.CellOffsetY},{d.Toggleable}"));
+
+            using var sha = SHA256.Create();
+            byte[] hash = sha.ComputeHash(Encoding.UTF8.GetBytes(repr));
+            return BitConverter.ToString(hash).Replace("-", string.Empty)[..16];
+        }
+
+        private MapTileLevelCache LoadMapTileLevelCache(IReadOnlyList<AutoMapOverlayDefinition> defs)
+        {
+            var emptyCache = new MapTileLevelCache
+            {
+                Version = CurrentMapTileLevelCacheVersion,
+                ConfigHash = ComputeAutoOverlayConfigHash(defs),
+                Items = []
+            };
+
+            try
+            {
+                if (!File.Exists(MAP_TILE_LEVEL_CACHE))
+                    return emptyCache;
+
+                string json = File.ReadAllText(MAP_TILE_LEVEL_CACHE);
+                var cache = JsonSerializer.Deserialize<MapTileLevelCache>(json, jsonSerializerOptions);
+
+                if (cache == null ||
+                    cache.Version != CurrentMapTileLevelCacheVersion ||
+                    cache.ConfigHash != emptyCache.ConfigHash)
+                {
+                    return emptyCache;
+                }
+
+                return cache;
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"MapLoader: Failed to load tile level cache: {ex.Message}");
+                return emptyCache;
+            }
+        }
+
+        private static string NormalizeMapBaseFilePath(string baseFilePath)
+            => baseFilePath
+                .Replace(Path.DirectorySeparatorChar, '/')
+                .Replace(Path.AltDirectorySeparatorChar, '/');
+
+        private void SaveMapTileLevelCache(MapTileLevelCache cache, IReadOnlyList<AutoMapOverlayDefinition> defs)
+        {
+            try
+            {
+                // Ensure config hash is current before saving
+                cache.ConfigHash = ComputeAutoOverlayConfigHash(defs);
+                string json = JsonSerializer.Serialize(cache, jsonSerializerOptions);
+                File.WriteAllText(MAP_TILE_LEVEL_CACHE, json);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"MapLoader: Failed to save tile level cache: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Checks the tile level cache for this map. If absent or stale, decodes IsoMapPack5
+        /// from the map file and runs building detection. Applies the result to the map object.
+        /// </summary>
+        private void ApplyTileLevelDataToMap(Map map, MapTileLevelCache tileLevelCache,
+            IReadOnlyList<AutoMapOverlayDefinition> autoOverlayDefs)
+        {
+            if (!MainClientConstants.USE_ISOMETRIC_CELLS)
+                return;
+
+            string key = NormalizeMapBaseFilePath(map.BaseFilePath);
+
+            if (tileLevelCache.Items.TryGetValue(key, out var cached) && !cached.IsOutdated(map.CompleteFilePath))
+            {
+                map.ApplyTileLevelData(cached.WaypointLevels, cached.BuildingOverlays);
+                return;
+            }
+
+            var item = ComputeTileLevelItem(map, autoOverlayDefs);
+            if (item != null)
+            {
+                tileLevelCache.Items[key] = item;
+                map.ApplyTileLevelData(item.WaypointLevels, item.BuildingOverlays);
+            }
+        }
+
+        /// <summary>
+        /// Reads a map file in one pass and returns the raw base64 IsoMapPack5 string and the
+        /// raw value lines from [Structures] (everything after the '=' on each line).
+        /// </summary>
+        private static (string isoBase64, List<string> structureValues) ReadMapSectionsFromFile(string filePath)
+        {
+            var isoSb = new StringBuilder(32 * 1024);
+            var structureValues = new List<string>(128);
+
+            bool inIso = false, inStructures = false;
+
+            using var reader = new StreamReader(filePath,
+                System.Text.Encoding.GetEncoding(1252),
+                detectEncodingFromByteOrderMarks: true,
+                bufferSize: 65536);
+
+            string line;
+            while ((line = reader.ReadLine()) != null)
+            {
+                if (line.Length == 0 || line[0] == ';')
+                    continue;
+
+                if (line[0] == '[')
+                {
+                    inIso        = line.Equals("[IsoMapPack5]",  StringComparison.OrdinalIgnoreCase);
+                    inStructures = line.Equals("[Structures]",   StringComparison.OrdinalIgnoreCase);
+                    continue;
+                }
+
+                if (inIso)
+                {
+                    int eq = line.IndexOf('=');
+                    if (eq >= 0) isoSb.Append(line, eq + 1, line.Length - eq - 1);
+                }
+                else if (inStructures)
+                {
+                    int eq = line.IndexOf('=');
+                    if (eq >= 0) structureValues.Add(line.Substring(eq + 1));
+                }
+            }
+
+            return (isoSb.ToString(), structureValues);
+        }
+
+        /// <summary>
+        /// Decodes IsoMapPack5 from the map file and computes tile level data:
+        /// waypoint heights and auto-detected building overlays.
+        /// Returns null on failure.
+        /// </summary>
+        private MapTileLevelCache.Item ComputeTileLevelItem(Map map,
+            IReadOnlyList<AutoMapOverlayDefinition> defs)
+        {
+            try
+            {
+                var (isoBase64, structureValues) = ReadMapSectionsFromFile(map.CompleteFilePath);
+
+                var tileLevels = IsoMapPackDecoder.Decode(isoBase64);
+
+                // Waypoint levels
+                int[] waypointLevels = null;
+                if (map.waypoints.Count > 0)
+                {
+                    waypointLevels = new int[map.waypoints.Count];
+                    for (int i = 0; i < map.waypoints.Count; i++)
+                    {
+                        var (wx, wy) = Map.ParseWaypointCellCoords(map.waypoints[i].Split(',')[0]);
+                        waypointLevels[i] = tileLevels.TryGetValue(IsoMapPackDecoder.TileKey(wx, wy), out byte lv) ? lv : 0;
+                    }
+                }
+
+                // Building overlays
+                var buildingOverlays = DetectBuildingOverlays(structureValues, tileLevels, defs);
+
+                var fi = new FileInfo(map.CompleteFilePath);
+                return new MapTileLevelCache.Item(fi.Length, fi.LastWriteTimeUtc, waypointLevels, buildingOverlays);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"MapLoader: Failed to decode tile levels for {map.BaseFilePath}: {ex.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Scans the raw [Structures] value lines for buildings matching the auto-overlay definitions
+        /// and returns ExtraMapPreviewTexture entries with the tile height level applied.
+        /// </summary>
+        private static List<ExtraMapPreviewTexture> DetectBuildingOverlays(
+            List<string> structureValues,
+            Dictionary<long, byte> tileLevels,
+            IReadOnlyList<AutoMapOverlayDefinition> defs)
+        {
+            var result = new List<ExtraMapPreviewTexture>();
+            if (structureValues.Count == 0 || defs.Count == 0)
+                return result;
+
+            // Split defs into exact-match dictionary and prefix-wildcard list.
+            // A BuildingId ending with '*' matches any ID starting with that prefix.
+            var exactDefs = new Dictionary<string, AutoMapOverlayDefinition>(StringComparer.OrdinalIgnoreCase);
+            var wildcardDefs = new List<(string Prefix, AutoMapOverlayDefinition Def)>();
+            foreach (var def in defs)
+            {
+                if (def.BuildingId.EndsWith("*"))
+                    wildcardDefs.Add((def.BuildingId.TrimEnd('*'), def));
+                else if (!exactDefs.ContainsKey(def.BuildingId))
+                    exactDefs[def.BuildingId] = def;
+            }
+
+            foreach (string value in structureValues)
+            {
+                // Format: Owner,BuildingTypeID,Health,X,Y,...
+                string[] parts = value.Split(',');
+                if (parts.Length < 5)
+                    continue;
+
+                string owner      = parts[0].Trim();
+                string buildingId = parts[1].Trim();
+
+                AutoMapOverlayDefinition def = null;
+                if (!exactDefs.TryGetValue(buildingId, out def))
+                {
+                    foreach (var (prefix, wildcardDef) in wildcardDefs)
+                    {
+                        if (buildingId.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                        {
+                            def = wildcardDef;
+                            break;
+                        }
+                    }
+                }
+
+                if (def == null)
+                    continue;
+
+                if (!string.IsNullOrEmpty(def.OwnerFilter) &&
+                    !string.Equals(owner, def.OwnerFilter, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                if (!int.TryParse(parts[3].Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out int x) ||
+                    !int.TryParse(parts[4].Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out int y))
+                    continue;
+
+                int cellX = x + def.CellOffsetX;
+                int cellY = y + def.CellOffsetY;
+                byte level = tileLevels.TryGetValue(IsoMapPackDecoder.TileKey(cellX, cellY), out byte lv) ? lv : (byte)0;
+
+                result.Add(new ExtraMapPreviewTexture(def.TextureName, new Point(cellX, cellY), level, def.Toggleable));
+            }
+
+            return result;
+        }
     }
 }

--- a/DXMainClient/Domain/Multiplayer/MapTileLevelCache.cs
+++ b/DXMainClient/Domain/Multiplayer/MapTileLevelCache.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json.Serialization;
+
+namespace DTAClient.Domain.Multiplayer
+{
+    /// <summary>
+    /// Persistent cache of per-map tile height data decoded from IsoMapPack5.
+    /// Covers both official and custom maps, keyed by normalized BaseFilePath.
+    /// Separate from CustomMapCache — stores only the height data needed for
+    /// accurate preview overlay and starting-position placement.
+    /// </summary>
+    public class MapTileLevelCache
+    {
+        [JsonInclude]
+        [JsonPropertyName("version")]
+        public required int Version { get; set; }
+
+        /// <summary>
+        /// Short hash of the [AutoMapOverlays] config. If this changes all entries are discarded
+        /// so the building detection is re-run with the new definitions.
+        /// </summary>
+        [JsonInclude]
+        [JsonPropertyName("configHash")]
+        public required string ConfigHash { get; set; }
+
+        [JsonInclude]
+        [JsonPropertyName("maps")]
+        public required ConcurrentDictionary<string, Item> Items { get; set; }
+
+        public sealed class Item
+        {
+            [JsonInclude]
+            public long FileSize { get; init; }
+
+            [JsonInclude]
+            public DateTime LastWriteTimeUtc { get; init; }
+
+            /// <summary>
+            /// Tile height level for each waypoint, indexed to match the map's waypoints list.
+            /// Null if the map is non-isometric or has no waypoints.
+            /// </summary>
+            [JsonInclude]
+            public int[] WaypointLevels { get; init; }
+
+            /// <summary>
+            /// Auto-detected building overlays including the height level at each building's cell.
+            /// Stored as cell coordinates (converted to preview pixels at render time).
+            /// </summary>
+            [JsonInclude]
+            public List<ExtraMapPreviewTexture> BuildingOverlays { get; init; }
+
+            [JsonConstructor]
+            public Item() { }
+
+            public Item(long fileSize, DateTime lastWriteTimeUtc,
+                int[] waypointLevels, List<ExtraMapPreviewTexture> buildingOverlays)
+            {
+                FileSize = fileSize;
+                LastWriteTimeUtc = lastWriteTimeUtc;
+                WaypointLevels = waypointLevels;
+                BuildingOverlays = buildingOverlays;
+            }
+
+            public bool IsOutdated(string completeFilePath)
+            {
+                var fi = new FileInfo(completeFilePath);
+                return !fi.Exists || fi.Length != FileSize || fi.LastWriteTimeUtc != LastWriteTimeUtc;
+            }
+        }
+    }
+}

--- a/Docs/INISystem.md
+++ b/Docs/INISystem.md
@@ -904,6 +904,38 @@ Maps can specify an extra INI file to consolidate into the map's INI at game lau
 ExtraIniName=MyExtraCode.ini  ; filename in `INI/Map Code/` to consolidate into the map INI
 ```
 
+### Map Preview Overlays
+
+Map previews support both manually placed overlay icons and automatically detected building overlays.
+
+Manual overlays are defined per map in `MPMaps.ini`:
+
+```ini
+[MAP_NAME]
+ExtraTexture0=oilderrick.png,200,150
+ExtraTexture1=techairport.png,260,180,2,true
+```
+
+`ExtraTextureN` format:
+- `ImageFile,X,Y[,Level][,Toggleable]`
+- `Level` is optional and defaults to `0`. For isometric maps, set this when the icon belongs on raised terrain so the preview position remains correct.
+- `Toggleable` is optional and defaults to `false`. Toggleable icons respect the user's `DisplayToggleableExtraTextures` setting.
+
+Automatic building overlays are configured globally in `ClientDefinitions.ini`:
+
+```ini
+[AutoMapOverlays]
+0=CAOILD,oilderrick.png,Neutral,0,0,true
+1=TECH*,techbuilding.png,,0,0
+```
+
+`[AutoMapOverlays]` entry format:
+- `BuildingID,ImageFile,OwnerFilter,CellOffsetX,CellOffsetY[,Toggleable]`
+- `BuildingID` may end with `*` to match any building ID with that prefix.
+- `OwnerFilter` can be left empty to match any owner.
+- `CellOffsetX` and `CellOffsetY` shift the detected building cell before placing the preview icon, which is useful for better centering of overlays.
+- `Toggleable` is optional and defaults to `false`.
+
 ## GameOptions
 
 The `GameOptions.ini` file defines sides, random selectors, multiplayer colors, and forced spawn options.


### PR DESCRIPTION
Adds automatic detection of building for overlays on the map preview. These are defined in `ClientDefinitions.ini`:
```ini
[AutoMapOverlays]
;BuildingID,ImageFile,OwnerFilter,CellOffsetX,CellOffsetY[,Toggleable]
0=CAOILD*,oilderrick.png,Neutral,1,1,true
1=CAAIRP,airport.png,Neutral,1,1,true
```

To do it properly we need to read IsoMapPack to get the building's level, otherwise the overlays will be offset if the buildings are on cliffs. Because we're reading IsoMapPack, we can also fix the issue where starting locations are incorrect due to cliffs. 

Adds a new cache `map_tile_levels_v1` shared across official and custom maps. Invalidated with size+last write time.
Performance wise, we directly scan the maps for IsoMapPack5 and Structures. It takes about 11 seconds to build a cache for 6,000 maps on my system. No noticeable impact on startup time once cached.

The building ID allows for a wildcard. Some blitz maps for example have several types of oils so you can catch all with `CAOILD*`:
```ini
[CAOILD]
[CAOILD1]
...
[CAOILD6]
```

You can also specify an owner. So setting to `Neutral` would ignore pre-captured oils, and you'd only get overlays on capturable ones.

The tile offset parameters help with centering the overlay better on the building - but the whole centering thing probably needs a second look. The info might already be available without needing to manually specify it.

I still need to test downloaded/sharing maps.

And note we can't get it perfect for every map. Some previews are just incorrectly scaled (not our fault) - all the main ones shipped in YR seem OK, or at least within range.

CC: #775 

<img width="625" height="568" alt="image" src="https://github.com/user-attachments/assets/95ecc0f6-34ed-4088-ad5a-382a5f245ef0" />

<img width="1372" height="505" alt="techToggle" src="https://github.com/user-attachments/assets/f360102a-6e24-4fc7-8d0b-1b9c22742040" />
