### PR TITLE
Add Tiberian Dawn game type and slightly refactor `ClientType` enum

### DIFF
--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -212,7 +212,7 @@ namespace ClientCore
 
         private string _ClientGameTypeString => clientDefinitionsIni.GetStringValue(SETTINGS, "ClientGameType", string.Empty);
         private ClientType? _ClientGameType = null;
-        public ClientType ClientGameType => _ClientGameType ??= ClientTypeHelper.FromString(_ClientGameTypeString);
+        public ClientType ClientGameType => _ClientGameType ??= ClientTypeExtensions.FromString(_ClientGameTypeString);
 
         public string DiscordAppId => clientDefinitionsIni.GetStringValue(SETTINGS, "DiscordAppId", string.Empty);
 

--- a/ClientCore/ClientConfiguration.cs
+++ b/ClientCore/ClientConfiguration.cs
@@ -212,7 +212,7 @@ namespace ClientCore
 
         private string _ClientGameTypeString => clientDefinitionsIni.GetStringValue(SETTINGS, "ClientGameType", string.Empty);
         private ClientType? _ClientGameType = null;
-        public ClientType ClientGameType => _ClientGameType ??= ClientTypeExtensions.FromString(_ClientGameTypeString);
+        public ClientType ClientGameType => _ClientGameType ??= ClientType.FromString(_ClientGameTypeString);
 
         public string DiscordAppId => clientDefinitionsIni.GetStringValue(SETTINGS, "DiscordAppId", string.Empty);
 

--- a/ClientCore/Enums/ClientType.cs
+++ b/ClientCore/Enums/ClientType.cs
@@ -2,9 +2,10 @@
 {
     public enum ClientType
     {
+        TD,
+        RA,
         TS,
         YR,
         Ares,
-        RA,
     }
 }

--- a/ClientCore/Enums/ClientTypeExtensions.cs
+++ b/ClientCore/Enums/ClientTypeExtensions.cs
@@ -1,9 +1,9 @@
 ﻿#nullable enable
 using System;
 
-using ClientCore.Enums;
+using ClientCore.Extensions;
 
-namespace ClientCore.Extensions;
+namespace ClientCore.Enums;
 
 public static class ClientTypeExtensions
 {

--- a/ClientCore/Enums/ClientTypeExtensions.cs
+++ b/ClientCore/Enums/ClientTypeExtensions.cs
@@ -36,7 +36,6 @@ public static class ClientTypeExtensions
             ClientType.RA => 2229840,
             ClientType.TS => 2229880,
             ClientType.YR or ClientType.Ares => 2229850,
-            // You may return null if a new ClientType does not have a corresponding Steam App ID
             _ => null,
         };
     }

--- a/ClientCore/Enums/ClientTypeExtensions.cs
+++ b/ClientCore/Enums/ClientTypeExtensions.cs
@@ -37,8 +37,7 @@ public static class ClientTypeExtensions
             ClientType.TS => 2229880,
             ClientType.YR or ClientType.Ares => 2229850,
             // You may return null if a new ClientType does not have a corresponding Steam App ID
-            // Throw on unexpected ClientType
-            _ => throw new Exception(unknownClientTypeErrorMsg),
+            _ => null,
         };
     }
 }

--- a/ClientCore/Enums/ClientTypeHelper.cs
+++ b/ClientCore/Enums/ClientTypeHelper.cs
@@ -1,24 +1,36 @@
 ﻿using System;
