### PR TITLE
Add Storage tab to Options window for log and save game rotation

### DIFF
--- a/ClientCore/GameLogManager.cs
+++ b/ClientCore/GameLogManager.cs
@@ -1,0 +1,133 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using ClientCore.Enums;
+
+using Rampastring.Tools;
+
+namespace ClientCore
+{
+    /// <summary>
+    /// Applies storage limits to the game's own debug folder: the logs Ares, Phobos and the spawner
+    /// write there, and the snapshot folders Ares creates for each crash or desync.
+    /// </summary>
+    public static class GameLogManager
+    {
+        private const string DEBUG_DIRECTORY_NAME = "debug";
+
+        /// <summary>Whether the game writes to the debug folder, which only Ares does.</summary>
+        public static bool IsSupported => ClientConfiguration.Instance.ClientGameType == ClientType.Ares;
+
+        public static void PruneGameLogs()
+        {
+            if (!IsSupported)
+                return;
+
+            PruneGameLogs(SafePath.GetDirectory(ProgramConstants.GamePath, DEBUG_DIRECTORY_NAME),
+                UserINISettings.Instance.MaxGameLogAgeDays.Value,
+                UserINISettings.Instance.MaxGameLogFolderSizeMB.Value,
+                DateTime.UtcNow);
+        }
+
+        internal static void PruneGameLogs(DirectoryInfo directory, int maxAgeDays, int maxFolderSizeMB, DateTime utcNow)
+        {
+            if (maxAgeDays <= 0 && maxFolderSizeMB <= 0)
+                return;
+
+            try
+            {
+                if (!directory.Exists)
+                    return;
+
+                // Each top-level entry is one log file or one snapshot folder, kept or deleted whole so
+                // a crash report is never left half there.
+                List<GameLogEntry> entries = directory.EnumerateFileSystemInfos("*", SearchOption.TopDirectoryOnly)
+                    .Select(GameLogEntry.Create)
+                    .OrderByDescending(entry => entry.LastWriteTimeUtc)
+                    .ThenBy(entry => entry.Info.Name, StringComparer.Ordinal)
+                    .ToList();
+
+                if (maxAgeDays > 0)
+                {
+                    DateTime threshold = utcNow.AddDays(-maxAgeDays);
+                    entries.RemoveAll(entry => entry.LastWriteTimeUtc <= threshold && TryDelete(entry));
+                }
+
+                if (maxFolderSizeMB > 0)
+                {
+                    long maxFolderSizeBytes = maxFolderSizeMB * 1024L * 1024L;
+                    long totalSize = entries.Sum(entry => entry.Size);
+
+                    // Always keep the newest entry - the last game's log - even if it alone exceeds the limit.
+                    for (int i = entries.Count - 1; i > 0 && totalSize > maxFolderSizeBytes; i--)
+                    {
+                        // Failed deletions still count as freed and are retried next time.
+                        totalSize -= entries[i].Size;
+                        TryDelete(entries[i]);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Log("Could not prune game logs: " + ex.Message);
+            }
+        }
+
+        private static bool TryDelete(GameLogEntry entry)
+        {
+            try
+            {
+                if (entry.Info is DirectoryInfo snapshotDirectory)
+                    snapshotDirectory.Delete(recursive: true);
+                else
+                    entry.Info.Delete();
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.Log("Could not delete game log " + entry.Info.Name + ": " + ex.Message);
+                return false;
+            }
+        }
+
+        private sealed class GameLogEntry
+        {
+            private GameLogEntry(FileSystemInfo info, long size, DateTime lastWriteTimeUtc)
+            {
+                Info = info;
+                Size = size;
+                LastWriteTimeUtc = lastWriteTimeUtc;
+            }
+
+            public FileSystemInfo Info { get; }
+
+            public long Size { get; }
+
+            public DateTime LastWriteTimeUtc { get; }
+
+            public static GameLogEntry Create(FileSystemInfo info)
+            {
+                if (info is not DirectoryInfo snapshotDirectory)
+                    return new GameLogEntry(info, ((FileInfo)info).Length, info.LastWriteTimeUtc);
+
+                // A snapshot is as recent as the newest file in it; the client copies logs into it
+                // after the game exits.
+                long size = 0;
+                DateTime lastWriteTimeUtc = snapshotDirectory.LastWriteTimeUtc;
+                foreach (FileInfo file in snapshotDirectory.EnumerateFiles("*", SearchOption.AllDirectories))
+                {
+                    size += file.Length;
+                    if (file.LastWriteTimeUtc > lastWriteTimeUtc)
+                        lastWriteTimeUtc = file.LastWriteTimeUtc;
+                }
+
+                return new GameLogEntry(info, size, lastWriteTimeUtc);
+            }
+        }
+    }
+}

--- a/ClientCore/GameLogManager.cs
+++ b/ClientCore/GameLogManager.cs
@@ -112,21 +112,28 @@ namespace ClientCore
 
             public static GameLogEntry Create(FileSystemInfo info)
             {
-                if (info is not DirectoryInfo snapshotDirectory)
-                    return new GameLogEntry(info, ((FileInfo)info).Length, info.LastWriteTimeUtc);
-
-                // A snapshot is as recent as the newest file in it; the client copies logs into it
-                // after the game exits.
-                long size = 0;
-                DateTime lastWriteTimeUtc = snapshotDirectory.LastWriteTimeUtc;
-                foreach (FileInfo file in snapshotDirectory.EnumerateFiles("*", SearchOption.AllDirectories))
+                switch (info)
                 {
-                    size += file.Length;
-                    if (file.LastWriteTimeUtc > lastWriteTimeUtc)
-                        lastWriteTimeUtc = file.LastWriteTimeUtc;
-                }
+                    case FileInfo fileInfo:
+                        return new GameLogEntry(info, fileInfo.Length, info.LastWriteTimeUtc);
 
-                return new GameLogEntry(info, size, lastWriteTimeUtc);
+                    case DirectoryInfo snapshotDirectory:
+                        // A snapshot is as recent as the newest file in it; the client copies logs into it
+                        // after the game exits.
+                        long size = 0;
+                        DateTime lastWriteTimeUtc = snapshotDirectory.LastWriteTimeUtc;
+                        foreach (FileInfo file in snapshotDirectory.EnumerateFiles("*", SearchOption.AllDirectories))
+                        {
+                            size += file.Length;
+                            if (file.LastWriteTimeUtc > lastWriteTimeUtc)
+                                lastWriteTimeUtc = file.LastWriteTimeUtc;
+                        }
+
+                        return new GameLogEntry(info, size, lastWriteTimeUtc);
+
+                    default:
+                        throw new ArgumentException("Unexpected file system info type: " + info.GetType().FullName, nameof(info));
+                }
             }
         }
     }

--- a/ClientCore/Settings/UserINISettings.cs
+++ b/ClientCore/Settings/UserINISettings.cs
@@ -22,6 +22,7 @@ namespace ClientCore
         public const string COMPATIBILITY = "Compatibility";
         public const string GAME_FILTERS = "GameFilters";
         public const string GAME_OPTION_FILTERS = "GameOptionFilters";
+        public const string CLIENT_LOGS = "ClientLogs";
         private const string FAVORITE_MAPS = "FavoriteMaps";
 
         private const bool DEFAULT_SHOW_FRIENDS_ONLY_GAMES = false;
@@ -181,6 +182,9 @@ namespace ClientCore
             AutoRemoveUnderscoresFromName = new BoolSetting(iniFile, OPTIONS, "AutoRemoveUnderscoresFromName", true);
             GenerateTranslationStub = new BoolSetting(iniFile, OPTIONS, nameof(GenerateTranslationStub), false);
             GenerateOnlyNewValuesInTranslationStub = new BoolSetting(iniFile, OPTIONS, nameof(GenerateOnlyNewValuesInTranslationStub), false);
+
+            MaxKeptClientLogFiles = new IntSetting(iniFile, CLIENT_LOGS, "MaxKeptLogFiles", 5);
+            MaxClientLogFolderSizeMB = new IntSetting(iniFile, CLIENT_LOGS, "MaxLogFolderSizeMB", 50);
 
             SortState = new IntSetting(iniFile, GAME_FILTERS, "SortState", (int)SortDirection.None);
             ShowFriendGamesOnly = new BoolSetting(iniFile, GAME_FILTERS, "ShowFriendGamesOnly", DEFAULT_SHOW_FRIENDS_ONLY_GAMES);
@@ -364,6 +368,12 @@ namespace ClientCore
         public BoolSetting GenerateOnlyNewValuesInTranslationStub { get; private set; }
 
         public List<string> FavoriteMaps { get; private set; }
+
+        /// <summary>Maximum number of old client log files to keep. 0 means unlimited.</summary>
+        public IntSetting MaxKeptClientLogFiles { get; private set; }
+
+        /// <summary>Maximum total size of old client log files in megabytes. 0 means unlimited.</summary>
+        public IntSetting MaxClientLogFolderSizeMB { get; private set; }
 
         public void SetValue(string section, string key, string value)
                => SettingsIni.SetStringValue(section, key, value);

