### PR TITLE
Improve V3 tunnel ping metrics and hide P2P IPs

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -8,6 +8,7 @@ using DTAClient.DXGUI.Multiplayer.GameLobby.CommandHandlers;
 using DTAClient.Online;
 using DTAClient.Online.EventArguments;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using Rampastring.Tools;
 using Rampastring.XNAUI;
 using Rampastring.XNAUI.XNAControls;
@@ -534,6 +535,11 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
             base.UpdatePlayerPingIndicator(pInfo, negotiationStatus, tooltipText);
         }
+
+        protected override Texture2D GetTextureForPing(PingValue ping)
+            => _tunnelMode == TunnelMode.V3Dynamic
+                ? PingTextures[PingQualityVisuals.GetTextureIndex(PingQualityRules.GetV3Tier(ping))]
+                : base.GetTextureForPing(ping);
 
         /// <summary>
         /// Builds a tooltip for V3 dynamic tunnel ping indicator

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/MultiplayerGameLobby.cs
@@ -1139,7 +1139,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             ddPlayerName.ToolTip.Text = string.Empty;
         }
 
-        private Texture2D GetTextureForPing(PingValue ping) => PingQualityVisuals.GetTexture(PingTextures, ping);
+        protected virtual Texture2D GetTextureForPing(PingValue ping) => PingQualityVisuals.GetTexture(PingTextures, ping);
 
         protected abstract void BroadcastPlayerOptions();
 

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/TunnelNegotiationStatusPanel.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/TunnelNegotiationStatusPanel.cs
@@ -358,7 +358,7 @@ public class TunnelNegotiationStatusPanel : XNAPanel
     {
         NegotiationStatus.NotStarted => ("-", Color.Gray),
         NegotiationStatus.InProgress => ("...", Color.Yellow),
-        NegotiationStatus.Succeeded when ping.HasValue => (ping.Value.ToString(), PingQualityVisuals.GetTextColor(ping.Value)),
+        NegotiationStatus.Succeeded when ping.HasValue => (ping.Value.ToString(), PingQualityVisuals.GetTextColor(PingQualityRules.GetV3Tier(ping.Value))),
         NegotiationStatus.Succeeded => ("OK".L10N("Client:Main:NegStatusOK"), Color.LightGreen),
         NegotiationStatus.Failed => ("FAIL".L10N("Client:Main:NegStatusFail"), Color.Red),
         _ => ("?", Color.Gray)
@@ -418,7 +418,7 @@ public class TunnelNegotiationStatusPanel : XNAPanel
                         new Rectangle(2, barY, LIST_BAR_MAX_WIDTH, barHeight), Color.White);
 
                     int fillWidth = Math.Max(2, Math.Min(LIST_BAR_MAX_WIDTH, ms * LIST_BAR_MAX_WIDTH / LIST_BAR_MAX_PING));
-                    DrawTexture(pingBarTextures![PingQualityVisuals.GetTextureIndex(ms)],
+                    DrawTexture(pingBarTextures![PingQualityVisuals.GetTextureIndex(PingQualityRules.GetV3Tier(ms))],
                         new Rectangle(2, barY, fillWidth, barHeight), Color.White);
                 }
 

--- a/DXMainClient/Domain/Multiplayer/CnCNet/P2PTunnel.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/P2PTunnel.cs
@@ -1,8 +1,9 @@
 #nullable enable
-using System;
 using System.Net;
 using System.Security.Cryptography;
 using System.Text;
+
+using Rampastring.Tools;
 
 namespace DTAClient.Domain.Multiplayer.CnCNet;
 
@@ -34,6 +35,6 @@ public class P2PTunnel : CnCNetTunnel
         using (var sha1 = SHA1.Create())
             hash = sha1.ComputeHash(Encoding.UTF8.GetBytes($"{PeerEndpointHashSalt}|{peerEndpoint}"));
 
-        return BitConverter.ToString(hash, 0, 3).Replace("-", "");
+        return Utilities.BytesToHexString(hash, 0, 3);
     }
 }

--- a/DXMainClient/Domain/Multiplayer/CnCNet/P2PTunnel.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/P2PTunnel.cs
@@ -1,5 +1,8 @@
 #nullable enable
+using System;
 using System.Net;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace DTAClient.Domain.Multiplayer.CnCNet;
 
@@ -11,15 +14,26 @@ namespace DTAClient.Domain.Multiplayer.CnCNet;
 /// </summary>
 public class P2PTunnel : CnCNetTunnel
 {
+    private const string PeerEndpointHashSalt = "cncnet-p2p-tunnel";
+
     public IPEndPoint PeerEndpoint { get; }
     public string PeerName { get; }
 
     public override bool IsDirect => true;
 
     public P2PTunnel(IPEndPoint peerEndpoint, string peerName)
-        : base(peerEndpoint.Address.ToString(), peerEndpoint.Port, $"Direct ({peerName})", version: 3)
+        : base(peerEndpoint.Address.ToString(), peerEndpoint.Port, $"Direct ({peerName} @ {GetPeerEndpointHash(peerEndpoint)})", version: 3)
     {
         PeerEndpoint = peerEndpoint;
         PeerName = peerName;
+    }
+
+    private static string GetPeerEndpointHash(IPEndPoint peerEndpoint)
+    {
+        byte[] hash;
+        using (var sha1 = SHA1.Create())
+            hash = sha1.ComputeHash(Encoding.UTF8.GetBytes($"{PeerEndpointHashSalt}|{peerEndpoint}"));
+
+        return BitConverter.ToString(hash, 0, 3).Replace("-", "");
     }
 }