-using System.Linq;
 using ClientCore.Extensions;
 
 namespace ClientCore.Enums
 {
     public static class ClientTypeHelper
     {
-        public static ClientType FromString(string value) => value switch
-        {
-            "TS" => ClientType.TS,
-            "YR" => ClientType.YR,
-            "Ares" => ClientType.Ares,
-            "RA" => ClientType.RA,
-            _ => throw new Exception(string.Format((
+        private static readonly string errorMsg = string.Format((
                 "It seems the client configuration was not migrated to accommodate for the v2.12 changes. " +
                 "Please specify 'ClientGameType' in '[Settings]' section of the 'ClientDefinitions.ini' file " +
                 "(allowed options: {0}).\n\n" +
                 "Please refer to documentation of the client {1} for more details. This link can also be found in the log file.").L10N("Client:Main:ClientGameTypeNotFoundException"),
                 EnumExtensions.GetNames<ClientType>(),
-                "https://github.com/CnCNet/xna-cncnet-client/")),
+                "https://github.com/CnCNet/xna-cncnet-client/");
+
+        public static ClientType FromString(string value) => value switch
+        {
+            "TD" => ClientType.TD,
+            "RA" => ClientType.RA,
+            "TS" => ClientType.TS,
+            "YR" => ClientType.YR,
+            "Ares" => ClientType.Ares,
+            _ => throw new Exception(errorMsg),
+        };
+
+        public static uint ToSteamAppId(ClientType gametype) => gametype switch
+        {
+            ClientType.TD => 2229830,
+            ClientType.RA => 2229840,
+            ClientType.TS => 2229880,
+            ClientType.YR 
+            or ClientType.Ares => 2229850,
+            _ => throw new Exception(errorMsg),
         };
     }
 }

--- a/ClientCore/Extensions/ClientTypeExtensions.cs
+++ b/ClientCore/Extensions/ClientTypeExtensions.cs
@@ -3,44 +3,43 @@ using System;
 
 using ClientCore.Enums;
 
-namespace ClientCore.Extensions
+namespace ClientCore.Extensions;
+
+public static class ClientTypeExtensions
 {
-    public static class ClientTypeExtensions
+    private static readonly string unknownClientTypeErrorMsg = string.Format((
+            "It seems the client configuration was not migrated to accommodate for the v2.12 changes. " +
+            "Please specify 'ClientGameType' in '[Settings]' section of the 'ClientDefinitions.ini' file " +
+            "(allowed options: {0}).\n\n" +
+            "Please refer to documentation of the client {1} for more details. This link can also be found in the log file.").L10N("Client:Main:ClientGameTypeNotFoundException"),
+            EnumExtensions.GetNames<ClientType>(),
+            "https://github.com/CnCNet/xna-cncnet-client/");
+
+    extension(ClientType)
     {
-        private static readonly string unknownClientTypeErrorMsg = string.Format((
-                "It seems the client configuration was not migrated to accommodate for the v2.12 changes. " +
-                "Please specify 'ClientGameType' in '[Settings]' section of the 'ClientDefinitions.ini' file " +
-                "(allowed options: {0}).\n\n" +
-                "Please refer to documentation of the client {1} for more details. This link can also be found in the log file.").L10N("Client:Main:ClientGameTypeNotFoundException"),
-                EnumExtensions.GetNames<ClientType>(),
-                "https://github.com/CnCNet/xna-cncnet-client/");
-
-        extension(ClientType)
+        public static ClientType FromString(string value) => value switch
         {
-            public static ClientType FromString(string value) => value switch
-            {
-                "TD" => ClientType.TD,
-                "RA" => ClientType.RA,
-                "TS" => ClientType.TS,
-                "YR" => ClientType.YR,
-                "Ares" => ClientType.Ares,
-                _ => throw new Exception(unknownClientTypeErrorMsg),
-            };
-        }
+            "TD" => ClientType.TD,
+            "RA" => ClientType.RA,
+            "TS" => ClientType.TS,
+            "YR" => ClientType.YR,
+            "Ares" => ClientType.Ares,
+            _ => throw new Exception(unknownClientTypeErrorMsg),
+        };
+    }
 
-        extension(ClientType clientType)
+    extension(ClientType clientType)
+    {
+        public uint? ToSteamAppId() => clientType switch
         {
-            public uint? ToSteamAppId() => clientType switch
-            {
-                ClientType.TD => 2229830,
-                ClientType.RA => 2229840,
-                ClientType.TS => 2229880,
-                ClientType.YR or ClientType.Ares => 2229850,
-                // You may return null if a new ClientType does not have a corresponding Steam App ID
-                // Throw on unexpected ClientType
-                _ => throw new Exception(unknownClientTypeErrorMsg),
-            };
-        }
+            ClientType.TD => 2229830,
+            ClientType.RA => 2229840,
+            ClientType.TS => 2229880,
+            ClientType.YR or ClientType.Ares => 2229850,
+            // You may return null if a new ClientType does not have a corresponding Steam App ID
+            // Throw on unexpected ClientType
+            _ => throw new Exception(unknownClientTypeErrorMsg),
+        };
     }
 }
 