--- a/ClientCore/Settings/UserINISettings.cs
+++ b/ClientCore/Settings/UserINISettings.cs
@@ -23,6 +23,7 @@ namespace ClientCore
         public const string GAME_FILTERS = "GameFilters";
         public const string GAME_OPTION_FILTERS = "GameOptionFilters";
         public const string CLIENT_LOGS = "ClientLogs";
+        public const string GAME_LOGS = "GameLogs";
         public const string SAVED_GAMES = "SavedGames";
         private const string FAVORITE_MAPS = "FavoriteMaps";
 
@@ -186,6 +187,9 @@ namespace ClientCore
 
             MaxKeptClientLogFiles = new IntSetting(iniFile, CLIENT_LOGS, "MaxKeptLogFiles", 20);
             MaxClientLogFolderSizeMB = new IntSetting(iniFile, CLIENT_LOGS, "MaxLogFolderSizeMB", 50);
+
+            MaxGameLogAgeDays = new IntSetting(iniFile, GAME_LOGS, "MaxGameLogAgeDays", 7);
+            MaxGameLogFolderSizeMB = new IntSetting(iniFile, GAME_LOGS, "MaxGameLogFolderSizeMB", 0);
 
             MaxKeptSavedGames = new IntSetting(iniFile, SAVED_GAMES, "MaxKeptSavedGames", 0);
             MaxSavedGameFolderSizeMB = new IntSetting(iniFile, SAVED_GAMES, "MaxSavedGameFolderSizeMB", 0);
@@ -378,6 +382,12 @@ namespace ClientCore
 
         /// <summary>Maximum total size of old client log files in megabytes. 0 means unlimited.</summary>
         public IntSetting MaxClientLogFolderSizeMB { get; private set; }
+
+        /// <summary>Days after which game logs and crash snapshots in the debug folder are deleted. 0 means never.</summary>
+        public IntSetting MaxGameLogAgeDays { get; private set; }
+
+        /// <summary>Maximum total size of the game's debug folder in megabytes. 0 means unlimited.</summary>
+        public IntSetting MaxGameLogFolderSizeMB { get; private set; }
 
         /// <summary>Maximum number of single-player saved games to keep. 0 means unlimited.</summary>
         public IntSetting MaxKeptSavedGames { get; private set; }

--- a/ClientCore/Settings/UserINISettings.cs
+++ b/ClientCore/Settings/UserINISettings.cs
@@ -23,6 +23,7 @@ namespace ClientCore
         public const string GAME_FILTERS = "GameFilters";
         public const string GAME_OPTION_FILTERS = "GameOptionFilters";
         public const string CLIENT_LOGS = "ClientLogs";
+        public const string SAVED_GAMES = "SavedGames";
         private const string FAVORITE_MAPS = "FavoriteMaps";
 
         private const bool DEFAULT_SHOW_FRIENDS_ONLY_GAMES = false;
@@ -183,8 +184,11 @@ namespace ClientCore
             GenerateTranslationStub = new BoolSetting(iniFile, OPTIONS, nameof(GenerateTranslationStub), false);
             GenerateOnlyNewValuesInTranslationStub = new BoolSetting(iniFile, OPTIONS, nameof(GenerateOnlyNewValuesInTranslationStub), false);
 
-            MaxKeptClientLogFiles = new IntSetting(iniFile, CLIENT_LOGS, "MaxKeptLogFiles", 5);
+            MaxKeptClientLogFiles = new IntSetting(iniFile, CLIENT_LOGS, "MaxKeptLogFiles", 20);
             MaxClientLogFolderSizeMB = new IntSetting(iniFile, CLIENT_LOGS, "MaxLogFolderSizeMB", 50);
+
+            MaxKeptSavedGames = new IntSetting(iniFile, SAVED_GAMES, "MaxKeptSavedGames", 0);
+            MaxSavedGameFolderSizeMB = new IntSetting(iniFile, SAVED_GAMES, "MaxSavedGameFolderSizeMB", 0);
 
             SortState = new IntSetting(iniFile, GAME_FILTERS, "SortState", (int)SortDirection.None);
             ShowFriendGamesOnly = new BoolSetting(iniFile, GAME_FILTERS, "ShowFriendGamesOnly", DEFAULT_SHOW_FRIENDS_ONLY_GAMES);
@@ -374,6 +378,12 @@ namespace ClientCore
 
         /// <summary>Maximum total size of old client log files in megabytes. 0 means unlimited.</summary>
         public IntSetting MaxClientLogFolderSizeMB { get; private set; }
+
+        /// <summary>Maximum number of single-player saved games to keep. 0 means unlimited.</summary>
+        public IntSetting MaxKeptSavedGames { get; private set; }
+
+        /// <summary>Maximum total size of single-player saved games in megabytes. 0 means unlimited.</summary>
+        public IntSetting MaxSavedGameFolderSizeMB { get; private set; }
 
         public void SetValue(string section, string key, string value)
                => SettingsIni.SetStringValue(section, key, value);

--- a/ClientCore/SinglePlayerSavedGameManager.cs
+++ b/ClientCore/SinglePlayerSavedGameManager.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/ClientCore/SinglePlayerSavedGameManager.cs
+++ b/ClientCore/SinglePlayerSavedGameManager.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using Rampastring.Tools;
+
+namespace ClientCore
+{
+    /// <summary>Applies optional storage limits to single-player saved games.</summary>
+    public static class SinglePlayerSavedGameManager
+    {
+        public static void PruneSavedGames()
+        {
+            PruneSavedGames(SafePath.GetDirectory(ProgramConstants.GamePath, "Saved Games"),
+                UserINISettings.Instance.MaxKeptSavedGames.Value,
+                UserINISettings.Instance.MaxSavedGameFolderSizeMB.Value);
+        }
+
+        internal static void PruneSavedGames(DirectoryInfo directory, int maxKeptSavedGames, int maxFolderSizeMB)
+        {
+            if (maxKeptSavedGames <= 0 && maxFolderSizeMB <= 0)
+                return;
+
+            try
+            {
+                if (!directory.Exists)
+                    return;
+
+                // Match only single-player saves, leaving multiplayer saves and metadata alone.
+                List<FileInfo> saves = directory.EnumerateFiles("*", SearchOption.TopDirectoryOnly)
+                    .Where(file => string.Equals(file.Extension, ".SAV", StringComparison.OrdinalIgnoreCase))
+                    .OrderByDescending(file => file.LastWriteTimeUtc)
+                    .ThenBy(file => file.Name, StringComparer.Ordinal)
+                    .ToList();
+
+                int remainingCount = saves.Count;
+                long totalSize = saves.Sum(file => file.Length);
+                long maxFolderSizeBytes = maxFolderSizeMB * 1024L * 1024L;
+
+                // Always preserve the newest save, even when it alone exceeds the size limit.
+                for (int i = saves.Count - 1; i > 0; i--)
+                {
+                    if ((maxKeptSavedGames <= 0 || remainingCount <= maxKeptSavedGames) &&
+                        (maxFolderSizeMB <= 0 || totalSize <= maxFolderSizeBytes))
+                        break;
+
+                    FileInfo save = saves[i];
+                    try
+                    {
+                        long size = save.Length;
+                        save.Delete();
+                        remainingCount--;
+                        totalSize -= size;
+                        Logger.Log("Deleted old single-player saved game: " + save.Name);
+                    }
+                    catch (Exception ex)
+                    {
+                        // Failed deletions still count towards both limits and can be retried next time.
+                        Logger.Log("Could not delete single-player saved game " + save.Name + ": " + ex.Message);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Log("Could not prune single-player saved games: " + ex.Message);
+            }
+        }
+    }
+}

--- a/ClientGUI/GameProcessLogic.cs
+++ b/ClientGUI/GameProcessLogic.cs
@@ -169,6 +169,7 @@ namespace ClientGUI
             Process proc = (Process)sender;
             proc.Exited -= Process_Exited;
             proc.Dispose();
+            SinglePlayerSavedGameManager.PruneSavedGames();
             GameProcessExited?.Invoke();
         }
     }

