### PR TITLE
Add DisableModifierKeys INI option for keyboard commands

### DIFF
--- a/ClientGUI/HotkeyConfigurationWindow.cs
+++ b/ClientGUI/HotkeyConfigurationWindow.cs
@@ -336,6 +336,9 @@ namespace ClientGUI
                 if (tsHotkey.HasValue)
                 {
                     Hotkey hotkey = new(tsHotkey.Value);
+                    if (command.DisableModifierKeys && hotkey.Modifier != KeyModifiers.None)
+                        hotkey = new Hotkey(hotkey.Key, KeyModifiers.None);
+
                     bool isDuplicate = false;
                     if (hotkey != Hotkey.None)
                         isDuplicate = !assignedHotkeys.Add(hotkey);
@@ -439,6 +442,8 @@ namespace ClientGUI
             }
 
             var command = (GameCommand)lbHotkeys.GetItem(0, lbHotkeys.SelectedIndex).Tag;
+            if (command.DisableModifierKeys && pendingHotkey.Modifier != KeyModifiers.None)
+                pendingHotkey = new Hotkey(pendingHotkey.Key, KeyModifiers.None);
             command.Hotkey = pendingHotkey;
             RefreshHotkeyList();
             pendingHotkey = Hotkey.None;
@@ -465,13 +470,6 @@ namespace ClientGUI
             }
 
             var currentModifiers = GetCurrentModifiers();
-
-            if (lbHotkeys.SelectedIndex >= 0 && lbHotkeys.SelectedIndex < lbHotkeys.ItemCount)
-            {
-                var selectedCommand = (GameCommand)lbHotkeys.GetItem(0, lbHotkeys.SelectedIndex).Tag;
-                if (selectedCommand.DisableModifierKeys)
-                    currentModifiers = KeyModifiers.None;
-            }
 
             // The XNA keys seem to match the Windows virtual keycodes! This saves us some work
             pendingHotkey = new Hotkey(e.PressedKey, currentModifiers);
@@ -649,10 +647,13 @@ namespace ClientGUI
                 Description = iniSection.GetStringValue("Description", "Unknown description")
                     .L10N($"INI:Hotkeys:{ININame}:Description");
 
+                DisableModifierKeys = iniSection.GetBooleanValue("DisableModifierKeys", false);
+
                 int? defaultTSKey = iniSection.GetIntValueOrNull("DefaultKey");
                 DefaultHotkey = defaultTSKey.HasValue ? new Hotkey(defaultTSKey.Value) : null;
 
-                DisableModifierKeys = iniSection.GetBooleanValue("DisableModifierKeys", false);
+                if (DefaultHotkey != null && DisableModifierKeys && DefaultHotkey.Modifier != KeyModifiers.None)
+                    DefaultHotkey = new Hotkey(DefaultHotkey.Key, KeyModifiers.None);
 
                 // Note: currently, we treat Hotkey.None as null for default hotkeys, since it doesn't make much sense to have a default hotkey that is explicitly "no hotkey" -- Hotkey.None prevents automatically setting a new hot key via DefaultHotkey from a future update
                 if (DefaultHotkey == Hotkey.None)

--- a/ClientGUI/HotkeyConfigurationWindow.cs
+++ b/ClientGUI/HotkeyConfigurationWindow.cs
@@ -252,7 +252,18 @@ namespace ClientGUI
                     bool isDuplicate = !defaultHotkeys.Add(gameCommand.DefaultHotkey);
 
                     if (isDuplicate)
-                        throw new Exception("The default hotkey " + gameCommand.DefaultHotkey.ToString() + " for command " + gameCommand.UIName + " is duplicated with another command's default hotkey. Please make sure all default hotkeys in " + KEYBOARD_COMMANDS_INI + " are unique.");
+                        throw new Exception(
+                            string.Format
+                            (
+                                (
+                                    "The default hotkey {0} for command {1} is duplicated with another command's default hotkey." +
+                                    "Please make sure all default hotkeys in {2} are unique."
+                                ).L10N("Client:Config:ExceptionDuplicatHotkeys"),
+                                gameCommand.DefaultHotkey.ToString(),
+                                gameCommand.UIName,
+                                KEYBOARD_COMMANDS_INI
+                            )
+                        );
                 }
             }
         }