--- a/DXMainClient/Domain/Multiplayer/CnCNet/P2PTunnel.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/P2PTunnel.cs
@@ -17,7 +17,7 @@ public class P2PTunnel : CnCNetTunnel
     public override bool IsDirect => true;
 
     public P2PTunnel(IPEndPoint peerEndpoint, string peerName)
-        : base(peerEndpoint.Address.ToString(), peerEndpoint.Port, $"Direct ({peerName} @ {peerEndpoint})", version: 3)
+        : base(peerEndpoint.Address.ToString(), peerEndpoint.Port, $"Direct ({peerName})", version: 3)
     {
         PeerEndpoint = peerEndpoint;
         PeerName = peerName;

--- a/DXMainClient/Domain/Multiplayer/CnCNet/PingQualityRules.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/PingQualityRules.cs
@@ -25,7 +25,7 @@ public static class PingQualityRules
     public const int V3PoorMaxMs = 500;
 
     public const int HighPingWarningMs = V3PoorMaxMs;
-    public const int KickSuggestionMinWorstMs = 300;
+    public const int KickSuggestionMinWorstMs = 400;
     public const int KickSuggestionMinImprovementMs = 150;
     public const int MaterialChangeMinDeltaMs = 25;
 

--- a/DXMainClient/Domain/Multiplayer/CnCNet/PingQualityRules.cs
+++ b/DXMainClient/Domain/Multiplayer/CnCNet/PingQualityRules.cs
@@ -14,11 +14,17 @@ public enum PingQualityTier
 
 public static class PingQualityRules
 {
+    // Legacy and static modes measure the round trip to the tunnel server.
     public const int GoodMaxMs = 100;
     public const int FairMaxMs = 250;
     public const int PoorMaxMs = 350;
 
-    public const int HighPingWarningMs = PoorMaxMs;
+    // Dynamic V3 measures the full player-to-player round trip, via relay or P2P.
+    public const int V3GoodMaxMs = 180;
+    public const int V3FairMaxMs = 350;
+    public const int V3PoorMaxMs = 500;
+
+    public const int HighPingWarningMs = V3PoorMaxMs;
     public const int KickSuggestionMinWorstMs = 300;
     public const int KickSuggestionMinImprovementMs = 150;
     public const int MaterialChangeMinDeltaMs = 25;
@@ -27,26 +33,36 @@ public static class PingQualityRules
         => ping.IsValid() ? GetTier(ping.Milliseconds) : PingQualityTier.Unknown;
 
     public static PingQualityTier GetTier(int milliseconds)
+        => GetTier(milliseconds, GoodMaxMs, FairMaxMs, PoorMaxMs);
+
+    public static PingQualityTier GetV3Tier(PingValue ping)
+        => ping.IsValid() ? GetV3Tier(ping.Milliseconds) : PingQualityTier.Unknown;
+
+    public static PingQualityTier GetV3Tier(int milliseconds)
+        => GetTier(milliseconds, V3GoodMaxMs, V3FairMaxMs, V3PoorMaxMs);
+
+    private static PingQualityTier GetTier(int milliseconds, int goodMaxMs, int fairMaxMs, int poorMaxMs)
     {
         if (milliseconds < 0)
             return PingQualityTier.Unknown;
 
-        if (milliseconds <= GoodMaxMs)
+        if (milliseconds <= goodMaxMs)
             return PingQualityTier.Good;
 
-        if (milliseconds <= FairMaxMs)
+        if (milliseconds <= fairMaxMs)
             return PingQualityTier.Fair;
 
-        if (milliseconds <= PoorMaxMs)
+        if (milliseconds <= poorMaxMs)
             return PingQualityTier.Poor;
 
         return PingQualityTier.Bad;
     }
 
+    // Warnings and live-update broadcasts operate on dynamic V3 pair pings.
     public static bool IsHighForWarning(PingValue ping)
         => ping.IsValid() && ping.Milliseconds > HighPingWarningMs;
 
     public static bool IsMaterialChange(int oldMilliseconds, int newMilliseconds)
         => Math.Abs(newMilliseconds - oldMilliseconds) > MaterialChangeMinDeltaMs ||
-           GetTier(oldMilliseconds) != GetTier(newMilliseconds);
+           GetV3Tier(oldMilliseconds) != GetV3Tier(newMilliseconds);
 }


### PR DESCRIPTION
Some small fixups for V3 tunnels based on my experience with the latest release and feedback from users.

1) Remove the P2P IP from showing on tooltips. This is for showmatches/streams where you don't want to accidentally broadcast the IP.

2) Update the ping quality tiers. With V3 tunnels, the ping measurement is different than V2. The V2 system would measure ICMP ping to the tunnel. With V3, it is a round-trip from player to player. So the tiers need to be adjusted to account for this, as right now most people are showing with poor ping quality icons when it was fine before. 

3) Adjust the kick suggestion threshold from 300ms to 400ms.