--- a/DXMainClient/DXGUI/Generic/OptionPanels/StorageOptionsPanel.cs
+++ b/DXMainClient/DXGUI/Generic/OptionPanels/StorageOptionsPanel.cs
@@ -1,0 +1,117 @@
+#nullable enable
+
+using System;
+
+using ClientCore;
+using ClientCore.Extensions;
+
+using ClientGUI;
+
+using Microsoft.Xna.Framework;
+
+using Rampastring.XNAUI;
+using Rampastring.XNAUI.XNAControls;
+
+namespace DTAClient.DXGUI.Generic.OptionPanels;
+
+/// <summary>Configures how much disk space client logs and (if supported) replays are allowed to use.</summary>
+class StorageOptionsPanel : XNAOptionsPanel
+{
+    private const int TEXT_BOX_WIDTH = 70;
+    private const int TEXT_BOX_HEIGHT = 21;
+    private const int TEXT_BOX_X = 170;
+    private const int ROW_SPACING = 30;
+    private const int MAX_KEPT_FILES_LIMIT = 100000;
+    private const int MAX_FOLDER_SIZE_LIMIT_MB = 1024 * 1024;
+
+    public StorageOptionsPanel(WindowManager windowManager, UserINISettings iniSettings)
+        : base(windowManager, iniSettings)
+    {
+    }
+
+    private XNATextBox tbMaxKeptLogFiles = null!;
+    private XNATextBox tbMaxLogFolderSize = null!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        Name = "StorageOptionsPanel";
+
+        var lblLogsHeader = new XNALabel(WindowManager);
+        lblLogsHeader.Name = nameof(lblLogsHeader);
+        lblLogsHeader.FontIndex = 1;
+        lblLogsHeader.Text = "Client Logs".L10N("Client:DTAConfig:StorageLogsHeader");
+        lblLogsHeader.ClientRectangle = new Rectangle(12, 14, 0, 0);
+
+        var lblKeptLogFiles = new XNALabel(WindowManager);
+        lblKeptLogFiles.Name = nameof(lblKeptLogFiles);
+        lblKeptLogFiles.Text = "Keep at most:".L10N("Client:DTAConfig:StorageKeepAtMost");
+        lblKeptLogFiles.ClientRectangle = new Rectangle(12, lblLogsHeader.Bottom + ROW_SPACING - 12, 0, 0);
+
+        tbMaxKeptLogFiles = new XNATextBox(WindowManager);
+        tbMaxKeptLogFiles.Name = nameof(tbMaxKeptLogFiles);
+        tbMaxKeptLogFiles.MaximumTextLength = 6;
+        tbMaxKeptLogFiles.ClientRectangle = new Rectangle(
+            TEXT_BOX_X, lblKeptLogFiles.Y - 4, TEXT_BOX_WIDTH, TEXT_BOX_HEIGHT);
+
+        var lblKeptLogFilesSuffix = new XNALabel(WindowManager);
+        lblKeptLogFilesSuffix.Name = nameof(lblKeptLogFilesSuffix);
+        lblKeptLogFilesSuffix.Text = "old log files  (0 = no limit)".L10N("Client:DTAConfig:StorageKeepLogsAtMostSuffix");
+        lblKeptLogFilesSuffix.ClientRectangle = new Rectangle(
+            tbMaxKeptLogFiles.Right + 8, lblKeptLogFiles.Y, 0, 0);
+
+        var lblLogFolderSize = new XNALabel(WindowManager);
+        lblLogFolderSize.Name = nameof(lblLogFolderSize);
+        lblLogFolderSize.Text = "Maximum size:".L10N("Client:DTAConfig:StorageMaxSize");
+        lblLogFolderSize.ClientRectangle = new Rectangle(12, lblKeptLogFiles.Y + ROW_SPACING, 0, 0);
+
+        tbMaxLogFolderSize = new XNATextBox(WindowManager);
+        tbMaxLogFolderSize.Name = nameof(tbMaxLogFolderSize);
+        tbMaxLogFolderSize.MaximumTextLength = 7;
+        tbMaxLogFolderSize.ClientRectangle = new Rectangle(
+            TEXT_BOX_X, lblLogFolderSize.Y - 4, TEXT_BOX_WIDTH, TEXT_BOX_HEIGHT);
+
+        var lblLogFolderSizeSuffix = new XNALabel(WindowManager);
+        lblLogFolderSizeSuffix.Name = nameof(lblLogFolderSizeSuffix);
+        lblLogFolderSizeSuffix.Text = "MB  (0 = no limit)".L10N("Client:DTAConfig:StorageMaxSizeSuffix");
+        lblLogFolderSizeSuffix.ClientRectangle = new Rectangle(
+            tbMaxLogFolderSize.Right + 8, lblLogFolderSize.Y, 0, 0);
+
+        AddChild(lblLogsHeader);
+        AddChild(lblKeptLogFiles);
+        AddChild(tbMaxKeptLogFiles);
+        AddChild(lblKeptLogFilesSuffix);
+        AddChild(lblLogFolderSize);
+        AddChild(tbMaxLogFolderSize);
+        AddChild(lblLogFolderSizeSuffix);
+    }
+
+    public override void Load()
+    {
+        base.Load();
+
+        tbMaxKeptLogFiles.Text = IniSettings.MaxKeptClientLogFiles.Value.ToString();
+        tbMaxLogFolderSize.Text = IniSettings.MaxClientLogFolderSizeMB.Value.ToString();
+    }
+
+    public override bool Save()
+    {
+        bool restartRequired = base.Save();
+
+        IniSettings.MaxKeptClientLogFiles.Value =
+            ParseLimit(tbMaxKeptLogFiles.Text, IniSettings.MaxKeptClientLogFiles.Value, MAX_KEPT_FILES_LIMIT);
+        IniSettings.MaxClientLogFolderSizeMB.Value =
+            ParseLimit(tbMaxLogFolderSize.Text, IniSettings.MaxClientLogFolderSizeMB.Value, MAX_FOLDER_SIZE_LIMIT_MB);
+
+        return restartRequired;
+    }
+
+    private static int ParseLimit(string? text, int previousValue, int maximum)
+    {
+        if (!int.TryParse(text?.Trim(), out int value) || value < 0)
+            return previousValue;
+
+        return Math.Min(value, maximum);
+    }
+}

--- a/DXMainClient/DXGUI/Generic/OptionPanels/StorageOptionsPanel.cs
+++ b/DXMainClient/DXGUI/Generic/OptionPanels/StorageOptionsPanel.cs
@@ -93,7 +93,7 @@ class StorageOptionsPanel : XNAOptionsPanel
         var lblLogsHeader = new XNALabel(WindowManager);
         lblLogsHeader.Name = nameof(lblLogsHeader);
         lblLogsHeader.FontIndex = 1;
-        lblLogsHeader.Text = "Client logs".L10N("Client:DTAConfig:StorageLogsHeader");
+        lblLogsHeader.Text = "Client Logs".L10N("Client:DTAConfig:StorageLogsHeader");
         lblLogsHeader.ClientRectangle = new Rectangle(12, y, 0, 0);
 
         var lblKeptLogFiles = new XNALabel(WindowManager);
@@ -197,7 +197,7 @@ class StorageOptionsPanel : XNAOptionsPanel
         var lblSavedGamesHeader = new XNALabel(WindowManager);
         lblSavedGamesHeader.Name = nameof(lblSavedGamesHeader);
         lblSavedGamesHeader.FontIndex = 1;
-        lblSavedGamesHeader.Text = "Single-player saved games".L10N("Client:DTAConfig:StorageSavedGamesHeader");
+        lblSavedGamesHeader.Text = "Single-player Saved Games".L10N("Client:DTAConfig:StorageSavedGamesHeader");
         lblSavedGamesHeader.ClientRectangle = new Rectangle(12, y, 0, 0);
 
         var lblKeptSavedGames = new XNALabel(WindowManager);

--- a/DXMainClient/DXGUI/Generic/OptionPanels/StorageOptionsPanel.cs
+++ b/DXMainClient/DXGUI/Generic/OptionPanels/StorageOptionsPanel.cs
@@ -197,7 +197,7 @@ class StorageOptionsPanel : XNAOptionsPanel
         var lblSavedGamesHeader = new XNALabel(WindowManager);
         lblSavedGamesHeader.Name = nameof(lblSavedGamesHeader);
         lblSavedGamesHeader.FontIndex = 1;
-        lblSavedGamesHeader.Text = "Single-player Saved Games".L10N("Client:DTAConfig:StorageSavedGamesHeader");
+        lblSavedGamesHeader.Text = "Single-Player Saved Games".L10N("Client:DTAConfig:StorageSavedGamesHeader");
         lblSavedGamesHeader.ClientRectangle = new Rectangle(12, y, 0, 0);
 
         var lblKeptSavedGames = new XNALabel(WindowManager);

--- a/DXMainClient/DXGUI/Generic/OptionPanels/StorageOptionsPanel.cs
+++ b/DXMainClient/DXGUI/Generic/OptionPanels/StorageOptionsPanel.cs
@@ -93,7 +93,7 @@ class StorageOptionsPanel : XNAOptionsPanel
         var lblLogsHeader = new XNALabel(WindowManager);
         lblLogsHeader.Name = nameof(lblLogsHeader);
         lblLogsHeader.FontIndex = 1;
-        lblLogsHeader.Text = "Client Logs".L10N("Client:DTAConfig:StorageLogsHeader");
+        lblLogsHeader.Text = "Client logs".L10N("Client:DTAConfig:StorageLogsHeader");
         lblLogsHeader.ClientRectangle = new Rectangle(12, y, 0, 0);
 
         var lblKeptLogFiles = new XNALabel(WindowManager);