@@ -647,8 +658,17 @@ namespace ClientGUI
                     && DisableModifierKeys && DefaultHotkey.Modifier != KeyModifiers.None)
                 {
                     throw new Exception(
-                        $"The default hotkey {DefaultHotkey} for command '{ININame}' has modifier keys but DisableModifierKeys is set to true. " +
-                        $"Please remove the modifier from the default hotkey or set DisableModifierKeys=false in {KEYBOARD_COMMANDS_INI}.");
+                        string.Format
+                        (
+                            (
+                                "The default hotkey {0} for command '{1}' has modifier keys but DisableModifierKeys is set to true. " +
+                                "Please remove the modifier from the default hotkey or set DisableModifierKeys=false in {2}."
+                            ).L10N("Client:Config:ExceptionModifierKeysDetected"),
+                            DefaultHotkey,
+                            ININame,
+                            KEYBOARD_COMMANDS_INI
+                        )
+                    );
                 }
 
                 // Note: currently, we treat Hotkey.None as null for default hotkeys, since it doesn't make much sense to have a default hotkey that is explicitly "no hotkey" -- Hotkey.None prevents automatically setting a new hot key via DefaultHotkey from a future update

--- a/ClientGUI/HotkeyConfigurationWindow.cs
+++ b/ClientGUI/HotkeyConfigurationWindow.cs
@@ -652,8 +652,14 @@ namespace ClientGUI
                 int? defaultTSKey = iniSection.GetIntValueOrNull("DefaultKey");
                 DefaultHotkey = defaultTSKey.HasValue ? new Hotkey(defaultTSKey.Value) : null;
 
-                if (DefaultHotkey != null && DisableModifierKeys && DefaultHotkey.Modifier != KeyModifiers.None)
-                    DefaultHotkey = new Hotkey(DefaultHotkey.Key, KeyModifiers.None);
+                if (DefaultHotkey != null && DefaultHotkey != Hotkey.None
+                    && DisableModifierKeys && DefaultHotkey.Modifier != KeyModifiers.None)
+                {
+                    throw new Exception("The default hotkey " + DefaultHotkey.ToString()
+                        + " for command " + UIName + " has modifier keys but DisableModifierKeys is set to true."
+                        + " Please remove the modifier from the default hotkey or disable DisableModifierKeys in "
+                        + KEYBOARD_COMMANDS_INI + ".");
+                }
 
                 // Note: currently, we treat Hotkey.None as null for default hotkeys, since it doesn't make much sense to have a default hotkey that is explicitly "no hotkey" -- Hotkey.None prevents automatically setting a new hot key via DefaultHotkey from a future update
                 if (DefaultHotkey == Hotkey.None)

--- a/ClientGUI/HotkeyConfigurationWindow.cs
+++ b/ClientGUI/HotkeyConfigurationWindow.cs
@@ -259,7 +259,7 @@ namespace ClientGUI
                                 (
                                     "The default hotkey {0} for command {1} is duplicated with another command's default hotkey." + " " +
                                     "Please make sure all default hotkeys in file {2} are unique."
-                                ).L10N("Client:DTAConfig:ExceptionDuplicatHotkeys"),
+                                ).L10N("Client:DTAConfig:ExceptionDuplicateHotkeys"),
                                 gameCommand.DefaultHotkey.ToString(),
                                 gameCommand.ININame,
                                 KEYBOARD_COMMANDS_INI

