### PR TITLE
Add EnforceMinPlayers option and ClientMinPlayer key

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
@@ -833,22 +833,25 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                         return;
                     }
                 }
+            }
 
-                int totalPlayerCount = Players.Count(p => p.SideId < ddPlayerSides[0].Items.Count - 1)
-                    + AIPlayers.Count;
+            int totalPlayerCount = Players.Count(p => p.SideId < ddPlayerSides[0].Items.Count - 1)
+                + AIPlayers.Count;
 
+            if (GameModeMap.EnforceMinPlayers)
+            {
                 int minPlayers = GameModeMap.MinPlayers;
                 if (totalPlayerCount < minPlayers)
                 {
                     InsufficientPlayersNotification();
                     return;
                 }
+            }
 
-                if (GameModeMap.EnforceMaxPlayers && totalPlayerCount > GameModeMap.MaxPlayers)
-                {
-                    TooManyPlayersNotification();
-                    return;
-                }
+            if (GameModeMap.EnforceMaxPlayers && totalPlayerCount > GameModeMap.MaxPlayers)
+            {
+                TooManyPlayersNotification();
+                return;
             }
 
             int iId = 0;

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/SkirmishLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/SkirmishLobby.cs
@@ -121,7 +121,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                     GameModeMap.ToString());
             }
 