--- a/ClientCore/Extensions/ClientTypeExtensions.cs
+++ b/ClientCore/Extensions/ClientTypeExtensions.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using ClientCore.Extensions;
+using ClientCore.Enums;
 
-namespace ClientCore.Enums
+namespace ClientCore.Extensions
 {
-    public static class ClientTypeHelper
+    public static class ClientTypeExtensions
     {
         private static readonly string errorMsg = string.Format((
                 "It seems the client configuration was not migrated to accommodate for the v2.12 changes. " +
@@ -23,7 +23,7 @@ namespace ClientCore.Enums
             _ => throw new Exception(errorMsg),
         };
 
-        public static uint ToSteamAppId(ClientType gametype) => gametype switch
+        public static uint ToSteamAppId(this ClientType ct) => ct switch
         {
             ClientType.TD => 2229830,
             ClientType.RA => 2229840,

--- a/ClientCore/Extensions/ClientTypeExtensions.cs
+++ b/ClientCore/Extensions/ClientTypeExtensions.cs
@@ -15,24 +15,31 @@ namespace ClientCore.Extensions
                 EnumExtensions.GetNames<ClientType>(),
                 "https://github.com/CnCNet/xna-cncnet-client/");
 
-        public static ClientType FromString(string value) => value switch
+        extension(ClientType)
         {
-            "TD" => ClientType.TD,
-            "RA" => ClientType.RA,
-            "TS" => ClientType.TS,
-            "YR" => ClientType.YR,
-            "Ares" => ClientType.Ares,
-            _ => throw new Exception(unknownClientTypeErrorMsg),
-        };
+            public static ClientType FromString(string value) => value switch
+            {
+                "TD" => ClientType.TD,
+                "RA" => ClientType.RA,
+                "TS" => ClientType.TS,
+                "YR" => ClientType.YR,
+                "Ares" => ClientType.Ares,
+                _ => throw new Exception(unknownClientTypeErrorMsg),
+            };
+        }
 
-        public static uint? ToSteamAppId(this ClientType ct) => ct switch
+        extension(ClientType clientType)
         {
-            ClientType.TD => 2229830,
-            ClientType.RA => 2229840,
-            ClientType.TS => 2229880,
-            ClientType.YR or ClientType.Ares => 2229850,
-            // You may return null if the ClientType does not have a corresponding Steam App ID
-            _ => throw new Exception(unknownClientTypeErrorMsg),
-        };
+            public uint? ToSteamAppId() => clientType switch
+            {
+                ClientType.TD => 2229830,
+                ClientType.RA => 2229840,
+                ClientType.TS => 2229880,
+                ClientType.YR or ClientType.Ares => 2229850,
+                // You may return null if the ClientType does not have a corresponding Steam App ID
+                _ => throw new Exception(unknownClientTypeErrorMsg),
+            };
+        }
     }
 }
+