@@ -197,7 +197,7 @@ class StorageOptionsPanel : XNAOptionsPanel
         var lblSavedGamesHeader = new XNALabel(WindowManager);
         lblSavedGamesHeader.Name = nameof(lblSavedGamesHeader);
         lblSavedGamesHeader.FontIndex = 1;
-        lblSavedGamesHeader.Text = "Single-player Saved Games".L10N("Client:DTAConfig:StorageSavedGamesHeader");
+        lblSavedGamesHeader.Text = "Single-player saved games".L10N("Client:DTAConfig:StorageSavedGamesHeader");
         lblSavedGamesHeader.ClientRectangle = new Rectangle(12, y, 0, 0);
 
         var lblKeptSavedGames = new XNALabel(WindowManager);

--- a/DXMainClient/DXGUI/Generic/OptionPanels/StorageOptionsPanel.cs
+++ b/DXMainClient/DXGUI/Generic/OptionPanels/StorageOptionsPanel.cs
@@ -23,16 +23,32 @@ class StorageOptionsPanel : XNAOptionsPanel
     private const int ROW_SPACING = 30;
     private const int MAX_KEPT_FILES_LIMIT = 100000;
     private const int MAX_FOLDER_SIZE_LIMIT_MB = 1024 * 1024;
+    private const int MAX_AGE_DAYS_LIMIT = 3650;
+
+    /// <summary>Exposes the content panel, which holds everything that scrolls.</summary>
+    private sealed class StorageScrollPanel : XNAScrollPanel
+    {
+        public StorageScrollPanel(WindowManager windowManager) : base(windowManager)
+        {
+        }
+
+        public XNAPanel Content => ContentPanel;
+    }
 
     public StorageOptionsPanel(WindowManager windowManager, UserINISettings iniSettings)
         : base(windowManager, iniSettings)
     {
     }
 
+    private StorageScrollPanel scrollPanel = null!;
+
     private XNATextBox tbMaxKeptLogFiles = null!;
     private XNATextBox tbMaxLogFolderSize = null!;
     private XNATextBox tbMaxKeptSavedGames = null!;
     private XNATextBox tbMaxSavedGameFolderSize = null!;
+
+    private XNATextBox? tbMaxGameLogAge;
+    private XNATextBox? tbMaxGameLogFolderSize;
 
     public override void Initialize()
     {
@@ -40,11 +56,45 @@ class StorageOptionsPanel : XNAOptionsPanel
 
         Name = "StorageOptionsPanel";
 
+        // The sections outgrow the panel once every feature is enabled, so they scroll.
+        scrollPanel = new StorageScrollPanel(WindowManager);
+        scrollPanel.Name = nameof(scrollPanel);
+        scrollPanel.ClientRectangle = new Rectangle(0, 0, Width, Height);
+        scrollPanel.DrawBorders = false;
+        scrollPanel.AllowScroll = (false, true);
+        // Arrow keys belong to the text boxes.
+        scrollPanel.AllowKeyboardInput = false;
+        scrollPanel.ScrollStep = ROW_SPACING;
+        AddChild(scrollPanel);
+
+        int nextSectionY = InitializeClientLogSection(14);
+
+        if (GameLogManager.IsSupported)
+            nextSectionY = InitializeGameLogSection(nextSectionY);
+
+        nextSectionY = InitializeSavedGameSection(nextSectionY);
+
+        // A spacer so the last row does not sit flush against the bottom edge when scrolled down.
+        var bottomMargin = new XNAPanel(WindowManager);
+        bottomMargin.Name = nameof(bottomMargin);
+        bottomMargin.DrawBorders = false;
+        bottomMargin.ClientRectangle = new Rectangle(0, nextSectionY, 1, 1);
+        AddContent(bottomMargin);
+    }
+
+    private void AddContent(params XNAControl[] controls)
+    {
+        foreach (XNAControl control in controls)
+            scrollPanel.Content.AddChild(control);
+    }
+
+    private int InitializeClientLogSection(int y)
+    {
         var lblLogsHeader = new XNALabel(WindowManager);
         lblLogsHeader.Name = nameof(lblLogsHeader);
         lblLogsHeader.FontIndex = 1;
         lblLogsHeader.Text = "Client Logs".L10N("Client:DTAConfig:StorageLogsHeader");
-        lblLogsHeader.ClientRectangle = new Rectangle(12, 14, 0, 0);
+        lblLogsHeader.ClientRectangle = new Rectangle(12, y, 0, 0);
 
         var lblKeptLogFiles = new XNALabel(WindowManager);
         lblKeptLogFiles.Name = nameof(lblKeptLogFiles);
@@ -80,18 +130,69 @@ class StorageOptionsPanel : XNAOptionsPanel
         lblLogFolderSizeSuffix.ClientRectangle = new Rectangle(
             tbMaxLogFolderSize.Right + 8, lblLogFolderSize.Y, 0, 0);
 
-        AddChild(lblLogsHeader);
-        AddChild(lblKeptLogFiles);
-        AddChild(tbMaxKeptLogFiles);
-        AddChild(lblKeptLogFilesSuffix);
-        AddChild(lblLogFolderSize);
-        AddChild(tbMaxLogFolderSize);
-        AddChild(lblLogFolderSizeSuffix);
+        AddContent(lblLogsHeader, lblKeptLogFiles, tbMaxKeptLogFiles, lblKeptLogFilesSuffix,
+            lblLogFolderSize, tbMaxLogFolderSize, lblLogFolderSizeSuffix);
 
-        InitializeSavedGameSection(lblLogFolderSize.Y + ROW_SPACING * 2);
+        return lblLogFolderSize.Y + ROW_SPACING;
     }
 