-            if (totalPlayerCount < GameModeMap.MinPlayers)
+            if (GameModeMap.EnforceMinPlayers && totalPlayerCount < GameModeMap.MinPlayers)
             {
                 return string.Format("{0} cannot be played with less than {1} players.".L10N("Client:Main:GameModeInsufficientPlayers"),
                     GameModeMap.ToString(), GameModeMap.MinPlayers);

--- a/DXMainClient/Domain/Multiplayer/GameModeMap.cs
+++ b/DXMainClient/Domain/Multiplayer/GameModeMap.cs
@@ -61,6 +61,9 @@ namespace DTAClient.Domain.Multiplayer
         public bool EnforceMaxPlayers =>
             Map.EnforceMaxPlayers ?? GameMode.EnforceMaxPlayers ?? false;
 
+        public bool EnforceMinPlayers =>
+            Map.EnforceMinPlayers ?? GameMode.EnforceMinPlayers ?? false;
+
         public bool ForceNoTeams =>
             Map.ForceNoTeams ?? GameMode.ForceNoTeams ?? false;
 

--- a/DXMainClient/Domain/Multiplayer/GameModeMap.cs
+++ b/DXMainClient/Domain/Multiplayer/GameModeMap.cs
@@ -59,10 +59,10 @@ namespace DTAClient.Domain.Multiplayer
             Map.CoopInfo ?? GameMode.CoopInfo ?? null;
 
         public bool EnforceMaxPlayers =>
-            Map.EnforceMaxPlayers ?? GameMode.EnforceMaxPlayers ?? false;
+            Map.EnforceMaxPlayers ?? GameMode.EnforceMaxPlayers ?? IsCoop;
 
         public bool EnforceMinPlayers =>
-            Map.EnforceMinPlayers ?? GameMode.EnforceMinPlayers ?? false;
+            Map.EnforceMinPlayers ?? GameMode.EnforceMinPlayers ?? IsCoop;
 
         public bool ForceNoTeams =>
             Map.ForceNoTeams ?? GameMode.ForceNoTeams ?? false;

--- a/DXMainClient/Domain/Multiplayer/GameModeMapBase.cs
+++ b/DXMainClient/Domain/Multiplayer/GameModeMapBase.cs
@@ -93,7 +93,10 @@ namespace DTAClient.Domain.Multiplayer
         protected void InitializeBaseSettingsFromIniSection(IniSection section, bool isCustomMap)
         {
             // MinPlayers
-            MinPlayers = section.GetIntValueOrNull(isCustomMap ? "MinPlayer" : "MinPlayers");
+            if (isCustomMap)
+                MinPlayers = section.GetIntValueOrNull("ClientMinPlayer") ?? section.GetIntValueOrNull("MinPlayer");
+            else
+                MinPlayers = section.GetIntValueOrNull("MinPlayers");
 
             // MaxPlayers
             if (isCustomMap)

--- a/DXMainClient/Domain/Multiplayer/GameModeMapBase.cs
+++ b/DXMainClient/Domain/Multiplayer/GameModeMapBase.cs
@@ -96,10 +96,7 @@ namespace DTAClient.Domain.Multiplayer
             MinPlayers = section.GetIntValueOrNull("ClientMinPlayer") ?? section.GetIntValueOrNull(isCustomMap ? "MinPlayer" : "MinPlayers");
 
             // MaxPlayers
-            if (isCustomMap)
-                MaxPlayers = section.GetIntValueOrNull("ClientMaxPlayer") ?? section.GetIntValueOrNull("MaxPlayer");
-            else
-                MaxPlayers = section.GetIntValueOrNull("MaxPlayers");
+            MaxPlayers = section.GetIntValueOrNull("ClientMaxPlayer") ?? section.GetIntValueOrNull(isCustomMap ? "MaxPlayer" : "MaxPlayers");
 
             // EnforceMaxPlayers
             EnforceMaxPlayers = section.GetBooleanValueOrNull("EnforceMaxPlayers");

--- a/DXMainClient/Domain/Multiplayer/GameModeMapBase.cs
+++ b/DXMainClient/Domain/Multiplayer/GameModeMapBase.cs
@@ -37,6 +37,14 @@ namespace DTAClient.Domain.Multiplayer
         public bool? EnforceMaxPlayers { get; private set; }
 
         /// <summary>
+        /// Whether to enforce the minimum player count of the map or a game mode.
+        /// If false (which is the default), MinPlayers is ignored and the game
+        /// can be launched with fewer players.
+        /// </summary>
+        [JsonInclude]
+        public bool? EnforceMinPlayers { get; private set; }
+
+        /// <summary>
         /// The allowed starting locations for this map or game mode.
         /// </summary>
         [JsonInclude]
@@ -95,6 +103,9 @@ namespace DTAClient.Domain.Multiplayer
 
             // EnforceMaxPlayers
             EnforceMaxPlayers = section.GetBooleanValueOrNull("EnforceMaxPlayers");
+
+            // EnforceMinPlayers
+            EnforceMinPlayers = section.GetBooleanValueOrNull("EnforceMinPlayers");
 
             // AllowedStartingLocations
             List<int>? rawAllowedStartingLocations = section.GetListValueOrNull<int>("AllowedStartingLocations", ',', int.Parse);

--- a/DXMainClient/Domain/Multiplayer/GameModeMapBase.cs
+++ b/DXMainClient/Domain/Multiplayer/GameModeMapBase.cs
@@ -93,10 +93,7 @@ namespace DTAClient.Domain.Multiplayer
         protected void InitializeBaseSettingsFromIniSection(IniSection section, bool isCustomMap)
         {
             // MinPlayers
-            if (isCustomMap)
-                MinPlayers = section.GetIntValueOrNull("ClientMinPlayer") ?? section.GetIntValueOrNull("MinPlayer");
-            else
-                MinPlayers = section.GetIntValueOrNull("MinPlayers");
+            MinPlayers = section.GetIntValueOrNull("ClientMinPlayer") ?? section.GetIntValueOrNull(isCustomMap ? "MinPlayer" : "MinPlayers");
 
             // MaxPlayers
             if (isCustomMap)

--- a/DXMainClient/Domain/Multiplayer/GameModeMapBase.cs
+++ b/DXMainClient/Domain/Multiplayer/GameModeMapBase.cs
@@ -30,7 +30,7 @@ namespace DTAClient.Domain.Multiplayer
 
         /// <summary>
         /// Whether to use MaxPlayers for limiting the player count of the map or a game mode.
-        /// If false (which is the default), MaxPlayers is only used for randomizing
+        /// If false, MaxPlayers is only used for randomizing
         /// players to starting waypoints.
         /// </summary>
         [JsonInclude]
@@ -38,7 +38,7 @@ namespace DTAClient.Domain.Multiplayer
 
         /// <summary>
         /// Whether to enforce the minimum player count of the map or a game mode.
-        /// If false (which is the default), MinPlayers is ignored and the game
+        /// If false, MinPlayers is ignored and the game
         /// can be launched with fewer players.
         /// </summary>
         [JsonInclude]

--- a/DXMainClient/Domain/Multiplayer/GameModeMapBase.cs
+++ b/DXMainClient/Domain/Multiplayer/GameModeMapBase.cs
@@ -93,10 +93,10 @@ namespace DTAClient.Domain.Multiplayer
         protected void InitializeBaseSettingsFromIniSection(IniSection section, bool isCustomMap)
         {
             // MinPlayers
-            MinPlayers = section.GetIntValueOrNull("ClientMinPlayer") ?? section.GetIntValueOrNull(isCustomMap ? "MinPlayer" : "MinPlayers");
+            MinPlayers = section.GetIntValueOrNull("ClientMinPlayer") ?? section.GetIntValueOrNull("MinPlayers") ?? section.GetIntValueOrNull("MinPlayer");
 
             // MaxPlayers
-            MaxPlayers = section.GetIntValueOrNull("ClientMaxPlayer") ?? section.GetIntValueOrNull(isCustomMap ? "MaxPlayer" : "MaxPlayers");
+            MaxPlayers = section.GetIntValueOrNull("ClientMaxPlayer") ?? section.GetIntValueOrNull("MaxPlayers") ?? section.GetIntValueOrNull("MaxPlayer");
 
             // EnforceMaxPlayers
             EnforceMaxPlayers = section.GetBooleanValueOrNull("EnforceMaxPlayers");

--- a/DXMainClient/Domain/Multiplayer/IGameModeMap.cs
+++ b/DXMainClient/Domain/Multiplayer/IGameModeMap.cs
@@ -9,6 +9,7 @@ namespace DTAClient.Domain.Multiplayer
         public int CoopDifficultyLevel { get; }
         public CoopMapInfo? CoopInfo { get; }
         public bool EnforceMaxPlayers { get; }
+        public bool EnforceMinPlayers { get; }
         public bool ForceNoTeams { get; }
         public bool ForceRandomStartLocations { get; }
         public bool HumanPlayersOnly { get; }

--- a/Docs/INISystem.md
+++ b/Docs/INISystem.md
@@ -864,9 +864,11 @@ The following properties are shared between maps (in `MPMaps.ini` map sections) 
 ```ini
 ; Map section keys:
 [MAP_NAME]
-MinPlayer=                            ; integer,  minimum player count.
+ClientMinPlayer=                      ; integer,  minimum player count (client-side).
+MinPlayer=                            ; integer,  minimum player count (game-side).
 ClientMaxPlayer=                      ; integer,  maximum player count (client-side).
 MaxPlayer=                            ; integer,  maximum player count (game-side).
+EnforceMinPlayers=                    ; boolean,  whether MinPlayer is enforced.
 EnforceMaxPlayers=                    ; boolean,  whether MaxPlayer is enforced.
 AllowedStartingLocations=             ; comma-separated integers,
                                       ;           restricts which starting locations can be used.
@@ -881,6 +883,7 @@ CoopDifficultyLevel=                  ; integer,  co-op difficulty override.
 [GAME_MODE]
 MinPlayers=                           ; integer,  minimum player count.
 MaxPlayers=                           ; integer,  maximum player count.
+EnforceMinPlayers=                    ; boolean,  whether MinPlayers is enforced.
 EnforceMaxPlayers=                    ; boolean,  whether MaxPlayers is enforced.
 AllowedStartingLocations=             ; comma-separated integers.
 IsCoopMission=                        ; boolean,  marks the mode as co-op.
@@ -892,8 +895,8 @@ CoopDifficultyLevel=                  ; integer,  co-op difficulty override.
 ```
 
 Priority resolution for player counts:
-- `MaxPlayers`: `GameMode.MaxPlayersOverride` > `Map.MaxPlayer` > `GameMode.MaxPlayers`
-- `MinPlayers`: `GameMode.MinPlayersOverride` > `Map.MinPlayer` > `GameMode.MinPlayers`
+- `MaxPlayers`: `GameMode.MaxPlayersOverride` > `Map.ClientMaxPlayer` > `Map.MaxPlayer` > `GameMode.MaxPlayers`
+- `MinPlayers`: `GameMode.MinPlayersOverride` > `Map.ClientMinPlayer` > `Map.MinPlayer` > `GameMode.MinPlayers`
 
 ### Map Extra INI
 

--- a/Docs/INISystem.md
+++ b/Docs/INISystem.md
@@ -864,14 +864,11 @@ The following properties are shared between maps (in `MPMaps.ini` map sections) 
 ```ini
 ; Map section keys:
 [MAP_NAME]
-ClientMinPlayer=                      ; integer,  minimum player count (client-side).
-MinPlayer=                            ; integer,  minimum player count (game-side).
-ClientMaxPlayer=                      ; integer,  maximum player count (client-side).
-MaxPlayer=                            ; integer,  maximum player count (game-side).
-EnforceMinPlayers=                    ; boolean,  whether MinPlayer is enforced.
-EnforceMaxPlayers=                    ; boolean,  whether MaxPlayer is enforced.
-AllowedStartingLocations=             ; comma-separated integers,
-                                      ;           restricts which starting locations can be used.
+ClientMinPlayer=                      ; integer,  minimum player count (client-side). The following alternative key names are also supported: `MinPlayers`, `MinPlayer`.
+ClientMaxPlayer=                      ; integer,  maximum player count (client-side). The following alternative key names are also supported: `MaxPlayers`, `MaxPlayer`.
+EnforceMinPlayers=                    ; boolean,  whether minimum player count is enforced.
+EnforceMaxPlayers=                    ; boolean,  whether maximum player count is enforced.
+AllowedStartingLocations=             ; comma-separated integers, restricts which starting locations can be used. Starts from 0. If not set, all starting locations are allowed.
 IsCoopMission=                        ; boolean,  marks the map as a co-op mission.
 ClientMultiplayerOnly=                ; boolean,  whether the map cannot be played in Skirmish.
 HumanPlayersOnly=                     ; boolean,  whether AI players are forbidden.
@@ -879,13 +876,13 @@ ForceRandomStartLocations=            ; boolean,  force random starting position
 ForceNoTeams=                         ; boolean,  force no team assignments.
 CoopDifficultyLevel=                  ; integer,  co-op difficulty override.
 
-; Game mode section keys (same properties, slightly different names):
+; Game mode section keys:
 [GAME_MODE]
-MinPlayers=                           ; integer,  minimum player count.
-MaxPlayers=                           ; integer,  maximum player count.
-EnforceMinPlayers=                    ; boolean,  whether MinPlayers is enforced.
-EnforceMaxPlayers=                    ; boolean,  whether MaxPlayers is enforced.
-AllowedStartingLocations=             ; comma-separated integers.
+MinPlayersOverride=                   ; integer,  minimum player count. Has higher priority than Map.ClientMinPlayer.
+MaxPlayersOverride=                   ; integer,  maximum player count. Has higher priority than Map.ClientMaxPlayer.
+EnforceMinPlayers=                    ; boolean,  whether minimum player count is enforced.
+EnforceMaxPlayers=                    ; boolean,  whether maximum player count is enforced.
+AllowedStartingLocations=             ; comma-separated integers, restricts which starting locations can be used. Starts from 0. If not set, all starting locations are allowed.
 IsCoopMission=                        ; boolean,  marks the mode as co-op.
 MultiplayerOnly=                      ; boolean,  whether maps in this mode cannot be played in Skirmish.
 HumanPlayersOnly=                     ; boolean,  whether AI players are forbidden.
@@ -895,8 +892,8 @@ CoopDifficultyLevel=                  ; integer,  co-op difficulty override.
 ```
 
 Priority resolution for player counts:
-- `MaxPlayers`: `GameMode.MaxPlayersOverride` > `Map.MaxPlayer` > `GameMode.MaxPlayers`
-- `MinPlayers`: `GameMode.MinPlayersOverride` > `Map.MinPlayer` > `GameMode.MinPlayers`
+- `MaxPlayers`: `GameMode.MaxPlayersOverride` > `Map.ClientMaxPlayer` > `Map.MaxPlayer`
+- `MinPlayers`: `GameMode.MinPlayersOverride` > `Map.ClientMinPlayer` > `Map.MinPlayer`
 
 ### Map Extra INI
 

--- a/Docs/INISystem.md
+++ b/Docs/INISystem.md
@@ -895,8 +895,8 @@ CoopDifficultyLevel=                  ; integer,  co-op difficulty override.
 ```
 
 Priority resolution for player counts:
-- `MaxPlayers`: `GameMode.MaxPlayersOverride` > `Map.ClientMaxPlayer` > `Map.MaxPlayer` > `GameMode.MaxPlayers`
-- `MinPlayers`: `GameMode.MinPlayersOverride` > `Map.ClientMinPlayer` > `Map.MinPlayer` > `GameMode.MinPlayers`
+- `MaxPlayers`: `GameMode.MaxPlayersOverride` > `Map.MaxPlayer` > `GameMode.MaxPlayers`
+- `MinPlayers`: `GameMode.MinPlayersOverride` > `Map.MinPlayer` > `GameMode.MinPlayers`
 
 ### Map Extra INI
 


### PR DESCRIPTION
Closes #1029

## Summary
- Added `EnforceMinPlayers` flag that gates `MinPlayer` enforcement,
  matching how `EnforceMaxPlayers` works
- Added `ClientMinPlayer` INI key as a client-side override for minimum player count, the name of which has been used in [DTA client](https://github.com/Rampastring/dta-xna-cncnet-client/)
- `ClientMinPlayer` and `ClientMaxPlayer` are now always read, not just for custom maps