--- a/ClientGUI/HotkeyConfigurationWindow.cs
+++ b/ClientGUI/HotkeyConfigurationWindow.cs
@@ -257,7 +257,7 @@ namespace ClientGUI
                             string.Format
                             (
                                 (
-                                    "The default hotkey {0} for command {1} is duplicated with another command's default hotkey." +
+                                    "The default hotkey {0} for command {1} is duplicated with another command's default hotkey." + " " +
                                     "Please make sure all default hotkeys in file {2} are unique."
                                 ).L10N("Client:Config:ExceptionDuplicatHotkeys"),
                                 gameCommand.DefaultHotkey.ToString(),
@@ -663,7 +663,7 @@ namespace ClientGUI
                         string.Format
                         (
                             (
-                                "The default hotkey {0} for command '{1}' has modifier keys but DisableModifierKeys is set to true. " +
+                                "The default hotkey {0} for command '{1}' has modifier keys but DisableModifierKeys is set to true." + " " +
                                 "Please remove the modifier from the default hotkey or set DisableModifierKeys=false in file {2}."
                             ).L10N("Client:Config:ExceptionModifierKeysDetected"),
                             DefaultHotkey,

--- a/ClientGUI/HotkeyConfigurationWindow.cs
+++ b/ClientGUI/HotkeyConfigurationWindow.cs
@@ -647,7 +647,7 @@ namespace ClientGUI
                     && DisableModifierKeys && DefaultHotkey.Modifier != KeyModifiers.None)
                 {
                     throw new Exception(
-                        $"The default hotkey {DefaultHotkey} for command '{ININame}' ({UIName}) has modifier keys but DisableModifierKeys is set to true. " +
+                        $"The default hotkey {DefaultHotkey} for command '{ININame}' has modifier keys but DisableModifierKeys is set to true. " +
                         $"Please remove the modifier from the default hotkey or set DisableModifierKeys=false in {KEYBOARD_COMMANDS_INI}.");
                 }
 

--- a/ClientGUI/HotkeyConfigurationWindow.cs
+++ b/ClientGUI/HotkeyConfigurationWindow.cs
@@ -260,7 +260,7 @@ namespace ClientGUI
                                     "Please make sure all default hotkeys in {2} are unique."
                                 ).L10N("Client:Config:ExceptionDuplicatHotkeys"),
                                 gameCommand.DefaultHotkey.ToString(),
-                                gameCommand.UIName,
+                                gameCommand.ININame,
                                 KEYBOARD_COMMANDS_INI
                             )
                         );