--- a/ClientCore/Extensions/ClientTypeExtensions.cs
+++ b/ClientCore/Extensions/ClientTypeExtensions.cs
@@ -7,7 +7,7 @@ namespace ClientCore.Extensions
 {
     public static class ClientTypeExtensions
     {
-        private static readonly string errorMsg = string.Format((
+        private static readonly string unknownClientTypeErrorMsg = string.Format((
                 "It seems the client configuration was not migrated to accommodate for the v2.12 changes. " +
                 "Please specify 'ClientGameType' in '[Settings]' section of the 'ClientDefinitions.ini' file " +
                 "(allowed options: {0}).\n\n" +
@@ -22,7 +22,7 @@ namespace ClientCore.Extensions
             "TS" => ClientType.TS,
             "YR" => ClientType.YR,
             "Ares" => ClientType.Ares,
-            _ => throw new Exception(errorMsg),
+            _ => throw new Exception(unknownClientTypeErrorMsg),
         };
 
         public static uint? ToSteamAppId(this ClientType ct) => ct switch
@@ -32,7 +32,7 @@ namespace ClientCore.Extensions
             ClientType.TS => 2229880,
             ClientType.YR or ClientType.Ares => 2229850,
             // You may return null if the ClientType does not have a corresponding Steam App ID
-            _ => throw new Exception(errorMsg),
+            _ => throw new Exception(unknownClientTypeErrorMsg),
         };
     }
 }

--- a/ClientCore/Extensions/ClientTypeExtensions.cs
+++ b/ClientCore/Extensions/ClientTypeExtensions.cs
@@ -36,7 +36,8 @@ namespace ClientCore.Extensions
                 ClientType.RA => 2229840,
                 ClientType.TS => 2229880,
                 ClientType.YR or ClientType.Ares => 2229850,
-                // You may return null if the ClientType does not have a corresponding Steam App ID
+                // You may return null if a new ClientType does not have a corresponding Steam App ID
+                // Throw on unexpected ClientType
                 _ => throw new Exception(unknownClientTypeErrorMsg),
             };
         }

--- a/ClientCore/Extensions/ClientTypeExtensions.cs
+++ b/ClientCore/Extensions/ClientTypeExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+using System;
+
 using ClientCore.Enums;
 
 namespace ClientCore.Extensions
@@ -23,13 +25,13 @@ namespace ClientCore.Extensions
             _ => throw new Exception(errorMsg),
         };
 
-        public static uint ToSteamAppId(this ClientType ct) => ct switch
+        public static uint? ToSteamAppId(this ClientType ct) => ct switch
         {
             ClientType.TD => 2229830,
             ClientType.RA => 2229840,
             ClientType.TS => 2229880,
-            ClientType.YR 
-            or ClientType.Ares => 2229850,
+            ClientType.YR or ClientType.Ares => 2229850,
+            // You may return null if the ClientType does not have a corresponding Steam App ID
             _ => throw new Exception(errorMsg),
         };
     }