-    private void InitializeSavedGameSection(int y)
+    private int InitializeGameLogSection(int y)
+    {
+        var lblGameLogsHeader = new XNALabel(WindowManager);
+        lblGameLogsHeader.Name = nameof(lblGameLogsHeader);
+        lblGameLogsHeader.FontIndex = 1;
+        lblGameLogsHeader.Text = "Game Logs".L10N("Client:DTAConfig:StorageGameLogsHeader");
+        lblGameLogsHeader.ClientRectangle = new Rectangle(12, y, 0, 0);
+
+        var lblGameLogAge = new XNALabel(WindowManager);
+        lblGameLogAge.Name = nameof(lblGameLogAge);
+        lblGameLogAge.Text = "Delete after:".L10N("Client:DTAConfig:StorageDeleteAfter");
+        lblGameLogAge.ClientRectangle = new Rectangle(12, lblGameLogsHeader.Bottom + ROW_SPACING - 12, 0, 0);
+
+        var tbMaxGameLogAge = new XNATextBox(WindowManager);
+        tbMaxGameLogAge.Name = nameof(tbMaxGameLogAge);
+        tbMaxGameLogAge.MaximumTextLength = 4;
+        tbMaxGameLogAge.ClientRectangle = new Rectangle(
+            TEXT_BOX_X, lblGameLogAge.Y - 4, TEXT_BOX_WIDTH, TEXT_BOX_HEIGHT);
+        this.tbMaxGameLogAge = tbMaxGameLogAge;
+
+        var lblGameLogAgeSuffix = new XNALabel(WindowManager);
+        lblGameLogAgeSuffix.Name = nameof(lblGameLogAgeSuffix);
+        lblGameLogAgeSuffix.Text = "days  (0 = never)".L10N("Client:DTAConfig:StorageDeleteAfterDaysSuffix");
+        lblGameLogAgeSuffix.ClientRectangle = new Rectangle(
+            tbMaxGameLogAge.Right + 8, lblGameLogAge.Y, 0, 0);
+
+        var lblGameLogFolderSize = new XNALabel(WindowManager);
+        lblGameLogFolderSize.Name = nameof(lblGameLogFolderSize);
+        lblGameLogFolderSize.Text = "Maximum size:".L10N("Client:DTAConfig:StorageMaxSize");
+        lblGameLogFolderSize.ClientRectangle = new Rectangle(12, lblGameLogAge.Y + ROW_SPACING, 0, 0);
+
+        var tbMaxGameLogFolderSize = new XNATextBox(WindowManager);
+        tbMaxGameLogFolderSize.Name = nameof(tbMaxGameLogFolderSize);
+        tbMaxGameLogFolderSize.MaximumTextLength = 7;
+        tbMaxGameLogFolderSize.ClientRectangle = new Rectangle(
+            TEXT_BOX_X, lblGameLogFolderSize.Y - 4, TEXT_BOX_WIDTH, TEXT_BOX_HEIGHT);
+        this.tbMaxGameLogFolderSize = tbMaxGameLogFolderSize;
+
+        var lblGameLogFolderSizeSuffix = new XNALabel(WindowManager);
+        lblGameLogFolderSizeSuffix.Name = nameof(lblGameLogFolderSizeSuffix);
+        lblGameLogFolderSizeSuffix.Text = "MB  (0 = no limit)".L10N("Client:DTAConfig:StorageMaxSizeSuffix");
+        lblGameLogFolderSizeSuffix.ClientRectangle = new Rectangle(
+            tbMaxGameLogFolderSize.Right + 8, lblGameLogFolderSize.Y, 0, 0);
+
+        var lblGameLogRetentionHint = new XNALabel(WindowManager);
+        lblGameLogRetentionHint.Name = nameof(lblGameLogRetentionHint);
+        lblGameLogRetentionHint.ClientRectangle = new Rectangle(12, lblGameLogFolderSize.Y + ROW_SPACING, 0, 0);
+        lblGameLogRetentionHint.Text = ("The game's debug folder: its logs and the snapshots saved for crashes and desyncs.\n" +
+            "Applied at client startup; the newest is always kept.").L10N("Client:DTAConfig:StorageGameLogRetentionHint");
+
+        AddContent(lblGameLogsHeader, lblGameLogAge, tbMaxGameLogAge, lblGameLogAgeSuffix,
+            lblGameLogFolderSize, tbMaxGameLogFolderSize, lblGameLogFolderSizeSuffix, lblGameLogRetentionHint);
+
+        return lblGameLogRetentionHint.Bottom + 12;
+    }
+
+    private int InitializeSavedGameSection(int y)
     {
         var lblSavedGamesHeader = new XNALabel(WindowManager);
         lblSavedGamesHeader.Name = nameof(lblSavedGamesHeader);
@@ -135,18 +236,14 @@ class StorageOptionsPanel : XNAOptionsPanel
 
         var lblSavedGameRetentionHint = new XNALabel(WindowManager);
         lblSavedGameRetentionHint.Name = nameof(lblSavedGameRetentionHint);
+        lblSavedGameRetentionHint.ClientRectangle = new Rectangle(12, lblSavedGameFolderSize.Y + ROW_SPACING, 0, 0);
         lblSavedGameRetentionHint.Text = ("Limits permanently delete oldest saves at client startup and after games.\n" +
             "The newest save is always kept, even if it exceeds the size limit.").L10N("Client:DTAConfig:StorageSavedGameRetentionHint");
-        lblSavedGameRetentionHint.ClientRectangle = new Rectangle(12, lblSavedGameFolderSize.Y + ROW_SPACING, 0, 0);
 
-        AddChild(lblSavedGamesHeader);
-        AddChild(lblKeptSavedGames);
-        AddChild(tbMaxKeptSavedGames);
-        AddChild(lblKeptSavedGamesSuffix);
-        AddChild(lblSavedGameFolderSize);
-        AddChild(tbMaxSavedGameFolderSize);
-        AddChild(lblSavedGameFolderSizeSuffix);
-        AddChild(lblSavedGameRetentionHint);
+        AddContent(lblSavedGamesHeader, lblKeptSavedGames, tbMaxKeptSavedGames, lblKeptSavedGamesSuffix,
+            lblSavedGameFolderSize, tbMaxSavedGameFolderSize, lblSavedGameFolderSizeSuffix, lblSavedGameRetentionHint);
+
+        return lblSavedGameRetentionHint.Bottom + 12;
     }
 
     public override void Load()
@@ -157,6 +254,12 @@ class StorageOptionsPanel : XNAOptionsPanel
         tbMaxLogFolderSize.Text = IniSettings.MaxClientLogFolderSizeMB.Value.ToString();
         tbMaxKeptSavedGames.Text = IniSettings.MaxKeptSavedGames.Value.ToString();
         tbMaxSavedGameFolderSize.Text = IniSettings.MaxSavedGameFolderSizeMB.Value.ToString();
+
+        if (GameLogManager.IsSupported)
+        {
+            tbMaxGameLogAge!.Text = IniSettings.MaxGameLogAgeDays.Value.ToString();
+            tbMaxGameLogFolderSize!.Text = IniSettings.MaxGameLogFolderSizeMB.Value.ToString();
+        }
     }
 
     public override bool Save()
@@ -171,6 +274,14 @@ class StorageOptionsPanel : XNAOptionsPanel
             ParseLimit(tbMaxKeptSavedGames.Text, IniSettings.MaxKeptSavedGames.Value, MAX_KEPT_FILES_LIMIT);
         IniSettings.MaxSavedGameFolderSizeMB.Value =
             ParseLimit(tbMaxSavedGameFolderSize.Text, IniSettings.MaxSavedGameFolderSizeMB.Value, MAX_FOLDER_SIZE_LIMIT_MB);
+
+        if (GameLogManager.IsSupported)
+        {
+            IniSettings.MaxGameLogAgeDays.Value =
+                ParseLimit(tbMaxGameLogAge!.Text, IniSettings.MaxGameLogAgeDays.Value, MAX_AGE_DAYS_LIMIT);
+            IniSettings.MaxGameLogFolderSizeMB.Value =
+                ParseLimit(tbMaxGameLogFolderSize!.Text, IniSettings.MaxGameLogFolderSizeMB.Value, MAX_FOLDER_SIZE_LIMIT_MB);
+        }
 
         return restartRequired;
     }

--- a/DXMainClient/DXGUI/Generic/OptionPanels/StorageOptionsPanel.cs
+++ b/DXMainClient/DXGUI/Generic/OptionPanels/StorageOptionsPanel.cs
@@ -31,6 +31,8 @@ class StorageOptionsPanel : XNAOptionsPanel
 
     private XNATextBox tbMaxKeptLogFiles = null!;
     private XNATextBox tbMaxLogFolderSize = null!;
+    private XNATextBox tbMaxKeptSavedGames = null!;
+    private XNATextBox tbMaxSavedGameFolderSize = null!;
 
     public override void Initialize()
     {
@@ -85,6 +87,66 @@ class StorageOptionsPanel : XNAOptionsPanel
         AddChild(lblLogFolderSize);
         AddChild(tbMaxLogFolderSize);
         AddChild(lblLogFolderSizeSuffix);
+
+        InitializeSavedGameSection(lblLogFolderSize.Y + ROW_SPACING * 2);
+    }
+
+    private void InitializeSavedGameSection(int y)
+    {
+        var lblSavedGamesHeader = new XNALabel(WindowManager);
+        lblSavedGamesHeader.Name = nameof(lblSavedGamesHeader);
+        lblSavedGamesHeader.FontIndex = 1;
+        lblSavedGamesHeader.Text = "Single-player Saved Games".L10N("Client:DTAConfig:StorageSavedGamesHeader");
+        lblSavedGamesHeader.ClientRectangle = new Rectangle(12, y, 0, 0);
+
+        var lblKeptSavedGames = new XNALabel(WindowManager);
+        lblKeptSavedGames.Name = nameof(lblKeptSavedGames);
+        lblKeptSavedGames.Text = "Keep at most:".L10N("Client:DTAConfig:StorageKeepAtMost");
+        lblKeptSavedGames.ClientRectangle = new Rectangle(12, lblSavedGamesHeader.Bottom + ROW_SPACING - 12, 0, 0);
+
+        tbMaxKeptSavedGames = new XNATextBox(WindowManager);
+        tbMaxKeptSavedGames.Name = nameof(tbMaxKeptSavedGames);
+        tbMaxKeptSavedGames.MaximumTextLength = 6;
+        tbMaxKeptSavedGames.ClientRectangle = new Rectangle(
+            TEXT_BOX_X, lblKeptSavedGames.Y - 4, TEXT_BOX_WIDTH, TEXT_BOX_HEIGHT);
+
+        var lblKeptSavedGamesSuffix = new XNALabel(WindowManager);
+        lblKeptSavedGamesSuffix.Name = nameof(lblKeptSavedGamesSuffix);
+        lblKeptSavedGamesSuffix.Text = "saved games  (0 = no limit)".L10N("Client:DTAConfig:StorageKeepSavedGamesAtMostSuffix");
+        lblKeptSavedGamesSuffix.ClientRectangle = new Rectangle(
+            tbMaxKeptSavedGames.Right + 8, lblKeptSavedGames.Y, 0, 0);
+
+        var lblSavedGameFolderSize = new XNALabel(WindowManager);
+        lblSavedGameFolderSize.Name = nameof(lblSavedGameFolderSize);
+        lblSavedGameFolderSize.Text = "Maximum size:".L10N("Client:DTAConfig:StorageMaxSize");
+        lblSavedGameFolderSize.ClientRectangle = new Rectangle(12, lblKeptSavedGames.Y + ROW_SPACING, 0, 0);
+
+        tbMaxSavedGameFolderSize = new XNATextBox(WindowManager);
+        tbMaxSavedGameFolderSize.Name = nameof(tbMaxSavedGameFolderSize);
+        tbMaxSavedGameFolderSize.MaximumTextLength = 7;
+        tbMaxSavedGameFolderSize.ClientRectangle = new Rectangle(
+            TEXT_BOX_X, lblSavedGameFolderSize.Y - 4, TEXT_BOX_WIDTH, TEXT_BOX_HEIGHT);
+
+        var lblSavedGameFolderSizeSuffix = new XNALabel(WindowManager);
+        lblSavedGameFolderSizeSuffix.Name = nameof(lblSavedGameFolderSizeSuffix);
+        lblSavedGameFolderSizeSuffix.Text = "MB  (0 = no limit)".L10N("Client:DTAConfig:StorageMaxSizeSuffix");
+        lblSavedGameFolderSizeSuffix.ClientRectangle = new Rectangle(
+            tbMaxSavedGameFolderSize.Right + 8, lblSavedGameFolderSize.Y, 0, 0);
+
+        var lblSavedGameRetentionHint = new XNALabel(WindowManager);
+        lblSavedGameRetentionHint.Name = nameof(lblSavedGameRetentionHint);
+        lblSavedGameRetentionHint.Text = ("Limits permanently delete oldest saves at client startup and after games.\n" +
+            "The newest save is always kept, even if it exceeds the size limit.").L10N("Client:DTAConfig:StorageSavedGameRetentionHint");
+        lblSavedGameRetentionHint.ClientRectangle = new Rectangle(12, lblSavedGameFolderSize.Y + ROW_SPACING, 0, 0);
+
+        AddChild(lblSavedGamesHeader);
+        AddChild(lblKeptSavedGames);
+        AddChild(tbMaxKeptSavedGames);
+        AddChild(lblKeptSavedGamesSuffix);
+        AddChild(lblSavedGameFolderSize);
+        AddChild(tbMaxSavedGameFolderSize);
+        AddChild(lblSavedGameFolderSizeSuffix);
+        AddChild(lblSavedGameRetentionHint);
     }
 
     public override void Load()