--- a/ClientGUI/HotkeyConfigurationWindow.cs
+++ b/ClientGUI/HotkeyConfigurationWindow.cs
@@ -350,7 +350,10 @@ namespace ClientGUI
                 {
                     Hotkey hotkey = new(tsHotkey.Value);
                     if (command.DisableModifierKeys && hotkey.Modifier != KeyModifiers.None)
-                        hotkey = new Hotkey(hotkey.Key, KeyModifiers.None);
+                    {
+                        command.Hotkey = null;
+                        continue;
+                    }
 
                     bool isDuplicate = false;
                     if (hotkey != Hotkey.None)
@@ -446,7 +449,7 @@ namespace ClientGUI
 
             var command = (GameCommand)lbHotkeys.GetItem(0, lbHotkeys.SelectedIndex).Tag;
             if (command.DisableModifierKeys && pendingHotkey.Modifier != KeyModifiers.None)
-                pendingHotkey = new Hotkey(pendingHotkey.Key, KeyModifiers.None);
+                return;
 
             // If the hotkey is already assigned to other command, unbind it
             if (pendingHotkey != Hotkey.None)

--- a/ClientGUI/HotkeyConfigurationWindow.cs
+++ b/ClientGUI/HotkeyConfigurationWindow.cs
@@ -504,29 +504,17 @@ namespace ClientGUI
         {
             base.Update(gameTime);
 
-            bool disableModifiers = false;
-            if (lbHotkeys.SelectedIndex >= 0 && lbHotkeys.SelectedIndex < lbHotkeys.ItemCount)
+            var oldModifiers = pendingHotkey.Modifier;
+            var currentModifiers = GetCurrentModifiers();
+
+            if ((pendingHotkey.Key == Keys.None && currentModifiers != oldModifiers)
+                ||
+                (pendingHotkey.Key != Keys.None &&
+                lastFrameModifiers == KeyModifiers.None &&
+                currentModifiers != lastFrameModifiers))
             {
-                var selectedCommand = (GameCommand)lbHotkeys.GetItem(0, lbHotkeys.SelectedIndex).Tag;
-                disableModifiers = selectedCommand.DisableModifierKeys;
-            }
-
-            if (!disableModifiers)
-            {
-                var oldModifiers = pendingHotkey.Modifier;
-                var currentModifiers = GetCurrentModifiers();
-
-                if ((pendingHotkey.Key == Keys.None && currentModifiers != oldModifiers)
-                    ||
-                    (pendingHotkey.Key != Keys.None &&
-                    lastFrameModifiers == KeyModifiers.None &&
-                    currentModifiers != lastFrameModifiers))
-                {
-                    pendingHotkey = new Hotkey(Keys.None, currentModifiers);
-                    lblCurrentlyAssignedTo.Text = string.Empty;
-                }
-
-                lastFrameModifiers = currentModifiers;
+                pendingHotkey = new Hotkey(Keys.None, currentModifiers);
+                lblCurrentlyAssignedTo.Text = string.Empty;
             }
 
             string displayString = pendingHotkey.ToString();
@@ -534,6 +522,8 @@ namespace ClientGUI
                 lblNewHotkeyValue.Text = pendingHotkey.ToString();
             else
                 lblNewHotkeyValue.Text = HOTKEY_TIP_TEXT;
+
+            lastFrameModifiers = currentModifiers;
         }
 
         /// <summary>

--- a/ClientGUI/HotkeyConfigurationWindow.cs
+++ b/ClientGUI/HotkeyConfigurationWindow.cs
@@ -646,10 +646,9 @@ namespace ClientGUI
                 if (DefaultHotkey != null && DefaultHotkey != Hotkey.None
                     && DisableModifierKeys && DefaultHotkey.Modifier != KeyModifiers.None)
                 {
-                    throw new Exception("The default hotkey " + DefaultHotkey.ToString()
-                        + " for command " + UIName + " has modifier keys but DisableModifierKeys is set to true."
-                        + " Please remove the modifier from the default hotkey or disable DisableModifierKeys in "
-                        + KEYBOARD_COMMANDS_INI + ".");
+                    throw new Exception(
+                        $"The default hotkey {DefaultHotkey} for command '{ININame}' ({UIName}) has modifier keys but DisableModifierKeys is set to true. " +
+                        $"Please remove the modifier from the default hotkey or set DisableModifierKeys=false in {KEYBOARD_COMMANDS_INI}.");
                 }
 
                 // Note: currently, we treat Hotkey.None as null for default hotkeys, since it doesn't make much sense to have a default hotkey that is explicitly "no hotkey" -- Hotkey.None prevents automatically setting a new hot key via DefaultHotkey from a future update

--- a/ClientGUI/HotkeyConfigurationWindow.cs
+++ b/ClientGUI/HotkeyConfigurationWindow.cs
@@ -466,6 +466,13 @@ namespace ClientGUI
 
             var currentModifiers = GetCurrentModifiers();
 
+            if (lbHotkeys.SelectedIndex >= 0 && lbHotkeys.SelectedIndex < lbHotkeys.ItemCount)
+            {
+                var selectedCommand = (GameCommand)lbHotkeys.GetItem(0, lbHotkeys.SelectedIndex).Tag;
+                if (selectedCommand.DisableModifierKeys)
+                    currentModifiers = KeyModifiers.None;
+            }
+
             // The XNA keys seem to match the Windows virtual keycodes! This saves us some work
             pendingHotkey = new Hotkey(e.PressedKey, currentModifiers);
 
@@ -499,17 +506,29 @@ namespace ClientGUI
         {
             base.Update(gameTime);
 
-            var oldModifiers = pendingHotkey.Modifier;
-            var currentModifiers = GetCurrentModifiers();
-
-            if ((pendingHotkey.Key == Keys.None && currentModifiers != oldModifiers)
-                ||
-                (pendingHotkey.Key != Keys.None &&
-                lastFrameModifiers == KeyModifiers.None &&
-                currentModifiers != lastFrameModifiers))
+            bool disableModifiers = false;
+            if (lbHotkeys.SelectedIndex >= 0 && lbHotkeys.SelectedIndex < lbHotkeys.ItemCount)
             {
-                pendingHotkey = new Hotkey(Keys.None, currentModifiers);
-                lblCurrentlyAssignedTo.Text = string.Empty;
+                var selectedCommand = (GameCommand)lbHotkeys.GetItem(0, lbHotkeys.SelectedIndex).Tag;
+                disableModifiers = selectedCommand.DisableModifierKeys;
+            }
+
+            if (!disableModifiers)
+            {
+                var oldModifiers = pendingHotkey.Modifier;
+                var currentModifiers = GetCurrentModifiers();
+
+                if ((pendingHotkey.Key == Keys.None && currentModifiers != oldModifiers)
+                    ||
+                    (pendingHotkey.Key != Keys.None &&
+                    lastFrameModifiers == KeyModifiers.None &&
+                    currentModifiers != lastFrameModifiers))
+                {
+                    pendingHotkey = new Hotkey(Keys.None, currentModifiers);
+                    lblCurrentlyAssignedTo.Text = string.Empty;
+                }
+
+                lastFrameModifiers = currentModifiers;
             }
 
             string displayString = pendingHotkey.ToString();
@@ -517,8 +536,6 @@ namespace ClientGUI
                 lblNewHotkeyValue.Text = pendingHotkey.ToString();
             else
                 lblNewHotkeyValue.Text = HOTKEY_TIP_TEXT;
-
-            lastFrameModifiers = currentModifiers;
         }
 
         /// <summary>
@@ -635,6 +652,8 @@ namespace ClientGUI
                 int? defaultTSKey = iniSection.GetIntValueOrNull("DefaultKey");
                 DefaultHotkey = defaultTSKey.HasValue ? new Hotkey(defaultTSKey.Value) : null;
 
+                DisableModifierKeys = iniSection.GetBooleanValue("DisableModifierKeys", false);
+
                 // Note: currently, we treat Hotkey.None as null for default hotkeys, since it doesn't make much sense to have a default hotkey that is explicitly "no hotkey" -- Hotkey.None prevents automatically setting a new hot key via DefaultHotkey from a future update
                 if (DefaultHotkey == Hotkey.None)
                     DefaultHotkey = null;
@@ -646,6 +665,7 @@ namespace ClientGUI
             public string ININame { get; private set; }
             public Hotkey? Hotkey { get; set; }
             public Hotkey? DefaultHotkey { get; private set; }
+            public bool DisableModifierKeys { get; private set; }
         }
 
         [Flags]

