### PR TITLE
Fix LAN host startup lag and prevent crash on occupied port

### DIFF
--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/LANGameLobby.cs
@@ -1,4 +1,5 @@
 using ClientCore;
+using ClientGUI;
 using DTAClient.Domain;
 using DTAClient.Domain.LAN;
 using DTAClient.Domain.Multiplayer;
@@ -137,9 +138,12 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
             PostInitialize();
         }
 
-        public void SetUp(bool isHost,
+        public bool SetUp(bool isHost,
             IPEndPoint hostEndPoint, TcpClient client)
         {
+            if (isHost && !StartHosting())
+                return false;
+
             leaving = false;
             sessionId++;
             Refresh(isHost);
@@ -151,9 +155,6 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 RandomSeed = random.Next();
                 Thread thread = new Thread(ListenForClients);
                 thread.Start();
-
-                this.client = new TcpClient();
-                this.client.Connect("127.0.0.1", ProgramConstants.LAN_GAME_LOBBY_PORT);
 
                 byte[] buffer = encoding.GetBytes(PLAYER_JOIN_COMMAND +
                     ProgramConstants.LAN_DATA_SEPARATOR + ProgramConstants.PLAYERNAME);
@@ -178,6 +179,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                 CopyPlayerDataToUI();
 
             WindowManager.SelectedControl = tbChatInput;
+            return true;
         }
 
         public void PostJoin()
@@ -190,11 +192,31 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
 
         #region Server code
 
+        private bool StartHosting()
+        {
+            try
+            {
+                listener = new TcpListener(IPAddress.Any, ProgramConstants.LAN_GAME_LOBBY_PORT);
+                listener.Start();
+
+                this.client = new TcpClient();
+                this.client.Connect("127.0.0.1", ProgramConstants.LAN_GAME_LOBBY_PORT);
+                return true;
+            }
+            catch (SocketException ex)
+            {
+                Logger.Log("Failed to start hosting the LAN game lobby: " + ex.ToString());
+                listener?.Stop();
+                this.client?.Close();
+                XNAMessageBox.Show(WindowManager, "Error".L10N("Client:Main:Error"),
+                    string.Format("Unable to host the game because TCP port {0} could not be opened. It may already be in use by another program.".L10N("Client:Main:LANListenerStartFailed"),
+                    ProgramConstants.LAN_GAME_LOBBY_PORT));
+                return false;
+            }
+        }
+
         private void ListenForClients()
         {
-            listener = new TcpListener(IPAddress.Any, ProgramConstants.LAN_GAME_LOBBY_PORT);
-            listener.Start();
-
             while (true)
             {
                 TcpClient client;

--- a/DXMainClient/DXGUI/Multiplayer/LANGameLoadingLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/LANGameLoadingLobby.cs
@@ -1,4 +1,5 @@
 ﻿using ClientCore;
+using ClientGUI;
 using DTAClient.Domain;
 using DTAClient.Domain.LAN;
 using DTAClient.Domain.Multiplayer;
@@ -101,10 +102,13 @@ namespace DTAClient.DXGUI.Multiplayer
         private volatile bool leaving;
         private int sessionId;
 
-        public void SetUp(bool isHost,
+        public bool SetUp(bool isHost,
             IPEndPoint hostEndPoint, TcpClient client,
             int loadedGameId)
         {
+            if (isHost && !StartHosting())
+                return false;
+
             leaving = false;
             sessionId++;
             Refresh(isHost);
@@ -119,9 +123,6 @@ namespace DTAClient.DXGUI.Multiplayer
             {
                 Thread thread = new Thread(ListenForClients);
                 thread.Start();
-
-                this.client = new TcpClient();
-                this.client.Connect("127.0.0.1", ProgramConstants.LAN_GAME_LOBBY_PORT);
 
                 byte[] buffer = encoding.GetBytes(PLAYER_JOIN_COMMAND +
                     ProgramConstants.LAN_DATA_SEPARATOR + ProgramConstants.PLAYERNAME +
@@ -145,6 +146,7 @@ namespace DTAClient.DXGUI.Multiplayer
                 CopyPlayerDataToUI();
 
             WindowManager.SelectedControl = tbChatInput;
+            return true;
         }
 
         public void PostJoin()
@@ -157,11 +159,31 @@ namespace DTAClient.DXGUI.Multiplayer
 
         #region Server code
 
+        private bool StartHosting()
+        {
+            try
+            {
+                listener = new TcpListener(IPAddress.Any, ProgramConstants.LAN_GAME_LOBBY_PORT);
+                listener.Start();
+
+                this.client = new TcpClient();
+                this.client.Connect("127.0.0.1", ProgramConstants.LAN_GAME_LOBBY_PORT);
+                return true;
+            }
+            catch (SocketException ex)
+            {
+                Logger.Log("Failed to start hosting the LAN game loading lobby: " + ex.ToString());
+                listener?.Stop();
+                this.client?.Close();
+                XNAMessageBox.Show(WindowManager, "Error".L10N("Client:Main:Error"),
+                    string.Format("Unable to host the game because TCP port {0} could not be opened. It may already be in use by another program.".L10N("Client:Main:LANListenerStartFailed"),
+                    ProgramConstants.LAN_GAME_LOBBY_PORT));
+                return false;
+            }
+        }
+
         private void ListenForClients()
         {
-            listener = new TcpListener(IPAddress.Any, ProgramConstants.LAN_GAME_LOBBY_PORT);
-            listener.Start();
-
             while (true)
             {
                 TcpClient client;

--- a/DXMainClient/DXGUI/Multiplayer/LANLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/LANLobby.cs
@@ -324,19 +324,21 @@ namespace DTAClient.DXGUI.Multiplayer
 
         private void GameCreationWindow_LoadGame(object sender, GameLoadEventArgs e)
         {
-            lanGameLoadingLobby.SetUp(true,
+            if (lanGameLoadingLobby.SetUp(true,
                 new IPEndPoint(IPAddress.Loopback, ProgramConstants.LAN_GAME_LOBBY_PORT),
-                null, e.LoadedGameID);
-
-            lanGameLoadingLobby.Enable();
+                null, e.LoadedGameID))
+            {
+                lanGameLoadingLobby.Enable();
+            }
         }
 
         private void GameCreationWindow_NewGame(object sender, EventArgs e)
         {
-            lanGameLobby.SetUp(true,
-                new IPEndPoint(IPAddress.Loopback, ProgramConstants.LAN_GAME_LOBBY_PORT), null);
-
-            lanGameLobby.Enable();
+            if (lanGameLobby.SetUp(true,
+                new IPEndPoint(IPAddress.Loopback, ProgramConstants.LAN_GAME_LOBBY_PORT), null))
+            {
+                lanGameLobby.Enable();
+            }
         }
 
         private void SetChatColor()


### PR DESCRIPTION
When hosting a LAN game, the host started its TCP listener on a background thread and then immediately connected to it. That connection ran before the listener was ready which caused a bit of lag. Fixed by starting the listener and connecting to it before the thread begins.
Also fixed a client crash when port 1233 was already in use. Now shows an error message to the user and logs it.

Closes #1056 
Not sure if you want to close ///// #1080. It is genuinely faster with this fix, but there is still some lag to do with map thumbnails and other bits and bobs.

No documentation changes needed as it's a simple bug fix. No breaking changes.