### PR TITLE
Add block user button on Private Message window

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/PrivateMessagingWindow.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/PrivateMessagingWindow.cs
@@ -62,6 +62,19 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
         private XNATextBox tbMessageInput;
 
+        private XNAClientButton btnBlockUser;
+
+        private readonly string BLOCK_USER = "Block User".L10N("Client:Main:BlockUser");
+        private readonly string UNBLOCK_USER = "Unblock User".L10N("Client:Main:UnblockUser");
+        private readonly string USER_BLOCKED = "{0} has been blocked.".L10N("Client:Main:UserBlocked");
+        private readonly string USER_UNBLOCKED = "{0} has been unblocked.".L10N("Client:Main:UserUnblocked");
+
+        /// <summary>
+        /// Users for which a WHOIS request to resolve their ident is pending,
+        /// so that multiple rapid clicks on the block button can't double-toggle.
+        /// </summary>
+        private readonly HashSet<string> pendingWhoIsUsers = new HashSet<string>();
+
         private GlobalContextMenu globalContextMenu;
 
         private CnCNetManager connectionManager;
@@ -184,6 +197,16 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             tbMessageInput.MaximumTextLength = 200;
             tbMessageInput.Enabled = false;
 
+            btnBlockUser = new XNAClientButton(WindowManager);
+            btnBlockUser.Name = nameof(btnBlockUser);
+            btnBlockUser.ClientRectangle = new Rectangle(
+                lbMessages.Right - UIDesignConstants.BUTTON_WIDTH_121,
+                lbMessages.Y - UIDesignConstants.BUTTON_HEIGHT,
+                UIDesignConstants.BUTTON_WIDTH_121,
+                UIDesignConstants.BUTTON_HEIGHT);
+            btnBlockUser.Text = BLOCK_USER;
+            btnBlockUser.LeftClick += BtnBlockUser_LeftClick;
+
             mclbRecentPlayerList = new RecentPlayerTable(WindowManager, connectionManager);
             mclbRecentPlayerList.ClientRectangle = new Rectangle(lbUserList.X, lbUserList.Y, lbMessages.Right - lbUserList.X, lbUserList.Height);
             mclbRecentPlayerList.PlayerRightClick += RecentPlayersList_RightClick;
@@ -203,6 +226,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             AddChild(lblMessages);
             AddChild(lbMessages);
             AddChild(tbMessageInput);
+            AddChild(btnBlockUser);
             AddChild(mclbRecentPlayerList);
             AddChild(globalContextMenu);
             WindowManager.AddAndInitializeControl(notificationBox);
@@ -259,6 +283,8 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
         private void ConnectionManager_UserRemoved(object sender, UserNameIndexEventArgs e)
         {
+            pendingWhoIsUsers.Remove(e.UserName);
+
             var pmUser = privateMessageUsers.Find(pmsgUser => pmsgUser.IrcUser.Name == e.UserName);
             ChatMessage leaveMessage = null;
 
@@ -333,7 +359,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
                     if (lbItem == lbUserList.SelectedItem)
                     {
-                        tbMessageInput.Enabled = true;
+                        tbMessageInput.Enabled = !IsUserBlocked(e.User);
 
                         if (joinMessage != null)
                             lbMessages.AddMessage(joinMessage);
@@ -376,6 +402,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             }
 
             lbUserList.SelectedIndexChanged += LbUserList_SelectedIndexChanged;
+            UpdateBlockUserButton();
         }
 
         public void SetInviteChannelInfo(string channelName, string gameName, string channelPassword)
@@ -426,6 +453,80 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
         }
 
         private bool IsPlayerOnline(string playerName) => !string.IsNullOrEmpty(playerName) && connectionManager.UserList.Find(u => u.Name == playerName) != null;