--- a/ClientGUI/HotkeyConfigurationWindow.cs
+++ b/ClientGUI/HotkeyConfigurationWindow.cs
@@ -352,6 +352,7 @@ namespace ClientGUI
                     if (command.DisableModifierKeys && hotkey.Modifier != KeyModifiers.None)
                     {
                         command.Hotkey = null;
+                        hotkeySection.RemoveKey(command.ININame);
                         continue;
                     }
 

--- a/ClientGUI/HotkeyConfigurationWindow.cs
+++ b/ClientGUI/HotkeyConfigurationWindow.cs
@@ -431,6 +431,10 @@ namespace ClientGUI
                 return;
             }
 
+            var command = (GameCommand)lbHotkeys.GetItem(0, lbHotkeys.SelectedIndex).Tag;
+            if (command.DisableModifierKeys && pendingHotkey.Modifier != KeyModifiers.None)
+                pendingHotkey = new Hotkey(pendingHotkey.Key, KeyModifiers.None);
+
             // If the hotkey is already assigned to other command, unbind it
             if (pendingHotkey != Hotkey.None)
             {
@@ -441,9 +445,6 @@ namespace ClientGUI
                 }
             }
 
-            var command = (GameCommand)lbHotkeys.GetItem(0, lbHotkeys.SelectedIndex).Tag;
-            if (command.DisableModifierKeys && pendingHotkey.Modifier != KeyModifiers.None)
-                pendingHotkey = new Hotkey(pendingHotkey.Key, KeyModifiers.None);
             command.Hotkey = pendingHotkey;
             RefreshHotkeyList();
             pendingHotkey = Hotkey.None;