--- a/DXMainClient/Startup.cs
+++ b/DXMainClient/Startup.cs
@@ -167,21 +167,8 @@ namespace DTAClient
             {
                 try
                 {
-                    if (ClientConfiguration.Instance.ClientGameType == ClientType.Ares || ClientConfiguration.Instance.ClientGameType == ClientType.YR)
-                    {
-                        Logger.Log("Steam init called");
-                        SteamClient.Init(2229850);
-                    }
-                    else if (ClientConfiguration.Instance.ClientGameType == ClientType.TS)
-                    {
-                        Logger.Log("Steam init called");
-                        SteamClient.Init(2229880);
-                    }
-                    else if (ClientConfiguration.Instance.ClientGameType == ClientType.RA)
-                    {
-                        Logger.Log("Steam init called");
-                        SteamClient.Init(2229840);
-                    }
+                    Logger.Log("Steam init called");
+                    SteamClient.Init(ClientTypeHelper.ToSteamAppId(ClientConfiguration.Instance.ClientGameType));
                 }
                 catch (System.Exception e)
                 {

--- a/DXMainClient/Startup.cs
+++ b/DXMainClient/Startup.cs
@@ -21,7 +21,6 @@ using System.Runtime.Versioning;
 using ClientCore.Settings;
 using ClientGUI;
 using Steamworks;
-using ClientCore.Extensions;
 
 namespace DTAClient
 {

--- a/DXMainClient/Startup.cs
+++ b/DXMainClient/Startup.cs
@@ -166,10 +166,14 @@ namespace DTAClient
         {
             if (UserINISettings.Instance.SteamIntegration)
             {
+                uint? steamAppId = ClientConfiguration.Instance.ClientGameType.ToSteamAppId();
+                if (!steamAppId.HasValue)
+                    return;
+
                 try
                 {
                     Logger.Log("Steam init called");
-                    SteamClient.Init(ClientConfiguration.Instance.ClientGameType.ToSteamAppId());
+                    SteamClient.Init(steamAppId.Value);
                 }
                 catch (System.Exception e)
                 {

--- a/DXMainClient/Startup.cs
+++ b/DXMainClient/Startup.cs
@@ -21,6 +21,7 @@ using System.Runtime.Versioning;
 using ClientCore.Settings;
 using ClientGUI;
 using Steamworks;
+using ClientCore.Extensions;
 
 namespace DTAClient
 {
@@ -168,7 +169,7 @@ namespace DTAClient
                 try
                 {
                     Logger.Log("Steam init called");
-                    SteamClient.Init(ClientTypeHelper.ToSteamAppId(ClientConfiguration.Instance.ClientGameType));
+                    SteamClient.Init(ClientConfiguration.Instance.ClientGameType.ToSteamAppId());
                 }
                 catch (System.Exception e)
                 {

--- a/Docs/Migration-INI.md
+++ b/Docs/Migration-INI.md
@@ -10,7 +10,7 @@ It is **highly recommended** to make a complete backup of your game/mod before s
 
 Since v2.12, the client has unified different builds among game types. The game type must be defined in `ClientDefinitions.ini` now.
 
-- Add `[Settings]->ClientGameType=YR` (defines client behaviour by game. Allowed options: TS, YR, Ares)
+- Add `[Settings]->ClientGameType=YR` (defines client behaviour by game. Allowed options: TD, RA, TS, YR, Ares)
 
 The way the client is launched on Unix systems has changed.
 

--- a/Docs/NewFeatures.md
+++ b/Docs/NewFeatures.md
@@ -10,6 +10,8 @@ Breaking changes are not covered here; see [Migration.md](Migration.md) instead.
 
 - A new "Enable direct P2P connections" checkbox is added to the CnCNet tab in the Options window. When enabled, the client will attempt to establish direct P2P connections with other players. This can improve latency and reduce server load, but may not work in all network environments.
 
+- Add Tiberian Dawn game type client.
+
 ## 2.13.4
 
 - The `KeyboardCommands.ini` file now supports `DisableModifierKeys`. It is recommended to set this key for RA2/YR's `PlanningMode` (Waypoint Mode) command. See [INISystem.md](INISystem.md).

--- a/Docs/NewFeatures.md
+++ b/Docs/NewFeatures.md
@@ -10,7 +10,7 @@ Breaking changes are not covered here; see [Migration.md](Migration.md) instead.
 
 - A new "Enable direct P2P connections" checkbox is added to the CnCNet tab in the Options window. When enabled, the client will attempt to establish direct P2P connections with other players. This can improve latency and reduce server load, but may not work in all network environments.
 
-- A new game type, Tiberian Dawn, has been added. Specify `[Settings]->ClientGameType=TD` in `ClientDefinitions.ini` to use this game type.
+- The client now supports the Tiberian Dawn game type. Specify `[Settings]->ClientGameType=TD` in `ClientDefinitions.ini` to use this game type.
 
 ## 2.13.4
 

--- a/Docs/NewFeatures.md
+++ b/Docs/NewFeatures.md
@@ -10,7 +10,7 @@ Breaking changes are not covered here; see [Migration.md](Migration.md) instead.
 
 - A new "Enable direct P2P connections" checkbox is added to the CnCNet tab in the Options window. When enabled, the client will attempt to establish direct P2P connections with other players. This can improve latency and reduce server load, but may not work in all network environments.
 
-- Add Tiberian Dawn game type client.
+- A new game type, Tiberian Dawn, has been added. Specify `[Settings]->ClientGameType=TD` in `ClientDefinitions.ini` to use this game type.
 
 ## 2.13.4
 


### PR DESCRIPTION
### What's Changed

Improved `ClientType` enum client usage:

* Refactor getting the steam app id from game type
* Added `TD` option

### Breaking Changes
No

### Documentation

- [x] Documentation update is needed and has been included

### Checklist

- [x] This pull request is not a bug fix or a new feature
- [x] Verifier: I honestly verified the implementation by running the client with this PR. Verifier name: `mah_boi`. The verifier must be a human, not an AI. The verifier can be the same person as the PR proposer.