+
+        private bool IsUserBlocked(IRCUser ircUser) =>
+            ircUser != null && !string.IsNullOrEmpty(ircUser.Ident) && cncnetUserData.IsIgnored(ircUser.Ident);
+
+        private void UpdateBlockUserButton()
+        {
+            var ircUser = (IRCUser)lbUserList.SelectedItem?.Tag;
+
+            btnBlockUser.Enabled = ircUser != null;
+
+            if (ircUser == null || string.IsNullOrEmpty(ircUser.Ident))
+            {
+                btnBlockUser.Text = BLOCK_USER;
+                return;
+            }
+
+            btnBlockUser.Text = cncnetUserData.IsIgnored(ircUser.Ident) ? UNBLOCK_USER : BLOCK_USER;
+        }
+
+        private void BtnBlockUser_LeftClick(object sender, EventArgs e)
+        {
+            var ircUser = (IRCUser)lbUserList.SelectedItem?.Tag;
+            if (ircUser == null)
+                return;
+
+            if (!string.IsNullOrEmpty(ircUser.Ident))
+            {
+                ToggleIgnoreUserAndNotify(ircUser, ircUser.Ident);
+                return;
+            }
+
+            if (!pendingWhoIsUsers.Add(ircUser.Name))
+                return;
+
+            void WhoIsReply(object whoSender, WhoEventArgs whoEventargs)
+            {
+                if (whoEventargs.UserName != ircUser.Name)
+                    return;
+
+                connectionManager.WhoReplyReceived -= WhoIsReply;
+                pendingWhoIsUsers.Remove(ircUser.Name);
+
+                if (!string.IsNullOrEmpty(whoEventargs.Ident))
+                {
+                    ircUser.Ident = whoEventargs.Ident;
+                    ToggleIgnoreUserAndNotify(ircUser, whoEventargs.Ident);
+                }
+            }
+
+            connectionManager.WhoReplyReceived += WhoIsReply;
+            connectionManager.SendWhoIsMessage(ircUser.Name);
+        }
+
+        private void ToggleIgnoreUserAndNotify(IRCUser ircUser, string ident)
+        {
+            bool isBlocked = !cncnetUserData.IsIgnored(ident);
+            cncnetUserData.ToggleIgnoreUser(ident);
+            ircUser.IsIgnored = isBlocked;
+
+            ChatMessage systemMessage = new ChatMessage(string.Format(
+                isBlocked ? USER_BLOCKED : USER_UNBLOCKED, ircUser.Name));
+
+            PrivateMessageUser pmUser = privateMessageUsers.Find(u => u.IrcUser.Name == ircUser.Name);
+            if (pmUser != null)
+                pmUser.Messages.Add(systemMessage);
+
+            if (ReferenceEquals(lbUserList.SelectedItem?.Tag, ircUser))
+            {
+                lbMessages.AddMessage(systemMessage);
+                tbMessageInput.Enabled = IsPlayerOnline(ircUser.Name) && !isBlocked;
+            }
+
+            UpdateBlockUserButton();
+        }
 
         private void PrivateMessageHandler_PrivateMessageReceived(object sender, PrivateMessageEventArgs e)
         {
@@ -584,7 +685,8 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             }
 
             var ircUser = (IRCUser)lbUserList.SelectedItem.Tag;
-            tbMessageInput.Enabled = IsPlayerOnline(ircUser?.Name);
+            tbMessageInput.Enabled = IsPlayerOnline(ircUser?.Name) && !IsUserBlocked(ircUser);
+            UpdateBlockUserButton();
 
             var pmUser = privateMessageUsers.Find(u =>
                 u.IrcUser.Name == lbUserList.SelectedItem.Text);
@@ -669,6 +771,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 tbMessageInput.Disable();
                 lblMessages.Disable();
                 lbUserList.Disable();
+                btnBlockUser.Disable();
                 lblPlayers.Text = RECENT_PLAYERS_TEXT;
                 mclbRecentPlayerList.Enable();
             }
@@ -680,6 +783,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 lbUserList.Enable();
                 lblPlayers.Text = DEFAULT_PLAYERS_TEXT;
                 mclbRecentPlayerList.Disable();
+                UpdateBlockUserButton();
             }
         }
 

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/PrivateMessagingWindow.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/PrivateMessagingWindow.cs
@@ -73,7 +73,8 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
         /// Users for which a WHOIS request to resolve their ident is pending,
         /// so that multiple rapid clicks on the block button can't double-toggle.
         /// </summary>
