### PR TITLE
Use a workaround for DLL search setup when running under Wine

### DIFF
--- a/DXMainClient/Program.cs
+++ b/DXMainClient/Program.cs
@@ -93,7 +93,7 @@ namespace DTAClient
                 if (IsRunningUnderWine())
                 {
                     // Wine and CrossOver export SetDefaultDllDirectories / AddDllDirectory,
-                    // so the availability check below succeeds. On real Windows those APIs
+                    // so areSecureDllLoadingAPIsAvailable() succeeds. On real Windows those APIs
                     // are the right way to load native libraries from
                     // SPECIFIC_LIBRARY_PATH/{arch} and COMMON_LIBRARY_PATH/{arch}:
                     // SetDefaultDllDirectories replaces the process default search path

--- a/DXMainClient/Program.cs
+++ b/DXMainClient/Program.cs
@@ -64,7 +64,10 @@ namespace DTAClient
             // does not search those subfolders by default, and HarfBuzzSharp's resolver looks
             // beside the EXE rather than beside its managed wrapper - so without help, P/Invoke
             // calls fail with "Unable to load library 'libHarfBuzzSharp'".
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            // In this Wine/Mono environment, SetDefaultDllDirectories changes how
+            // System.Windows.Forms resolves its native P/Invoke dependencies,
+            // causing user32.dll to fail to load even though it is available.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !IsRunningUnderWine())
             {
                 static bool areSecureDllLoadingAPIsAvailable()
                 {
@@ -135,6 +138,12 @@ namespace DTAClient
         [DllImport("kernel32.dll", CharSet = CharSet.Ansi, ExactSpelling = true, SetLastError = true, ThrowOnUnmappableChar = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         private static extern IntPtr GetProcAddress([In] IntPtr hModule, [In][MarshalAs(UnmanagedType.LPStr)] string lpProcName);
+
+        private static bool IsRunningUnderWine()
+        {
+            IntPtr ntdllModuleHandle = GetModuleHandle("ntdll");
+            return ntdllModuleHandle != IntPtr.Zero && GetProcAddress(ntdllModuleHandle, "wine_get_version") != IntPtr.Zero;
+        }
 #endif
 
         private static string COMMON_LIBRARY_PATH;

--- a/DXMainClient/Program.cs
+++ b/DXMainClient/Program.cs
@@ -64,10 +64,7 @@ namespace DTAClient
             // does not search those subfolders by default, and HarfBuzzSharp's resolver looks
             // beside the EXE rather than beside its managed wrapper - so without help, P/Invoke
             // calls fail with "Unable to load library 'libHarfBuzzSharp'".
-            // In this Wine/Mono environment, SetDefaultDllDirectories changes how
-            // System.Windows.Forms resolves its native P/Invoke dependencies,
-            // causing user32.dll to fail to load even though it is available.
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !IsRunningUnderWine())
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 static bool areSecureDllLoadingAPIsAvailable()
                 {
@@ -85,11 +82,6 @@ namespace DTAClient
                     return true;
                 }
 
-                if (!areSecureDllLoadingAPIsAvailable())
-                    throw new PlatformNotSupportedException("This application requires at least Windows 7 SP1 with KB4457144 (alternatively, KB2533623 or KB3063858) installed.");
-
-                SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_APPLICATION_DIR | LOAD_LIBRARY_SEARCH_USER_DIRS | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
-
                 string archSubfolder = RuntimeInformation.ProcessArchitecture switch
                 {
                     Architecture.X64 => "x64",
@@ -98,16 +90,71 @@ namespace DTAClient
                     _ => null
                 };
 
-                if (archSubfolder is not null)
+                if (IsRunningUnderWine())
                 {
-                    static void addDllDirectoryIfExists(string path)
-                    {
-                        if (Directory.Exists(path))
-                            AddDllDirectory(path);
-                    }
+                    // Wine/CrossOver: SetDefaultDllDirectories + AddDllDirectory is the correct
+                    // approach on Windows. After SetDefaultDllDirectories the process no longer
+                    // uses the standard search order (System32, Windows directory, PATH, current
+                    // directory). On Windows that is safe because user32/gdi32/... are Known DLLs
+                    // mapped from System32.
+                    //
+                    // Wine does not resolve those builtins the same way. They are placeholder
+                    // PEs plus Unix implementations found via Wine's own builtin path
+                    // (WINEDLLPATH, the Wine lib/wine tree), which is not a LOAD_LIBRARY_SEARCH_* directory.
+                    // Wine-Mono then P/Invokes user32.dll from System.Windows.Forms.Control's
+                    // type initializer and throws DllNotFoundException even though user32 is
+                    // present in the prefix. This is a Wine loader compatibility gap, not a
+                    // defect in the Windows search flags below. Wine still exports the secure
+                    // loading APIs, so the availability check below would succeed and the
+                    // restricted search would be applied — which is what breaks WinForms.
+                    //
+                    // Workaround: on Wine skip SetDefaultDllDirectories and prepend the
+                    // architecture subfolders to PATH so libHarfBuzzSharp (and similar) are
+                    // still found, while Wine's builtin search for user32/gdi32 remains intact.
+                    // AddDllDirectory is not used here because without SetDefaultDllDirectories
+                    // those directories are not part of the process default search path.
+                    //
+                    // If a future Wine/CrossOver build loads builtins correctly after
+                    // SetDefaultDllDirectories (verify with WinForms after that call, e.g.
+                    // Application.SetCompatibleTextRenderingDefault), this branch can be
+                    // removed and Wine can share the Windows path
+                    // (SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS) +
+                    // AddDllDirectory). Re-test before deleting the branch; CrossOver often
+                    // lags upstream Wine.
 
-                    addDllDirectoryIfExists(Path.Combine(SPECIFIC_LIBRARY_PATH, archSubfolder));
-                    addDllDirectoryIfExists(Path.Combine(COMMON_LIBRARY_PATH, archSubfolder));
+                    if (archSubfolder is not null)
+                    {
+                        static void prependToPathIfExists(string directory)
+                        {
+                            if (!Directory.Exists(directory))
+                                return;
+
+                            string current = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+                            Environment.SetEnvironmentVariable("PATH", directory + Path.PathSeparator + current);
+                        }
+
+                        prependToPathIfExists(Path.Combine(SPECIFIC_LIBRARY_PATH, archSubfolder));
+                        prependToPathIfExists(Path.Combine(COMMON_LIBRARY_PATH, archSubfolder));
+                    }
+                }
+                else
+                {
+                    if (!areSecureDllLoadingAPIsAvailable())
+                        throw new PlatformNotSupportedException("This application requires at least Windows 7 SP1 with KB4457144 (alternatively, KB2533623 or KB3063858) installed.");
+
+                    SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_APPLICATION_DIR | LOAD_LIBRARY_SEARCH_USER_DIRS | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+
+                    if (archSubfolder is not null)
+                    {
+                        static void addDllDirectoryIfExists(string path)
+                        {
+                            if (Directory.Exists(path))
+                                AddDllDirectory(path);
+                        }
+
+                        addDllDirectoryIfExists(Path.Combine(SPECIFIC_LIBRARY_PATH, archSubfolder));
+                        addDllDirectoryIfExists(Path.Combine(COMMON_LIBRARY_PATH, archSubfolder));
+                    }
                 }
             }
 #endif

--- a/DXMainClient/Program.cs
+++ b/DXMainClient/Program.cs
@@ -92,35 +92,42 @@ namespace DTAClient
 
                 if (IsRunningUnderWine())
                 {
-                    // Wine/CrossOver: SetDefaultDllDirectories + AddDllDirectory is the correct
-                    // approach on Windows. After SetDefaultDllDirectories the process no longer
-                    // uses the standard search order (System32, Windows directory, PATH, current
-                    // directory). On Windows that is safe because user32/gdi32/... are Known DLLs
-                    // mapped from System32.
+                    // Wine and CrossOver export SetDefaultDllDirectories / AddDllDirectory,
+                    // so the availability check below succeeds. On real Windows those APIs
+                    // are the right way to load native libraries from
+                    // SPECIFIC_LIBRARY_PATH/{arch} and COMMON_LIBRARY_PATH/{arch}:
+                    // SetDefaultDllDirectories replaces the process default search path
+                    // with application dir + System32 + AddDllDirectory folders, which
+                    // still finds system libraries because user32.dll, gdi32.dll, and
+                    // similar are Known DLLs mapped from System32.
                     //
-                    // Wine does not resolve those builtins the same way. They are placeholder
-                    // PEs plus Unix implementations found via Wine's own builtin path
-                    // (WINEDLLPATH, the Wine lib/wine tree), which is not a LOAD_LIBRARY_SEARCH_* directory.
-                    // Wine-Mono then P/Invokes user32.dll from System.Windows.Forms.Control's
-                    // type initializer and throws DllNotFoundException even though user32 is
-                    // present in the prefix. This is a Wine loader compatibility gap, not a
-                    // defect in the Windows search flags below. Wine still exports the secure
-                    // loading APIs, so the availability check below would succeed and the
-                    // restricted search would be applied — which is what breaks WinForms.
+                    // Wine does not implement that Known-DLL behaviour. Its user32/gdi32
+                    // are placeholder PE files whose real code lives in Unix libraries
+                    // discovered through Wine's private builtin path (WINEDLLPATH /
+                    // lib/wine), which is not one of the LOAD_LIBRARY_SEARCH_* directories.
+                    // After SetDefaultDllDirectories, LoadLibrary("user32.dll") therefore
+                    // fails. The first such call is the P/Invoke inside the static
+                    // constructor of System.Windows.Forms.Control (reached from
+                    // Application.SetCompatibleTextRenderingDefault). That surfaces as
+                    // TypeInitializationException wrapping DllNotFoundException for
+                    // user32.dll, even though user32 is present in the Wine prefix.
+                    // That failure is a Wine loader gap, not incorrect flags on Windows.
                     //
-                    // Workaround: on Wine skip SetDefaultDllDirectories and prepend the
-                    // architecture subfolders to PATH so libHarfBuzzSharp (and similar) are
-                    // still found, while Wine's builtin search for user32/gdi32 remains intact.
-                    // AddDllDirectory is not used here because without SetDefaultDllDirectories
-                    // those directories are not part of the process default search path.
+                    // Workaround: when running under Wine, do not call
+                    // SetDefaultDllDirectories. Prepend the architecture subfolders to
+                    // PATH instead so libHarfBuzzSharp.dll (and similar) are still found,
+                    // while Wine's default search continues to locate user32/gdi32.
+                    // AddDllDirectory is omitted on this path because, without
+                    // SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_USER_DIRS), those
+                    // directories are not part of the process default search path.
                     //
-                    // If a future Wine/CrossOver build loads builtins correctly after
-                    // SetDefaultDllDirectories (verify with WinForms after that call, e.g.
-                    // Application.SetCompatibleTextRenderingDefault), this branch can be
-                    // removed and Wine can share the Windows path
+                    // Removal condition: if a future Wine/CrossOver build can load
+                    // user32.dll via P/Invoke after SetDefaultDllDirectories — confirm by
+                    // running through Application.SetCompatibleTextRenderingDefault —
+                    // delete this branch and use the Windows path for Wine as well
                     // (SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS) +
-                    // AddDllDirectory). Re-test before deleting the branch; CrossOver often
-                    // lags upstream Wine.
+                    // AddDllDirectory). Re-test on CrossOver specifically; it often lags
+                    // upstream Wine.
 
                     if (archSubfolder is not null)
                     {


### PR DESCRIPTION
## Bug Fix Pull Request

### Related Issue

Fixes https://github.com/CnCNet/xna-cncnet-client/issues/1069

### What Changed

Detect Wine through the `wine_get_version` export in `ntdll`. On native Windows, keep the existing secure DLL-search setup using `SetDefaultDllDirectories` and `AddDllDirectory`. Under Wine, avoid `SetDefaultDllDirectories`, which causes Wine/Mono to fail resolving built-in Windows DLLs such as `user32.dll`, and instead prepend the architecture-specific native-library directories to `PATH` so native dependencies such as `libHarfBuzzSharp.dll` remain discoverable.

### Test Result without Your PR Applied

On CrossOver/Wine Mono, the 9.3.x client failed during Windows Forms initialization with `System.DllNotFoundException: user32.dll` after the secure DLL search initialization was introduced.

### Test Result with Your PR Applied

I personally tested the maintainer-provided Actions build in the same macOS / CrossOver `Steam` bottle.

I used run `33877803985` / artifact `9938706057` in a complete runtime package with the official `Fonts.ini` and font assets. The client reached the main menu without the previous `user32.dll` startup error. I opened `Options` and `Skirmish`, interacted with both screens, returned to the main menu, and exited normally.

The `client.log` from this run shows that `Fonts.ini` was loaded, text shaping remained enabled, 3 font indexes were loaded with 3 `FontSystems`, and startup completed successfully. It also contains `Exiting.` There was no `user32.dll` error, `System.DllNotFoundException`, or native HarfBuzz loading failure.

The artifact-provided files used in this test remained identical to the downloaded artifact.

### Breaking Changes

- [ ] This pull request introduces a breaking change
- [x] This pull request does not introduce a breaking change

### Documentation

- [ ] Documentation update is needed and has been included
- [x] Documentation update is not needed

### Checklist

- [x] I linked the corresponding bug issue above
- [x] This pull request is scoped to one bug fix only
- [x] I verified the fix by running the client with and without applying my PR. Verifier name: Oğuzhan Tanrıkulu (@oguzhantanrikulu)