@@ -93,6 +155,8 @@ class StorageOptionsPanel : XNAOptionsPanel
 
         tbMaxKeptLogFiles.Text = IniSettings.MaxKeptClientLogFiles.Value.ToString();
         tbMaxLogFolderSize.Text = IniSettings.MaxClientLogFolderSizeMB.Value.ToString();
+        tbMaxKeptSavedGames.Text = IniSettings.MaxKeptSavedGames.Value.ToString();
+        tbMaxSavedGameFolderSize.Text = IniSettings.MaxSavedGameFolderSizeMB.Value.ToString();
     }
 
     public override bool Save()
@@ -103,6 +167,10 @@ class StorageOptionsPanel : XNAOptionsPanel
             ParseLimit(tbMaxKeptLogFiles.Text, IniSettings.MaxKeptClientLogFiles.Value, MAX_KEPT_FILES_LIMIT);
         IniSettings.MaxClientLogFolderSizeMB.Value =
             ParseLimit(tbMaxLogFolderSize.Text, IniSettings.MaxClientLogFolderSizeMB.Value, MAX_FOLDER_SIZE_LIMIT_MB);
+        IniSettings.MaxKeptSavedGames.Value =
+            ParseLimit(tbMaxKeptSavedGames.Text, IniSettings.MaxKeptSavedGames.Value, MAX_KEPT_FILES_LIMIT);
+        IniSettings.MaxSavedGameFolderSizeMB.Value =
+            ParseLimit(tbMaxSavedGameFolderSize.Text, IniSettings.MaxSavedGameFolderSizeMB.Value, MAX_FOLDER_SIZE_LIMIT_MB);
 
         return restartRequired;
     }

--- a/DXMainClient/DXGUI/Generic/OptionPanels/StorageOptionsPanel.cs
+++ b/DXMainClient/DXGUI/Generic/OptionPanels/StorageOptionsPanel.cs
@@ -14,7 +14,7 @@ using Rampastring.XNAUI.XNAControls;
 
 namespace DTAClient.DXGUI.Generic.OptionPanels;
 