-        private readonly HashSet<string> pendingWhoIsUsers = new HashSet<string>();
+        private readonly Dictionary<string, EventHandler<WhoEventArgs>> pendingWhoIsUsers =
+            new Dictionary<string, EventHandler<WhoEventArgs>>(StringComparer.OrdinalIgnoreCase);
 
         private GlobalContextMenu globalContextMenu;
 
@@ -283,7 +284,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
 
         private void ConnectionManager_UserRemoved(object sender, UserNameIndexEventArgs e)
         {
-            pendingWhoIsUsers.Remove(e.UserName);
+            CancelPendingWhoIs(e.UserName);
 
             var pmUser = privateMessageUsers.Find(pmsgUser => pmsgUser.IrcUser.Name == e.UserName);
             ChatMessage leaveMessage = null;
@@ -360,6 +361,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                     if (lbItem == lbUserList.SelectedItem)
                     {
                         tbMessageInput.Enabled = !IsUserBlocked(e.User);
+                        UpdateBlockUserButton();
 
                         if (joinMessage != null)
                             lbMessages.AddMessage(joinMessage);
@@ -484,26 +486,38 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
                 return;
             }
 
-            if (!pendingWhoIsUsers.Add(ircUser.Name))
+            if (pendingWhoIsUsers.ContainsKey(ircUser.Name))
                 return;
 
-            void WhoIsReply(object whoSender, WhoEventArgs whoEventargs)
+            EventHandler<WhoEventArgs> whoIsReply = (whoSender, whoEventargs) =>
             {
-                if (whoEventargs.UserName != ircUser.Name)
+                if (!string.Equals(whoEventargs.UserName, ircUser.Name, StringComparison.OrdinalIgnoreCase))
                     return;
 
-                connectionManager.WhoReplyReceived -= WhoIsReply;
-                pendingWhoIsUsers.Remove(ircUser.Name);
+                CancelPendingWhoIs(ircUser.Name);
 
                 if (!string.IsNullOrEmpty(whoEventargs.Ident))
                 {
                     ircUser.Ident = whoEventargs.Ident;
                     ToggleIgnoreUserAndNotify(ircUser, whoEventargs.Ident);
                 }
-            }
+            };
 
-            connectionManager.WhoReplyReceived += WhoIsReply;
+            pendingWhoIsUsers.Add(ircUser.Name, whoIsReply);
+            connectionManager.WhoReplyReceived += whoIsReply;
             connectionManager.SendWhoIsMessage(ircUser.Name);
+        }
+
+        private void CancelPendingWhoIs(string userName)
+        {
+            if (string.IsNullOrEmpty(userName))
+                return;
+
+            if (pendingWhoIsUsers.TryGetValue(userName, out EventHandler<WhoEventArgs> whoIsReply))
+            {
+                connectionManager.WhoReplyReceived -= whoIsReply;
+                pendingWhoIsUsers.Remove(userName);
+            }
         }
 
         private void ToggleIgnoreUserAndNotify(IRCUser ircUser, string ident)


### PR DESCRIPTION
## Feature Pull Request

> [!WARNING]
> A linked feature issue is required. Pull requests that do not link an existing feature issue—or link an issue that has not been approved by the maintainers—may be closed.

### Related Issue

Closes #1057 

### What Changed

Added block user button to private message window
<img width="609" height="606" alt="image" src="https://github.com/user-attachments/assets/798c4a17-ac2c-432a-a09f-2d1df4619f8a" />

### Breaking Changes

- [ ] This pull request introduces a breaking change
- [X] This pull request does not introduce a breaking change

If checked, describe the breaking change and migration impact:

<!-- Breaking change details -->

### Documentation

- [ ] Documentation update is needed and has been included
- [X] Documentation update is not needed

### Checklist

- [X] I linked the corresponding feature issue above
- [X] This pull request is scoped to one feature only
- [X] I verified the implementation by running the client
