### PR TITLE
Set default font renderings parameters for good quality

### DIFF
--- a/DXMainClient/Resources/DTA/Fonts.ini
+++ b/DXMainClient/Resources/DTA/Fonts.ini
@@ -4,9 +4,9 @@ EnableBiDi=true
 CacheSize=100
 
 [FontRendering]
-KernelWidth=2
-KernelHeight=2
-FontResolutionFactor=3
+KernelWidth=4
+KernelHeight=4
+FontResolutionFactor=5
 
 [Fonts]
 Count=3

--- a/DXMainClient/Resources/DTA/Fonts.ini
+++ b/DXMainClient/Resources/DTA/Fonts.ini
@@ -13,7 +13,7 @@ Count=3
 
 [Font0]
 Path=Fonts/Roboto_SemiCondensed-Medium.ttf
-Size=12
+Size=13
 Type=TrueType
 Fallback=2
 

--- a/Docs/Fonts.md
+++ b/Docs/Fonts.md
@@ -73,12 +73,12 @@ Size=18
 ; Optional section. Advanced FontStashSharp rasterization settings.
 ; All properties are optional; the defaults shown here are used when the section is absent.
 ; Horizontal blur kernel applied to each rasterized glyph. Default: 0 (no blur)
-KernelWidth=0
+KernelWidth=4
 ; Vertical blur kernel applied to each rasterized glyph. Default: 0 (no blur)
-KernelHeight=0
+KernelHeight=4
 ; Multiplier for the glyph rasterization size. Values > 1 produce sharper output when the
 ; render target is upscaled at the cost of a larger texture atlas. Default: 1
-FontResolutionFactor=1
+FontResolutionFactor=5
 ; Width of each FontStashSharp atlas page in pixels. Default: 1024
 TextureWidth=1024
 ; Height of each FontStashSharp atlas page in pixels. Default: 1024
@@ -115,9 +115,9 @@ Font paths are relative to the directory containing `Fonts.ini`. Both `/` and `\
 
 | Property | Default | Description |
 |----------|---------|-------------|
-| `KernelWidth` | `0` | Horizontal blur kernel size applied by FontStashSharp when rasterizing glyphs. Must be non-negative. |
-| `KernelHeight` | `0` | Vertical blur kernel size. Must be non-negative. |
-| `FontResolutionFactor` | `1` | Multiplier for the internal glyph rasterization size. Values above `1` produce sharper output at the cost of a larger atlas. Must be non-negative. |
+| `KernelWidth` | `4` | Horizontal blur kernel size applied by FontStashSharp when rasterizing glyphs. Must be non-negative. |
+| `KernelHeight` | `4` | Vertical blur kernel size. Must be non-negative. |
+| `FontResolutionFactor` | `5` | Multiplier for the internal glyph rasterization size. Values above `1` produce sharper output at the cost of a larger atlas. Must be non-negative. |
 | `TextureWidth` | `1024` | Width of each FontStashSharp atlas page in pixels. |
 | `TextureHeight` | `1024` | Height of each FontStashSharp atlas page in pixels. |
 | `GlyphRenderResult` | `Premultiplied` | How glyph alpha is encoded: `Premultiplied` (matches a premultiplied-alpha `SpriteBatch`), `NonPremultiplied` (matches `AlphaBlend`), or `NoAntialiasing` (hard 1-bit edges for pixel-art fonts). |


### PR DESCRIPTION
# BEFORE: 12P 2 - 2 - 3
<img width="1442" height="932" alt="Screenshot 2026-06-14 012805" src="https://github.com/user-attachments/assets/d1e1f526-b951-4c5d-82ef-f3079cd27fe0" />
<img width="2128" height="1229" alt="Screenshot 2026-06-14 013655" src="https://github.com/user-attachments/assets/3fe076bc-32c2-4ffd-a6ef-975bc063d0ac" />

# AFTER: 13P 4 - 4 - 5

<img width="1442" height="932" alt="Screenshot 2026-06-14 013258" src="https://github.com/user-attachments/assets/7e3d4129-0e4e-431d-89fd-99a6953b9ffb" />
<img width="2125" height="1224" alt="image" src="https://github.com/user-attachments/assets/679780a5-c3a5-4dda-990b-ca53c9c6d8e5" />