-/// <summary>Configures how much disk space client logs and (if supported) replays are allowed to use.</summary>
+/// <summary>Configures how much disk space is used for various client features.</summary>
 class StorageOptionsPanel : XNAOptionsPanel
 {
     private const int TEXT_BOX_WIDTH = 70;

--- a/DXMainClient/DXGUI/Generic/OptionsWindow.cs
+++ b/DXMainClient/DXGUI/Generic/OptionsWindow.cs
@@ -11,6 +11,7 @@ using Rampastring.XNAUI.XNAControls;
 using System;
 using ClientUpdater;
 using DTAClient.Domain;
+using System.Collections.Generic;
 
 namespace DTAClient.DXGUI.Generic
 {
@@ -41,7 +42,7 @@ namespace DTAClient.DXGUI.Generic
         public override void Initialize()
         {
             Name = "OptionsWindow";
-            ClientRectangle = new Rectangle(0, 0, 576, 475);
+            ClientRectangle = new Rectangle(0, 0, 576 + UIDesignConstants.BUTTON_WIDTH_92, 475);
             BackgroundTexture = AssetLoader.LoadTextureUncached("optionsbg.png");
 
             tabControl = new XNAClientTabControl(WindowManager);
@@ -55,6 +56,9 @@ namespace DTAClient.DXGUI.Generic
             tabControl.AddTab("CnCNet".L10N("Client:DTAConfig:TabCnCNet"), UIDesignConstants.BUTTON_WIDTH_92);
             tabControl.AddTab("Updater".L10N("Client:DTAConfig:TabUpdater"), UIDesignConstants.BUTTON_WIDTH_92);
             tabControl.AddTab("Components".L10N("Client:DTAConfig:TabComponents"), UIDesignConstants.BUTTON_WIDTH_92);
+
+            tabControl.AddTab("Storage".L10N("Client:DTAConfig:TabStorage"), UIDesignConstants.BUTTON_WIDTH_92);
+
             tabControl.SelectedIndexChanged += TabControl_SelectedIndexChanged;
 
             var btnCancel = new XNAClientButton(WindowManager);
@@ -75,7 +79,7 @@ namespace DTAClient.DXGUI.Generic
             var updaterOptionsPanel = new UpdaterOptionsPanel(WindowManager, UserINISettings.Instance);
             updaterOptionsPanel.OnForceUpdate += (s, e) => { Disable(); OnForceUpdate?.Invoke(this, EventArgs.Empty); };
 
-            optionsPanels = new XNAOptionsPanel[]
+            var panels = new List<XNAOptionsPanel>
             {
                 displayOptionsPanel,
                 new AudioOptionsPanel(WindowManager, UserINISettings.Instance),
@@ -84,6 +88,10 @@ namespace DTAClient.DXGUI.Generic
                 updaterOptionsPanel,
                 componentsPanel
             };
+
+            panels.Add(new StorageOptionsPanel(WindowManager, UserINISettings.Instance));
+
+            optionsPanels = panels.ToArray();
 
             if (ClientConfiguration.Instance.ModMode || Updater.UpdateMirrors == null || Updater.UpdateMirrors.Count < 1)
             {

--- a/DXMainClient/DXGUI/Generic/OptionsWindow.cs
+++ b/DXMainClient/DXGUI/Generic/OptionsWindow.cs
@@ -86,10 +86,9 @@ namespace DTAClient.DXGUI.Generic
                 new GameOptionsPanel(WindowManager, UserINISettings.Instance, topBar),
                 new CnCNetOptionsPanel(WindowManager, UserINISettings.Instance, gameCollection, tunnelHandler),
                 updaterOptionsPanel,
-                componentsPanel
+                componentsPanel,
+                new StorageOptionsPanel(WindowManager, UserINISettings.Instance)
             };
-
-            panels.Add(new StorageOptionsPanel(WindowManager, UserINISettings.Instance));
 
             optionsPanels = panels.ToArray();
 

--- a/DXMainClient/DXGUI/Generic/OptionsWindow.cs
+++ b/DXMainClient/DXGUI/Generic/OptionsWindow.cs
@@ -9,9 +9,9 @@ using Rampastring.Tools;
 using Rampastring.XNAUI;
 using Rampastring.XNAUI.XNAControls;
 using System;
+using System.Collections.Generic;
 using ClientUpdater;
 using DTAClient.Domain;
-using System.Collections.Generic;
 
 namespace DTAClient.DXGUI.Generic
 {

--- a/DXMainClient/PreStartup.cs
+++ b/DXMainClient/PreStartup.cs
@@ -80,13 +80,7 @@ namespace DTAClient
             ProgramConstants.LogFileName = clientLogFile.FullName;
 
             if (clientLogFile.Exists)
-            {
-                // Copy client.log file as client_previous.log. Override client_previous.log if it exists.
-                FileInfo clientPrevLogFile = SafePath.GetFile(clientUserFilesDirectory.FullName, "client_previous.log");
-                if (clientPrevLogFile.Exists)
-                    File.Delete(clientPrevLogFile.FullName);
-                File.Move(clientLogFile.FullName, clientPrevLogFile.FullName);
-            }
+                RotateLogFiles(clientUserFilesDirectory, clientLogFile);
 
             Logger.Initialize(clientUserFilesDirectory.FullName, clientLogFile.Name);
             Logger.WriteLogFile = true;
@@ -283,6 +277,91 @@ namespace DTAClient
                 MainClientConstants.SUPPORT_URL_SHORT);
 
             MainClientConstants.DisplayErrorAction("KABOOOOOOOM".L10N("Client:Main:FatalErrorTitle"), error, true);
+        }
+
+        private const int DEFAULT_MAX_KEPT_LOG_FILES = 5;
+        private const int DEFAULT_MAX_LOG_FOLDER_SIZE_MB = 50;
+        private const string LOG_BACKUP_SEARCH_PATTERN = "client_*.log";
+
+        /// <summary>
+        /// Renames the previous client.log to a timestamped backup and prunes old backups
+        /// down to the configured count/size limits. Settings are read directly from the
+        /// settings INI since UserINISettings is not initialized yet.
+        /// </summary>
+        private static void RotateLogFiles(DirectoryInfo clientUserFilesDirectory, FileInfo clientLogFile)
+        {
+            (int maxKeptLogFiles, long maxFolderSizeBytes) = ReadLogRetentionSettings();
+
+            FileInfo backupFile = SafePath.GetFile(clientUserFilesDirectory.FullName,
+                $"client_{DateTime.Now:yyyyMMdd_HHmmss_fff}.log");
+
+            try
+            {
+                if (backupFile.Exists)
+                    backupFile.Delete();
+
+                File.Move(clientLogFile.FullName, backupFile.FullName);
+            }
+            catch
+            {
+                return;
+            }
+
+            List<FileInfo> backups = clientUserFilesDirectory
+                .EnumerateFiles(LOG_BACKUP_SEARCH_PATTERN)
+                .OrderByDescending(f => f.LastWriteTimeUtc)
+                .ToList();
+
+            if (maxKeptLogFiles > 0)
+            {
+                foreach (FileInfo old in backups.Skip(maxKeptLogFiles))
+                    TryDeleteFile(old);
+
+                backups = backups.Take(maxKeptLogFiles).ToList();
+            }
+
+            if (maxFolderSizeBytes > 0)
+            {
+                long totalSize = backups.Sum(f => f.Length);
+                for (int i = backups.Count - 1; i >= 0 && totalSize > maxFolderSizeBytes; i--)
+                {
+                    totalSize -= backups[i].Length;
+                    TryDeleteFile(backups[i]);
+                }
+            }
+        }
+
+        private static void TryDeleteFile(FileInfo file)
+        {
+            try
+            {
+                file.Delete();
+            }
+            catch
+            {
+                // Ignored - the file will simply be considered again on the next startup.
+            }
+        }
+
+        private static (int maxKeptLogFiles, long maxFolderSizeBytes) ReadLogRetentionSettings()
+        {
+            try
+            {
+                FileInfo settingsFile = SafePath.GetFile(ProgramConstants.GamePath, ClientConfiguration.Instance.SettingsIniName);
+                if (settingsFile.Exists)
+                {
+                    var settingsIni = new IniFile(settingsFile.FullName);
+                    int maxKeptLogFiles = settingsIni.GetIntValue("ClientLogs", "MaxKeptLogFiles", DEFAULT_MAX_KEPT_LOG_FILES);
+                    int maxFolderSizeMB = settingsIni.GetIntValue("ClientLogs", "MaxLogFolderSizeMB", DEFAULT_MAX_LOG_FOLDER_SIZE_MB);
+                    return (maxKeptLogFiles, maxFolderSizeMB * 1024L * 1024L);
+                }
+            }
+            catch
+            {
+                // Fall through to defaults.
+            }
+
+            return (DEFAULT_MAX_KEPT_LOG_FILES, DEFAULT_MAX_LOG_FOLDER_SIZE_MB * 1024L * 1024L);
         }
 
         [SupportedOSPlatform("windows")]

--- a/DXMainClient/PreStartup.cs
+++ b/DXMainClient/PreStartup.cs
@@ -290,7 +290,7 @@ namespace DTAClient
         /// </summary>
         private static void RotateLogFiles(DirectoryInfo clientUserFilesDirectory, FileInfo clientLogFile)
         {
-            (int maxKeptLogFiles, long maxFolderSizeBytes) = ReadLogRetentionSettings();
+            (int maxKeptLogFiles, int maxFolderSizeMB) = ReadLogRetentionSettings();
 
             FileInfo backupFile = SafePath.GetFile(clientUserFilesDirectory.FullName,
                 $"client_{DateTime.Now:yyyyMMdd_HHmmss_fff}.log");
@@ -320,8 +320,9 @@ namespace DTAClient
                 backups = backups.Take(maxKeptLogFiles).ToList();
             }
 
-            if (maxFolderSizeBytes > 0)
+            if (maxFolderSizeMB > 0)
             {
+                long maxFolderSizeBytes = maxFolderSizeMB * 1024L * 1024L;
                 long totalSize = backups.Sum(f => f.Length);
                 for (int i = backups.Count - 1; i >= 0 && totalSize > maxFolderSizeBytes; i--)
                 {
@@ -343,7 +344,7 @@ namespace DTAClient
             }
         }
 
-        private static (int maxKeptLogFiles, long maxFolderSizeBytes) ReadLogRetentionSettings()
+        private static (int maxKeptLogFiles, int maxFolderSizeMB) ReadLogRetentionSettings()
         {
             try
             {
@@ -353,7 +354,7 @@ namespace DTAClient
                     var settingsIni = new IniFile(settingsFile.FullName);
                     int maxKeptLogFiles = Math.Max(0, settingsIni.GetIntValue("ClientLogs", "MaxKeptLogFiles", DEFAULT_MAX_KEPT_LOG_FILES));
                     int maxFolderSizeMB = Math.Max(0, settingsIni.GetIntValue("ClientLogs", "MaxLogFolderSizeMB", DEFAULT_MAX_LOG_FOLDER_SIZE_MB));
-                    return (maxKeptLogFiles, maxFolderSizeMB * 1024L * 1024L);
+                    return (maxKeptLogFiles, maxFolderSizeMB);
                 }
             }
             catch
@@ -361,7 +362,7 @@ namespace DTAClient
                 // Fall through to defaults.
             }
 
-            return (DEFAULT_MAX_KEPT_LOG_FILES, DEFAULT_MAX_LOG_FOLDER_SIZE_MB * 1024L * 1024L);
+            return (DEFAULT_MAX_KEPT_LOG_FILES, DEFAULT_MAX_LOG_FOLDER_SIZE_MB);
         }
 
         [SupportedOSPlatform("windows")]

--- a/DXMainClient/PreStartup.cs
+++ b/DXMainClient/PreStartup.cs
@@ -279,7 +279,7 @@ namespace DTAClient
             MainClientConstants.DisplayErrorAction("KABOOOOOOOM".L10N("Client:Main:FatalErrorTitle"), error, true);
         }
 
-        private const int DEFAULT_MAX_KEPT_LOG_FILES = 5;
+        private const int DEFAULT_MAX_KEPT_LOG_FILES = 20;
         private const int DEFAULT_MAX_LOG_FOLDER_SIZE_MB = 50;
         private const string LOG_BACKUP_SEARCH_PATTERN = "client_*.log";
 
@@ -304,7 +304,7 @@ namespace DTAClient
             }
             catch
             {
-                return;
+                // Ignored - the previous log will be overwritten.
             }
 
             List<FileInfo> backups = clientUserFilesDirectory

--- a/DXMainClient/PreStartup.cs
+++ b/DXMainClient/PreStartup.cs
@@ -351,8 +351,8 @@ namespace DTAClient
                 if (settingsFile.Exists)
                 {
                     var settingsIni = new IniFile(settingsFile.FullName);
-                    int maxKeptLogFiles = settingsIni.GetIntValue("ClientLogs", "MaxKeptLogFiles", DEFAULT_MAX_KEPT_LOG_FILES);
-                    int maxFolderSizeMB = settingsIni.GetIntValue("ClientLogs", "MaxLogFolderSizeMB", DEFAULT_MAX_LOG_FOLDER_SIZE_MB);
+                    int maxKeptLogFiles = Math.Max(0, settingsIni.GetIntValue("ClientLogs", "MaxKeptLogFiles", DEFAULT_MAX_KEPT_LOG_FILES));
+                    int maxFolderSizeMB = Math.Max(0, settingsIni.GetIntValue("ClientLogs", "MaxLogFolderSizeMB", DEFAULT_MAX_LOG_FOLDER_SIZE_MB));
                     return (maxKeptLogFiles, maxFolderSizeMB * 1024L * 1024L);
                 }
             }

