### PR TITLE
Fix LAN host listener startup race

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
@@ -107,6 +107,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
         private TcpListener listener;
         private TcpClient client;
+        private readonly ManualResetEventSlim listenerReady = new(false);
         private volatile bool leaving;
         private int sessionId;
 
@@ -149,8 +150,13 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             if (isHost)
             {
                 RandomSeed = random.Next();
+                listenerReady.Reset();
+
                 Thread thread = new Thread(ListenForClients);
                 thread.Start();
+
+                if (!listenerReady.Wait(TimeSpan.FromSeconds(5)))
+                    throw new TimeoutException("LAN listener did not start within 5 seconds.");
 
                 this.client = new TcpClient();
                 this.client.Connect("127.0.0.1", ProgramConstants.LAN_GAME_LOBBY_PORT);
@@ -194,6 +200,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
         {
             listener = new TcpListener(IPAddress.Any, ProgramConstants.LAN_GAME_LOBBY_PORT);
             listener.Start();
+            listenerReady.Set();
 
             while (true)
             {


### PR DESCRIPTION
## Summary

Fixes a race condition when hosting LAN games where the local client can attempt to connect to the LAN lobby TCP listener before the listener has actually started.

## Problem

On Linux using the .NET 8 UniversalGL client, creating a LAN game consistently failed with:

    System.Net.Sockets.SocketException: Connection refused
    127.0.0.1:1233

`SetUp()` starts `ListenForClients()` on a new thread and immediately attempts to connect to `127.0.0.1:1233`. The listener thread is not guaranteed to have called `TcpListener.Start()` before that connection attempt occurs.

## Fix

Added a `ManualResetEventSlim` that is signaled immediately after `listener.Start()` succeeds. The host waits for that signal before attempting the local TCP connection.

A 5-second timeout is included so the client does not wait indefinitely if the listener fails to start.

## Testing

Tested with:

- Ubuntu 26.04.1
- .NET 8 UniversalGL client
- Yuri's Revenge / CnCNet client 2.13.3
- LAN host on Linux
- Remote Windows client

Before the change, port 1233 never reached LISTEN before the connection attempt and hosting consistently failed.

After the change:

- LAN game creation succeeds
- Local client connects successfully
- Remote Windows client joins successfully
- Game launches and plays normally

Firewall was also disabled during troubleshooting to rule out packet filtering as the cause.