### PR TITLE
Fix loaded game options not showing in GameListBox

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetGameLoadingLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetGameLoadingLobby.cs
@@ -717,7 +717,8 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             sb.Append(0); // LoadedGameId
             sb.Append(";");
             sb.Append(ClientConfiguration.Instance.DefaultSkillLevelIndex); // we don't know the original skill level
-            sb.Append(";"); // Map SHA1
+            sb.Append(";");
+            sb.Append(SavedMapSHA1);
             sb.Append(";");
             sb.Append(SavedBroadcastOptionValues);
 

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetGameLoadingLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetGameLoadingLobby.cs
@@ -718,9 +718,9 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             sb.Append(";");
             sb.Append(ClientConfiguration.Instance.DefaultSkillLevelIndex); // we don't know the original skill level
             sb.Append(";");
-            sb.Append(SavedMapSHA1);
+            sb.Append(savedMapSHA1);
             sb.Append(";");
-            sb.Append(SavedBroadcastOptionValues);
+            sb.Append(savedBroadcastOptionValues);
 
             broadcastChannel.SendCTCPMessage(sb.ToString(), QueuedMessageType.SYSTEM_MESSAGE, 20);
         }

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetGameLoadingLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetGameLoadingLobby.cs
@@ -718,7 +718,8 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             sb.Append(";");
             sb.Append(ClientConfiguration.Instance.DefaultSkillLevelIndex); // we don't know the original skill level
             sb.Append(";"); // Map SHA1
-            sb.Append(";"); // Game option values
+            sb.Append(";");
+            sb.Append(SavedBroadcastOptionValues);
 
             broadcastChannel.SendCTCPMessage(sb.ToString(), QueuedMessageType.SYSTEM_MESSAGE, 20);
         }

--- a/DXMainClient/DXGUI/Multiplayer/GameLoadingLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLoadingLobbyBase.cs
@@ -67,8 +67,8 @@ namespace DTAClient.DXGUI.Multiplayer
 
         private string loadedGameID;
 
-        protected string SavedMapSHA1 = string.Empty;
-        protected string SavedBroadcastOptionValues = string.Empty;
+        protected string savedMapSHA1 = string.Empty;
+        protected string savedBroadcastOptionValues = string.Empty;
 
         private bool isSettingUp = false;
         private FileSystemWatcher fsw;
@@ -404,8 +404,8 @@ namespace DTAClient.DXGUI.Multiplayer
             IniFile spawnSGIni = new IniFile(SafePath.CombineFilePath(ProgramConstants.GamePath, "Saved Games", "spawnSG.ini"));
 
             loadedGameID = spawnSGIni.GetStringValue("Settings", "GameID", "0");
-            SavedMapSHA1 = spawnSGIni.GetStringValue("Settings", "MapSHA1", string.Empty);
-            SavedBroadcastOptionValues = spawnSGIni.GetStringValue("Settings", "BroadcastedGameOptionValues", string.Empty);
+            savedMapSHA1 = spawnSGIni.GetStringValue("Settings", "MapSHA1", string.Empty);
+            savedBroadcastOptionValues = spawnSGIni.GetStringValue("Settings", "BroadcastedGameOptionValues", string.Empty);
             lblMapNameValue.Tag = spawnSGIni.GetStringValue("Settings", "UIMapName", string.Empty);
             lblMapNameValue.Text = ((string)lblGameModeValue.Tag).L10N($"INI:Maps:{spawnSGIni.GetStringValue("Settings", "MapID", string.Empty)}:Description");
             lblGameModeValue.Tag = spawnSGIni.GetStringValue("Settings", "UIGameMode", string.Empty);

--- a/DXMainClient/DXGUI/Multiplayer/GameLoadingLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLoadingLobbyBase.cs
@@ -67,6 +67,7 @@ namespace DTAClient.DXGUI.Multiplayer
 
         private string loadedGameID;
 
+        protected string SavedMapSHA1 = string.Empty;
         protected string SavedBroadcastOptionValues = string.Empty;
 
         private bool isSettingUp = false;
@@ -403,6 +404,7 @@ namespace DTAClient.DXGUI.Multiplayer
             IniFile spawnSGIni = new IniFile(SafePath.CombineFilePath(ProgramConstants.GamePath, "Saved Games", "spawnSG.ini"));
 
             loadedGameID = spawnSGIni.GetStringValue("Settings", "GameID", "0");
+            SavedMapSHA1 = spawnSGIni.GetStringValue("Settings", "MapSHA1", string.Empty);
             SavedBroadcastOptionValues = spawnSGIni.GetStringValue("Settings", "BroadcastedGameOptionValues", string.Empty);
             lblMapNameValue.Tag = spawnSGIni.GetStringValue("Settings", "UIMapName", string.Empty);
             lblMapNameValue.Text = ((string)lblGameModeValue.Tag).L10N($"INI:Maps:{spawnSGIni.GetStringValue("Settings", "MapID", string.Empty)}:Description");

--- a/DXMainClient/DXGUI/Multiplayer/GameLoadingLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLoadingLobbyBase.cs
@@ -67,6 +67,8 @@ namespace DTAClient.DXGUI.Multiplayer
 
         private string loadedGameID;
 
+        protected string SavedBroadcastOptionValues = string.Empty;
+
         private bool isSettingUp = false;
         private FileSystemWatcher fsw;
 
@@ -401,6 +403,7 @@ namespace DTAClient.DXGUI.Multiplayer
             IniFile spawnSGIni = new IniFile(SafePath.CombineFilePath(ProgramConstants.GamePath, "Saved Games", "spawnSG.ini"));
 
             loadedGameID = spawnSGIni.GetStringValue("Settings", "GameID", "0");