--- a/ClientGUI/HotkeyConfigurationWindow.cs
+++ b/ClientGUI/HotkeyConfigurationWindow.cs
@@ -258,7 +258,7 @@ namespace ClientGUI
                             (
                                 (
                                     "The default hotkey {0} for command {1} is duplicated with another command's default hotkey." +
-                                    "Please make sure all default hotkeys in {2} are unique."
+                                    "Please make sure all default hotkeys in file {2} are unique."
                                 ).L10N("Client:Config:ExceptionDuplicatHotkeys"),
                                 gameCommand.DefaultHotkey.ToString(),
                                 gameCommand.ININame,
@@ -664,7 +664,7 @@ namespace ClientGUI
                         (
                             (
                                 "The default hotkey {0} for command '{1}' has modifier keys but DisableModifierKeys is set to true. " +
-                                "Please remove the modifier from the default hotkey or set DisableModifierKeys=false in {2}."
+                                "Please remove the modifier from the default hotkey or set DisableModifierKeys=false in file {2}."
                             ).L10N("Client:Config:ExceptionModifierKeysDetected"),
                             DefaultHotkey,
                             ININame,

--- a/ClientGUI/HotkeyConfigurationWindow.cs
+++ b/ClientGUI/HotkeyConfigurationWindow.cs
@@ -252,6 +252,7 @@ namespace ClientGUI
                     bool isDuplicate = !defaultHotkeys.Add(gameCommand.DefaultHotkey);
 
                     if (isDuplicate)
+                    {
                         throw new Exception(
                             string.Format
                             (
@@ -264,6 +265,7 @@ namespace ClientGUI
                                 KEYBOARD_COMMANDS_INI
                             )
                         );
+                    }
                 }
             }
         }

--- a/ClientGUI/HotkeyConfigurationWindow.cs
+++ b/ClientGUI/HotkeyConfigurationWindow.cs
@@ -259,7 +259,7 @@ namespace ClientGUI
                                 (
                                     "The default hotkey {0} for command {1} is duplicated with another command's default hotkey." + " " +
                                     "Please make sure all default hotkeys in file {2} are unique."
-                                ).L10N("Client:Config:ExceptionDuplicatHotkeys"),
+                                ).L10N("Client:DTAConfig:ExceptionDuplicatHotkeys"),
                                 gameCommand.DefaultHotkey.ToString(),
                                 gameCommand.ININame,
                                 KEYBOARD_COMMANDS_INI
@@ -665,7 +665,7 @@ namespace ClientGUI
                             (
                                 "The default hotkey {0} for command '{1}' has modifier keys but DisableModifierKeys is set to true." + " " +
                                 "Please remove the modifier from the default hotkey or set DisableModifierKeys=false in file {2}."
-                            ).L10N("Client:Config:ExceptionModifierKeysDetected"),
+                            ).L10N("Client:DTAConfig:ExceptionModifierKeysDetected"),
                             DefaultHotkey,
                             ININame,
                             KEYBOARD_COMMANDS_INI

--- a/Docs/INISystem.md
+++ b/Docs/INISystem.md
@@ -751,7 +751,7 @@ A `[CampaignForcedSpawnIniOptions]` section in `GameOptions.ini` defines keys th
 
 ## KeyboardCommands
 
-The `KeyboardCommands.ini` file defines in-game hotkey commands that the client writes to the game's `Keyboard.ini` (or equivalent). Each section represents a game command with its default key binding.
+The `KeyboardCommands.ini` file defines in-game hotkey commands that the client writes to the game's keyboard INI file. Each section represents a game command with its default key binding.
 
 The file is located in the `Resources` directory and is read by the Hotkey Configuration window.
 

--- a/Docs/INISystem.md
+++ b/Docs/INISystem.md
@@ -753,7 +753,7 @@ A `[CampaignForcedSpawnIniOptions]` section in `GameOptions.ini` defines keys th
 
 The `KeyboardCommands.ini` file defines in-game hotkey commands that the client writes to the game's `Keyboard.ini` (or equivalent). Each section represents a game command with its default key binding.
 