--- a/DXMainClient/Startup.cs
+++ b/DXMainClient/Startup.cs
@@ -66,8 +66,8 @@ namespace DTAClient
             Thread onlineIdThread = new Thread(GenerateOnlineId);
             onlineIdThread.Start();
 
-            if (ClientConfiguration.Instance.ClientGameType == ClientType.Ares)
-                Task.Run(() => PruneFiles(SafePath.GetDirectory(ProgramConstants.GamePath, "debug"), DateTime.Now.AddDays(-7)));
+            if (GameLogManager.IsSupported)
+                Task.Run(GameLogManager.PruneGameLogs);
 
             Task.Run(MigrateOldLogFiles);
 
@@ -181,50 +181,6 @@ namespace DTAClient
                     Logger.Log("Steam init failed: " + e.Message);
                     // Couldn't init for some reason (steam is closed etc)
                 }
-            }
-        }
-
-        /// <summary>
-        /// Recursively deletes all files from the specified directory that were created at <paramref name="pruneThresholdTime"/> or before.
-        /// If directory is empty after deleting files, the directory itself will also be deleted.
-        /// </summary>
-        /// <param name="directory">Directory to prune files from.</param>
-        /// <param name="pruneThresholdTime">Time at or before which files must have been created for them to be pruned.</param>
-        private void PruneFiles(DirectoryInfo directory, DateTime pruneThresholdTime)
-        {
-            if (!directory.Exists)
-                return;
-
-            try
-            {
-                foreach (FileSystemInfo fsEntry in directory.EnumerateFileSystemInfos())
-                {
-                    if ((fsEntry.Attributes & FileAttributes.Directory) == FileAttributes.Directory)
-                        PruneFiles(new DirectoryInfo(fsEntry.FullName), pruneThresholdTime);
-                    else
-                    {
-                        try
-                        {
-                            FileInfo fileInfo = new FileInfo(fsEntry.FullName);
-                            if (fileInfo.CreationTime <= pruneThresholdTime)
-                                fileInfo.Delete();
-                        }
-                        catch (Exception ex)
-                        {
-                            Logger.Log("PruneFiles: Could not delete file " + fsEntry.Name +
-                                ". Error message: " + ex.ToString());
-                            continue;
-                        }
-                    }
-                }
-
-                if (!directory.EnumerateFileSystemInfos().Any())
-                    directory.Delete();
-            }
-            catch (Exception ex)
-            {
-                Logger.Log("PruneFiles: An error occurred while pruning files from " +
-                   directory.Name + ". Message: " + ex.ToString());
             }
         }
 

--- a/DXMainClient/Startup.cs
+++ b/DXMainClient/Startup.cs
@@ -105,6 +105,8 @@ namespace DTAClient
                 }
             }
 
+            SinglePlayerSavedGameManager.PruneSavedGames();
+
             if (Updater.CustomComponents != null)
             {
                 Logger.Log("Removing partial custom component downloads.");

--- a/Docs/INISystem.md
+++ b/Docs/INISystem.md
@@ -871,6 +871,8 @@ AllowedCustomGameModes=Standard,Custom Map ; comma-separated list of strings,
                                            ; Official maps are not affected by this filter.
 ```
 
+The options window always has a `Storage` tab, where the player caps how many old client log files are kept and how large they may grow in total (see Issue [#1021](https://github.com/CnCNet/xna-cncnet-client/issues/1021)).
+
 ## Game Modes
 
 Game modes are defined in the `[GameModes]` section of `MPMaps.ini`. Each game mode can have its own configuration section with the same name.

--- a/Docs/INISystem.md
+++ b/Docs/INISystem.md
@@ -877,6 +877,14 @@ MaxKeptLogFiles=20      ; maximum number of timestamped old log files; 0 = unlim
 MaxLogFolderSizeMB=50   ; maximum combined size of old log files in MB; 0 = unlimited
 ```
 
+Game logs are the game's own `debug` folder (Ares, Phobos and spawner logs, and the snapshot folders for crashes and desyncs), pruned at client startup when `ClientGameType` is `Ares`. Each log file or snapshot folder is kept or deleted whole, and the newest is always kept when applying the size limit.
+
+```ini
+[GameLogs]
+MaxGameLogAgeDays=7         ; delete entries not written to for this many days; 0 = never
+MaxGameLogFolderSizeMB=0    ; maximum combined size of the debug folder in MB, oldest deleted first; 0 = unlimited (default)
+```
+
 Packages can provide initial values in `Resources/UserDefaults.ini`; existing user settings take precedence.
 
 ```ini

--- a/Docs/INISystem.md
+++ b/Docs/INISystem.md
@@ -871,7 +871,15 @@ AllowedCustomGameModes=Standard,Custom Map ; comma-separated list of strings,
                                            ; Official maps are not affected by this filter.
 ```
 
-The options window always has a `Storage` tab, where the player caps how many old client log files are kept and how large they may grow in total (see Issue [#1021](https://github.com/CnCNet/xna-cncnet-client/issues/1021)).
+The options window has a `Storage` tab, where the player caps how many old client log files are kept and how large they may grow in total. These values are stored in the client's user settings file, whose name is configured by `SettingsFile` in `ClientDefinitions.ini` (the default is `Settings.ini` in the game directory):
+
+```ini
+[ClientLogs]
+MaxKeptLogFiles=5       ; maximum number of timestamped old log files; 0 = unlimited
+MaxLogFolderSizeMB=50   ; maximum combined size of old log files in MB; 0 = unlimited
+```
+
+Packages can provide initial values in `Resources/UserDefaults.ini`; existing user settings take precedence.
 
 ## Game Modes
 

--- a/Docs/INISystem.md
+++ b/Docs/INISystem.md
@@ -873,11 +873,17 @@ AllowedCustomGameModes=Standard,Custom Map ; comma-separated list of strings,
 
 ```ini
 [ClientLogs]
-MaxKeptLogFiles=5       ; maximum number of timestamped old log files; 0 = unlimited
+MaxKeptLogFiles=20      ; maximum number of timestamped old log files; 0 = unlimited
 MaxLogFolderSizeMB=50   ; maximum combined size of old log files in MB; 0 = unlimited
 ```
 
 Packages can provide initial values in `Resources/UserDefaults.ini`; existing user settings take precedence.
+
+```ini
+[SavedGames]
+MaxKeptSavedGames=0           ; maximum number of single-player saved games; 0 = unlimited (default)
+MaxSavedGameFolderSizeMB=0    ; maximum combined size of single-player saved games in MB; 0 = unlimited (default)
+```
 
 ## Game Modes
 

--- a/Docs/INISystem.md
+++ b/Docs/INISystem.md
@@ -871,8 +871,6 @@ AllowedCustomGameModes=Standard,Custom Map ; comma-separated list of strings,
                                            ; Official maps are not affected by this filter.
 ```
 
-The options window has a `Storage` tab, where the player caps how many old client log files are kept and how large they may grow in total. These values are stored in the client's user settings file, whose name is configured by `SettingsFile` in `ClientDefinitions.ini` (the default is `Settings.ini` in the game directory):
-
 ```ini
 [ClientLogs]
 MaxKeptLogFiles=5       ; maximum number of timestamped old log files; 0 = unlimited

--- a/Docs/Migration.md
+++ b/Docs/Migration.md
@@ -9,6 +9,7 @@ This document lists all the breaking changes and how to address them. Each secti
 
 - The client now defaults to Dynamic (V3) tunnel mode. If you need the old V2 behavior, set `TunnelMode=2` in `[MultiPlayer]` of `Resources/UserDefaults.ini`.
 - Copy [negotiating.png](/DXMainClient/Resources/DTA/negotiating.png) and [negotiation-failed.png](/DXMainClient/Resources/DTA/negotiation-failed.png) into your client's `Resources` folder.
+- `OptionsWindow` is now wider to fit the new "Storage" tab, growing from `576` to `576 + UIDesignConstants.BUTTON_WIDTH_92` (668) pixels. If your `OptionsWindow.ini` positions any controls relative to the window's right edge or in a second column, you will need to adjust their `ClientRectangle`/`Size` accordingly.
 
 ## 2.13.0
 


### PR DESCRIPTION
Adds a **Storage** tab to the options window, and replaces the single `client_previous.log` backup with proper log rotation.

Today the client keeps one old log: `client.log` is copied over `client_previous.log` on every start. Logs are now renamed to a timestamped backup and pruned to a configured file count and total folder size

(`[ClientLogs]` `MaxKeptLogFiles`, `MaxLogFolderSizeMB`), which addresses #1021.

Retention is read straight from the settings INI rather than through `UserINISettings`, because rotation runs before that is initialised.

<img width="827" height="611" alt="image" src="https://github.com/user-attachments/assets/a047496e-03a9-4d62-ab62-b717f626d8e5" />


Note: Screenshots show the replay options - these will be added in a later PR and are opt-in. For now, it's just the client logs.