+            SavedBroadcastOptionValues = spawnSGIni.GetStringValue("Settings", "BroadcastedGameOptionValues", string.Empty);
             lblMapNameValue.Tag = spawnSGIni.GetStringValue("Settings", "UIMapName", string.Empty);
             lblMapNameValue.Text = ((string)lblGameModeValue.Tag).L10N($"INI:Maps:{spawnSGIni.GetStringValue("Settings", "MapID", string.Empty)}:Description");
             lblGameModeValue.Tag = spawnSGIni.GetStringValue("Settings", "UIGameMode", string.Empty);

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -2290,38 +2290,9 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             sb.Append(";");
             sb.Append(Map?.SHA1);
 
-            List<IGameSessionSetting> broadcastableSettings = GetBroadcastableSettings();
-
-            List<int> gameOptionValues = new();
-
-            int checkboxCount = CheckBoxes.Count(cb => cb.BroadcastToLobby);
-            if (checkboxCount > 0)
-            {
-                bool[] checkboxValues = new bool[checkboxCount];
-                for (int i = 0; i < checkboxCount; i++)
-                    checkboxValues[i] = CheckBoxes.Where(cb => cb.BroadcastToLobby).ElementAt(i).Checked;
-
-                List<byte> byteList = Conversions.BoolArrayIntoBytes(checkboxValues).ToList();
-
-                // Pad to multiple of 4 bytes
-                while (byteList.Count % 4 != 0)
-                    byteList.Add(0);
-
-                byte[] byteArray = byteList.ToArray();
-
-                // Convert bytes to integers
-                for (int i = 0; i < byteArray.Length / 4; i++)
-                    gameOptionValues.Add(BinaryPrimitives.ReadInt32LittleEndian(byteArray.AsSpan(i * 4)));
-            }
-
-            // Add dropdown indices
-            int dropdownCount = DropDowns.Count(dd => dd.BroadcastToLobby);
-            if (dropdownCount > 0)
-                gameOptionValues.AddRange(DropDowns.Where(dd => dd.BroadcastToLobby).Select(dd => dd.SelectedIndex));
-
+            string gameOptionValues = GetPackedGameOptionValuesString();
             sb.Append(";");
-            if (gameOptionValues.Count > 0)
-                sb.Append(string.Join(",", gameOptionValues));
+            sb.Append(gameOptionValues);
 
             broadcastChannel.SendCTCPMessage(sb.ToString(), QueuedMessageType.SYSTEM_MESSAGE, 20);
         }

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -11,6 +11,7 @@ using Rampastring.XNAUI.XNAControls;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Buffers.Binary;
 using System.Linq;
 using ClientCore.Enums;
 using DTAClient.DXGUI.Multiplayer.CnCNet;
@@ -101,6 +102,31 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             result.AddRange(DropDowns.Where(dd => dd.BroadcastToLobby));
 
             return result;
+        }
+
+        protected string GetPackedGameOptionValuesString()
+        {
+            var values = new List<int>();
+
+            var broadcastCheckBoxes = CheckBoxes.Where(cb => cb.BroadcastToLobby).ToList();
+            if (broadcastCheckBoxes.Count > 0)
+            {
+                bool[] checkboxValues = broadcastCheckBoxes.Select(cb => cb.Checked).ToArray();
+
+                List<byte> byteList = Conversions.BoolArrayIntoBytes(checkboxValues).ToList();
+                while (byteList.Count % 4 != 0)
+                    byteList.Add(0);
+                byte[] byteArray = byteList.ToArray();
+
+                for (int i = 0; i < byteArray.Length / 4; i++)
+                    values.Add(BinaryPrimitives.ReadInt32LittleEndian(byteArray.AsSpan(i * 4)));
+            }
+
+            var broadcastDropDowns = DropDowns.Where(dd => dd.BroadcastToLobby).ToList();
+            if (broadcastDropDowns.Count > 0)
+                values.AddRange(broadcastDropDowns.Select(dd => dd.SelectedIndex));
+
+            return values.Count > 0 ? string.Join(",", values) : string.Empty;
         }
 
         protected DiscordHandler discordHandler;
@@ -1777,6 +1803,9 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                         startingWaypoint);
                 }
             }
+
+            string packedGameOptionValues = GetPackedGameOptionValuesString();
+            spawnIni.SetStringValue("Settings", "BroadcastedGameOptionValues", packedGameOptionValues);
 
             spawnIni.WriteIniFile();
 

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/GameLobbyBase.cs
@@ -1804,6 +1804,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 }
             }
 
+            spawnIni.SetStringValue("Settings", "MapSHA1", Map.SHA1);
             string packedGameOptionValues = GetPackedGameOptionValuesString();
             spawnIni.SetStringValue("Settings", "BroadcastedGameOptionValues", packedGameOptionValues);
 


### PR DESCRIPTION
Loaded games in the GameListBox didn't show game options (e.g. RA2 mode icon) because the loading lobby didn't broadcast the options.

Fixes this by writing the broadcastable option values to spawnSG.ini at game launch, then reading them back in the loading lobby to include in its broadcast. Also consolidates the option packing logic into a single shared method on GameLobbyBase.

Before:
<img width="926" height="430" alt="image" src="https://github.com/user-attachments/assets/b30be75e-b59e-44ca-a04d-28d7ce0cfce2" />


After:
<img width="827" height="450" alt="image" src="https://github.com/user-attachments/assets/6371786f-7362-4488-8329-8aae67b9fce6" />
