### PR TITLE
Fix client startup hangs on macOS

### DIFF
--- a/DXMainClient/DXGUI/GameClass.cs
+++ b/DXMainClient/DXGUI/GameClass.cs
@@ -22,7 +22,6 @@ using DTAClient.DXGUI.Multiplayer.GameLobby;
 using DTAClient.Online;
 using ClientGUI.Settings;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Rampastring.XNAUI.XNAControls;
 using MainMenu = DTAClient.DXGUI.Generic.MainMenu;
 using System.Threading.Tasks;
@@ -259,9 +258,12 @@ namespace DTAClient.DXGUI
 
         private IServiceProvider BuildServiceProvider(WindowManager windowManager)
         {
-            // Create host - this allows for things like DependencyInjection
-            IHost host = Host.CreateDefaultBuilder()
-                .ConfigureServices((_, services) =>
+            // Dependency-injection container. This previously built a full .NET Generic Host
+            // (Host.CreateDefaultBuilder().Build()), but the client only ever used it as a DI
+            // container, and that Build() hangs on macOS: the host's configuration provider sets
+            // up a FileSystemWatcher (reloadOnChange), whose FSEvents-backed setup stalls there.
+            // A plain ServiceCollection provides the same DI with none of that machinery.
+            var services = new ServiceCollection();
                     {
                         // services (or service-like)
                         services
@@ -336,10 +338,8 @@ namespace DTAClient.DXGUI
                             .AddTransientXnaControl<FileSettingCheckBox>()
                             .AddTransientXnaControl<FileSettingDropDown>();
                     }
-                )
-                .Build();
 
-            return host.Services.GetService<IServiceProvider>();
+            return services.BuildServiceProvider();
         }
 
         private void InitializeUISettings()

--- a/DXMainClient/Domain/Multiplayer/MapLoader.cs
+++ b/DXMainClient/Domain/Multiplayer/MapLoader.cs
@@ -114,7 +114,12 @@ namespace DTAClient.Domain.Multiplayer
 
         public void Initialize()
         {
-            MapLoadingComplete += (sender, args) => StartMapFileWatcher();
+            // .NET's FileSystemWatcher (FSEvents-backed) stalls during setup on macOS.
+            // Since MapLoadingComplete is invoked synchronously, that would block the map
+            // loading task from ever completing and hang the client on the loading screen.
+            // Skip the live map-file watcher on macOS; maps still load, just no hot-reload.
+            if (!OperatingSystem.IsMacOS())
+                MapLoadingComplete += (sender, args) => StartMapFileWatcher();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Fixes two startup deadlocks that prevented the UniversalGL client from reaching the main menu on macOS.

Both hangs occurred while .NET attempted to initialize `FileSystemWatcher` instances backed by macOS FSEvents. Without these changes, the client either blocked during dependency-injection setup or remained indefinitely on the map-loading screen without rendering a usable main window.

## Root cause

### Generic Host initialization

`GameClass.BuildServiceProvider` previously created a complete .NET Generic Host:

```csharp
Host.CreateDefaultBuilder()
    .ConfigureServices(...)
    .Build();
```

`Host.CreateDefaultBuilder` configures application settings with change monitoring enabled. During `Build()`, the configuration system creates a `FileSystemWatcher` for `reloadOnChange`.

On macOS, initialization of that watcher stalls, causing `Build()` to never return and permanently blocking the main thread.

The client did not use hosting, configuration reloads, application lifetime management, or any other Generic Host functionality. It only used the resulting service provider as a dependency-injection container.

This change replaces the Generic Host with a plain `ServiceCollection` while preserving the existing service registrations:

```csharp
var services = new ServiceCollection();
// Existing registrations...
return services.BuildServiceProvider();
```

This provides the same dependency-injection functionality without initializing the additional Generic Host infrastructure.

### Map file watcher initialization

`MapLoader.Initialize` previously subscribed `StartMapFileWatcher` to `MapLoadingComplete`.

`MapLoadingComplete` is invoked synchronously at the end of the map-loading task. `StartMapFileWatcher` creates another `FileSystemWatcher`, whose initialization also stalls on macOS.

Because the event handler runs synchronously, the watcher prevents the map-loading task from completing. The client consequently remains stuck on:

```text
Waiting for loading maps...
```

The live map-file watcher is now disabled on macOS. Maps still load normally, but changes to map files are not detected and hot-reloaded while the client is running.

## Result

The UniversalGL client now:

* completes startup;
* renders the main menu;
* connects to the CnCNet lobby; and
* can create and start a game session on macOS.

Verified end to end on:

* Apple Silicon;
* macOS 26; and
* .NET 8.

The tested flow was:

```text
Main menu → CnCNet Online → create game → start game
```

## Platform notes

The `MapLoader` workaround is restricted to macOS through `OperatingSystem.IsMacOS()`. Windows and Linux retain the existing map hot-reload behavior.

The replacement of the Generic Host with `ServiceCollection` applies to all platforms. The client only used the host as a dependency-injection container, so no intentional behavior changes are expected on Windows or Linux.

**This change has been tested on macOS. A native Windows and Linux build-and-run check is still recommended to confirm that the dependency-injection change introduces no platform-specific regressions.**

## Related

This PR fixes startup and lobby rendering for the UniversalGL client on macOS.

Launching the actual game process from the lobby under Wine requires a separate Syringe fix. Stock Syringe silently fails to perform DLL injection and hook installation under Wine, causing the game to exit before `spawn.ini` is read.

That independent SyringeEx change is available here:

https://github.com/Phobos-developers/SyringeEx/pull/25