-The file is located in the `Resources` directory (e.g., `DXMainClient/Resources/DTA/KeyboardCommands.ini`) and is read by the Hotkey Configuration window.
+The file is located in the `Resources` directory and is read by the Hotkey Configuration window.
 
 In `KeyboardCommands.ini`:
 ```ini
@@ -773,7 +773,7 @@ DisableModifierKeys=false ; boolean, whether to prevent modifier keys (Ctrl, Shi
 - **`Category`** — category used to group commands in the hotkey configuration dropdown. Supports localization via `INI:HotkeyCategories:{Category}`.
 - **`Description`** — description text shown when the command is selected. Supports localization via `INI:Hotkeys:{CommandName}:Description`.
 - **`DefaultKey`** — the default key binding in TS-encoded integer format (`(modifier << 8) + key`). Modifier flags: 0 = None, 1 = Shift, 2 = Ctrl, 4 = Alt. Set to `0` if the command has no default hotkey.
-- **`DisableModifierKeys`** — when `true`, the hotkey configuration window will not allow modifier key combinations for this command. Only a single key (without Ctrl, Shift, or Alt) can be assigned. This is useful for RA2/YR where certain commands do not support modifier-combined hotkeys (e.g., Waypoint Mode with Ctrl+V can conflict with the force-attack cursor).
+- **`DisableModifierKeys`** — when `true`, the hotkey configuration window will not allow modifier key combinations for this command. Only a single key (without Ctrl, Shift, or Alt) can be assigned. This is useful for certain commands do not support modifier-combined hotkeys.
 
 ### Example
 

--- a/Docs/INISystem.md
+++ b/Docs/INISystem.md
@@ -751,7 +751,7 @@ A `[CampaignForcedSpawnIniOptions]` section in `GameOptions.ini` defines keys th
 
 ## KeyboardCommands
 
-The `KeyboardCommands.ini` file defines in-game hotkey commands that the client writes to the game's keyboard INI file. Each section represents a game command with its default key binding.
+The `KeyboardCommands.ini` file defines in-game hotkey commands that the client writes to the game's keyboard INI file, the filename of which is defined as `KeyboardINI` in `[Settings]` section of `ClientDefinitions.ini` file. Each section represents a game command with its default key binding.
 
 The file is located in the `Resources` directory and is read by the Hotkey Configuration window.
 

--- a/Docs/INISystem.md
+++ b/Docs/INISystem.md
@@ -749,6 +749,43 @@ The tag name in `ButtonTag_{TagName}` is matched against mission `Tags` values. 
 
 A `[CampaignForcedSpawnIniOptions]` section in `GameOptions.ini` defines keys that are always written to `spawn.ini` for campaign missions, regardless of UI options. This is separate from the multiplayer `[ForcedSpawnIniOptions]` section. See [GameOptions](#GameOptions).
 
+## KeyboardCommands
+
+The `KeyboardCommands.ini` file defines in-game hotkey commands that the client writes to the game's `Keyboard.ini` (or equivalent). Each section represents a game command with its default key binding.
+
+The file is located in the `Resources` directory (e.g., `DXMainClient/Resources/DTA/KeyboardCommands.ini`) and is read by the Hotkey Configuration window.
+
+In `KeyboardCommands.ini`:
+```ini
+[CommandName]
+UIName=Display name       ; string,  display name for the command in the hotkey configuration UI.
+Category=CategoryName     ; string,  grouping category used in the hotkey configuration UI dropdown.
+Description=Description   ; string,  description text shown in the hotkey configuration UI.
+DefaultKey=0              ; integer, the default TS-encoded key value (low byte = key code, high byte = modifier flags).
+                          ;          Use 0 for commands with no default hotkey.
+DisableModifierKeys=false ; boolean, whether to prevent modifier keys (Ctrl, Shift, Alt) from being combined with this command.
+                          ;          When true, only single keys can be assigned. Defaults to false.
+```
+
+### Command Properties
+
+- **`UIName`** — display name for the command. Supports localization via `INI:Hotkeys:{CommandName}:UIName`.
+- **`Category`** — category used to group commands in the hotkey configuration dropdown. Supports localization via `INI:HotkeyCategories:{Category}`.
+- **`Description`** — description text shown when the command is selected. Supports localization via `INI:Hotkeys:{CommandName}:Description`.
+- **`DefaultKey`** — the default key binding in TS-encoded integer format (`(modifier << 8) + key`). Modifier flags: 0 = None, 1 = Shift, 2 = Ctrl, 4 = Alt. Set to `0` if the command has no default hotkey.
+- **`DisableModifierKeys`** — when `true`, the hotkey configuration window will not allow modifier key combinations for this command. Only a single key (without Ctrl, Shift, or Alt) can be assigned. This is useful for RA2/YR where certain commands do not support modifier-combined hotkeys (e.g., Waypoint Mode with Ctrl+V can conflict with the force-attack cursor).
+
+### Example
+
+```ini
+[PlanningMode]
+UIName=Waypoint Mode
+Category=Interface
+Description=Enable waypoint mode.
+DefaultKey=90
+DisableModifierKeys=true
+```
+
 # Global Config Files
 
 ## [ClientDefinition](https://github.com/CnCNet/xna-cncnet-client/blob/develop/ClientCore/ClientConfiguration.cs)

--- a/Docs/INISystem.md
+++ b/Docs/INISystem.md
@@ -773,7 +773,7 @@ DisableModifierKeys=false ; boolean, whether to prevent modifier keys (Ctrl, Shi
 - **`Category`** — category used to group commands in the hotkey configuration dropdown. Supports localization via `INI:HotkeyCategories:{Category}`.
 - **`Description`** — description text shown when the command is selected. Supports localization via `INI:Hotkeys:{CommandName}:Description`.
 - **`DefaultKey`** — the default key binding in TS-encoded integer format (`(modifier << 8) + key`). Modifier flags: 0 = None, 1 = Shift, 2 = Ctrl, 4 = Alt. Set to `0` if the command has no default hotkey.
-- **`DisableModifierKeys`** — when `true`, the hotkey configuration window will not allow modifier key combinations for this command. Only a single key (without Ctrl, Shift, or Alt) can be assigned. This is useful for certain commands do not support modifier-combined hotkeys.
+- **`DisableModifierKeys`** — when `true`, the hotkey configuration window will not allow modifier key combinations for this command. Only a single key (without Ctrl, Shift, or Alt) can be assigned. This is useful for certain commands that do not support modifier-combined hotkeys.
 
 ### Example
 

--- a/Docs/NewFeatures.md
+++ b/Docs/NewFeatures.md
@@ -4,6 +4,10 @@ This document describes optional, non-breaking changes. While not mandatory, ado
 
 Breaking changes are not covered here; see [Migration.md](Migration.md) instead.
 
+## 2.13.4
+
+- The `KeyboardCommands.ini` file now supports `DisableModifierKeys`. See [INISystem.md](INISystem.md).
+
 ## 2.13.0
 
 - The client now supports using TTF/OTF font files. See [Fonts.md](Fonts.md) for details.

--- a/Docs/NewFeatures.md
+++ b/Docs/NewFeatures.md
@@ -6,7 +6,7 @@ Breaking changes are not covered here; see [Migration.md](Migration.md) instead.
 
 ## 2.13.4
 
-- The `KeyboardCommands.ini` file now supports `DisableModifierKeys`. See [INISystem.md](INISystem.md).
+- The `KeyboardCommands.ini` file now supports `DisableModifierKeys`. It is recommended to set this key for RA2/YR's `PlanningMode` (Waypoint Mode) command. See [INISystem.md](INISystem.md).
 
 ## 2.13.0
 


### PR DESCRIPTION
## Feature Pull Request

**Note for whoever merges it: delete all squash messages, including the co-author field! This modification is NOT done by claude, but DeepSeek v4 pro. Therefore, claude should not take this credit.**

> [!WARNING]
> A linked feature issue is required. Pull requests that do not link an existing feature issue—or link an issue that has not been approved by the maintainers—may be closed.

### Related Issue

Closes https://github.com/CnCNet/xna-cncnet-client/issues/1051

### What Changed

Added a new ini key `DisableModifierKeys` in `KeyboardCommands.ini`. 

Example in CnCNet YR:
```ini
[PlanningMode]
UIName=Waypoint Mode
Category=Interface
Description=Enable waypoint mode.
DefaultKey=90
DisableModifierKeys=true
```

When this option is set, only single key can be set for that keyboard command.

### Breaking Changes

- [ ] This pull request introduces a breaking change
- [X] This pull request does not introduce a breaking change

If checked, describe the breaking change and migration impact:

No breaking change.

### Documentation

- [X] Documentation update is needed and has been included
- [ ] Documentation update is not needed

### Checklist

- [X] I linked the corresponding feature issue above
- [X] This pull request is scoped to one feature only
- [x] I verified the implementation by running the client
