### PR TITLE
Remove `Support = false` from Tiberian Dawn game

### DIFF
--- a/DXMainClient/Domain/Multiplayer/CnCNet/GameCollection.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/GameCollection.cs
@@ -95,8 +95,7 @@ namespace DTAClient.Domain.Multiplayer.CnCNet
                     GameBroadcastChannel = "#cncnet-td-games",
                     InternalName = "td",
                     RegistryInstallPath = "HKLM\\Software\\Westwood\\Tiberian Dawn",
-                    UIName = "Tiberian Dawn".L10N("Client:ClientCore:TiberianDawn"),
-                    Supported = false
+                    UIName = "Tiberian Dawn".L10N("Client:ClientCore:TiberianDawn")
                 },
 
                 new DefaultCnCNetGame("DTAClient.Icons.raicon.png")


### PR DESCRIPTION
## Bug Fix Pull Request

### Related Issue

Fixes #1082

### What's Changed

Removed `Supported = true` valued field from default CnCNet game list

### Breaking Changes

- [ ] This pull request introduces a breaking change
- [x] This pull request does not introduce a breaking change

### Documentation

- [ ] Documentation update is needed and has been included
- [x] Documentation update is not needed

### Test Result without Your PR Applied

Look at issue

### Test Result with Your PR Applied

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/8a862a58-a524-4d11-acc7-a6f3ed03983d" />

### Checklist

- [x] I linked the corresponding bug issue above
- [x] This pull request is scoped to one bug fix only
- [x] Verifier: I honestly verified the fix by running the client with and without applying this PR. Verifier name: mah_boi. The verifier must be a human, not an AI. The verifier can be the same person as the PR proposer.
